### PR TITLE
fix: avoid utcnow in trend workflow

### DIFF
--- a/.github/workflows/cstylecheck_rules.yml
+++ b/.github/workflows/cstylecheck_rules.yml
@@ -188,7 +188,7 @@ jobs:
           import json, datetime, os, pathlib
 
           record = {
-              "date":     datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "date":     datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
               "run":      int(os.environ["RUN_NUMBER"]),
               "sha":      os.environ["SHA"][:8],
               "errors":   int(os.environ["ERRORS"]),


### PR DESCRIPTION
Fixes #56

## Changes in this PR

- Replaces the deprecated `datetime.datetime.utcnow()` call in the trend record workflow step.
- Keeps the existing UTC `Z` timestamp format used in `cstylecheck/trend.jsonl`.

## Validation

- `rg -n utcnow|datetime\.datetime\.now\(datetime\.timezone\.utc\) .github/workflows/cstylecheck_rules.yml`
- `git diff --check`
- Tests not run locally