### PR TITLE
Align checker section numbering

### DIFF
--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -72,9 +72,9 @@ This document defines the detailed design of each software unit in **CStyleCheck
 | UNIT-28 | `Checker._check_structs` | `cstylecheck.py:1739` | COMP-05d |
 | UNIT-29 | `Checker._check_include_guard` | `cstylecheck.py:1879` | COMP-05e |
 | UNIT-30 | `Checker._check_misc` | `cstylecheck.py:1912` | COMP-05f |
-| UNIT-31 | `Checker._check_yoda` | `cstylecheck.py:2245` | COMP-05f |
-| UNIT-32 | `Checker._check_spelling` | `cstylecheck.py:2226` | COMP-05f |
-| UNIT-33 | `Checker._check_reserved_names` | `cstylecheck.py:2348` | COMP-05f |
+| UNIT-31 | `Checker._check_yoda` | `cstylecheck.py:2319` | COMP-05f |
+| UNIT-32 | `Checker._check_reserved_names` | `cstylecheck.py:2528` | COMP-05f |
+| UNIT-33 | `Checker._check_spelling` | `cstylecheck.py:2300` | COMP-05f |
 | UNIT-34 | `SignChecker._check_calls` | `cstylecheck.py:2688` | COMP-05g |
 | UNIT-35 | `load_baseline` | `cstylecheck.py:3006` | COMP-06 |
 | UNIT-36 | `write_baseline` | `cstylecheck.py:3021` | COMP-06 |
@@ -231,7 +231,7 @@ This document defines the detailed design of each software unit in **CStyleCheck
 
 **Algorithm:** Call each enabled `_check_*` method in fixed order; each appends to `self.result.violations`. Return `self.result`.
 
-**Order:** `_check_defines`, `_check_variables`, `_check_functions`, `_check_typedefs`, `_check_enums`, `_check_structs`, `_check_include_guard`, `_check_misc`, `_check_yoda`, `_check_spelling`, `_check_reserved_names`, `_check_copyright_header`, `_check_block_comment_spacing`, `_check_eof_comment`
+**Order:** `_check_copyright_header`, `_check_defines`, `_check_variables`, `_check_functions`, `_check_typedefs`, `_check_enums`, `_check_structs`, `_check_include_guard` for headers, `_check_misc`, `_check_yoda`, `_check_reserved_names`, `_check_lowercase_l_suffix`, `_check_octal_constants`, `_check_trigraphs`, `_check_spelling` when a spelling dictionary is configured.
 
 ---
 

--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -2176,7 +2176,7 @@ class Checker:
                         f"'U' or 'u' suffix (or assign to a signed type)"))
 
     # -----------------------------------------------------------------------
-    # 9. Block-comment spacing
+    # 8a. Block-comment spacing
     # Checks that the number of blank lines between the closing */ of a
     # multi-line block comment and the next non-blank line is within the
     # configured [min, max] range.
@@ -2221,7 +2221,7 @@ class Checker:
                         f"Block comment has {_blanks} blank line(s) after '*/'; "
                         f"maximum is {bcs_max}"))
 
-        # EOF comment
+        # 8b. EOF comment
         # The last non-blank line must equal the configured template string
         # (with {filename} replaced by the file's base name, case-adjusted).
         # Exactly one blank line must follow it as the final line of the file.
@@ -2297,7 +2297,7 @@ class Checker:
                         f"line; found {n_after}"))
 
     # -----------------------------------------------------------------------
-    # 10. Comment spell-check
+    # 14. Comment spell-check
     # -----------------------------------------------------------------------
 
     def _check_spelling(self) -> None:
@@ -2316,7 +2316,7 @@ class Checker:
 
 
     # -----------------------------------------------------------------------
-    # 11. Yoda conditions  (constant on the LHS of == and !=)
+    # 9. Yoda conditions  (constant on the LHS of == and !=)
     # -----------------------------------------------------------------------
 
     def _check_yoda(self) -> None:
@@ -2412,7 +2412,7 @@ class Checker:
         return bool(re.fullmatch(r"[a-z_][a-zA-Z0-9_]*", t))
 
     # -----------------------------------------------------------------------
-    # 12. MISRA C:2012/2023 Rule 7.3 — lowercase 'l' suffix forbidden
+    # 11. MISRA C:2012/2023 Rule 7.3 — lowercase 'l' suffix forbidden
     #
     # The letter 'l' (lowercase L) is visually indistinguishable from the
     # digit '1' in many fonts.  MISRA C:2012 Rule 7.3 and MISRA C:2023
@@ -2448,7 +2448,7 @@ class Checker:
                 )
 
     # -----------------------------------------------------------------------
-    # 13. MISRA C:2012/2023 Rule 7.1 — octal integer constants forbidden
+    # 12. MISRA C:2012/2023 Rule 7.1 — octal integer constants forbidden
     #
     # An integer literal that starts with '0' followed by one or more
     # octal digits (0–7) is an octal constant.  This is a common source
@@ -2488,7 +2488,7 @@ class Checker:
             )
 
     # -----------------------------------------------------------------------
-    # 14. MISRA C:2012/2023 Rule 4.2 — trigraphs forbidden
+    # 13. MISRA C:2012/2023 Rule 4.2 — trigraphs forbidden
     #
     # Trigraphs are three-character sequences beginning with '??' that the
     # C preprocessor replaces with a single character before parsing.  They
@@ -2525,7 +2525,7 @@ class Checker:
             ))
 
     # -----------------------------------------------------------------------
-    # 11. Reserved / banned name check
+    # 10. Reserved / banned name check
     # -----------------------------------------------------------------------
 
     def _is_reserved(self, name: str) -> tuple:


### PR DESCRIPTION
## Summary
- Renumber the checker section headers so Yoda and reserved-name checks no longer both use section 11.
- Align the SWE3 detailed design unit order and `run_all()` order description with the current invocation order.

Fixes #78.

## Validation
- `git diff --check`
- Not run locally