### PR TITLE
fix(ci): correct path trigger to src/rules.yml in docker_publish.yml

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -31,7 +31,7 @@ on:
     paths:
       - "Dockerfile/**"
       - "src/cstylecheck.py"
-      - "src/cstylecheck_rules.yaml"
+      - "src/rules.yml"
       - "src/_version.py"
       - ".github/workflows/docker_publish.yml"
     tags:


### PR DESCRIPTION
Fixes #49.

Line 34 referenced `src/cstylecheck_rules.yaml` but the actual file in `src/` is `rules.yml`. As a result, modifying rules never triggered a Docker image rebuild.