### PR TITLE
Remove redundant re import in violation helper

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -979,8 +979,7 @@ class Checker:
 
     def _v(self, pos: int, sev: str, rule: str, msg: str) -> None:
         if self._ident_disabled:
-            import re as _re
-            _m = _re.search(r"'([^']+)'", msg)
+            _m = re.search(r"'([^']+)'", msg)
             if _m and rule in self._ident_disabled.get(_m.group(1), frozenset()):
                 return
         self.result.add(self._violation(pos, sev, rule, msg))


### PR DESCRIPTION
## Summary
- Remove the redundant local `import re as _re` from `Checker._v()`.
- Use the existing module-level `re` import for per-identifier exclusion parsing.

Fixes #75.

## Validation
- `git diff --check`
- `rg -n "import re as _re|_re\.search|def _v" src/cstylecheck.py`
- Not run locally
