### PR TITLE
Categorize GitHub annotation titles

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -145,6 +145,37 @@ _VERSION_STRING = f"{_TOOL_NAME} {_VERSION}"
 # Data structures
 # ---------------------------------------------------------------------------
 
+_MISRA_ANNOTATION_RULES = frozenset({
+    "misc.trigraph",
+    "misc.octal_constant",
+    "misc.lowercase_l_suffix",
+})
+
+_NAMING_ANNOTATION_PREFIXES = frozenset({
+    "constant",
+    "enum",
+    "function",
+    "include_guard",
+    "macro",
+    "reserved_name",
+    "struct",
+    "typedef",
+    "variable",
+})
+
+
+def _github_annotation_category(rule: str) -> str:
+    if rule in _MISRA_ANNOTATION_RULES:
+        return "MISRA"
+    if rule == "sign_compatibility":
+        return "SignCompat"
+    if rule == "spell_check":
+        return "SpellCheck"
+    if rule.split(".", 1)[0] in _NAMING_ANNOTATION_PREFIXES:
+        return "NamingConvention"
+    return "Misc"
+
+
 @dataclass
 class Violation:
     filepath: str
@@ -155,10 +186,15 @@ class Violation:
     message: str
 
     def github_annotation(self) -> str:
-        level = self.severity if self.severity in ("error", "warning", "notice") else "notice"
+        level = (
+            self.severity
+            if self.severity in ("error", "warning", "notice")
+            else "notice"
+        )
+        title = _github_annotation_category(self.rule)
         return (
             f"::{level} file={self.filepath},line={self.line},"
-            f"col={self.col},title=NamingConvention[{self.rule}]::"
+            f"col={self.col},title={title}[{self.rule}]::"
             f"{self.message}"
         )
 

--- a/tests/test_github_annotations.py
+++ b/tests/test_github_annotations.py
@@ -1,0 +1,38 @@
+"""Tests for GitHub Actions annotation formatting."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from harness import Violation  # noqa: E402
+
+
+class TestGitHubAnnotationTitles(unittest.TestCase):
+    def _annotation_for(self, rule):
+        return Violation(
+            "source.c", 10, 4, "error", rule, "message"
+        ).github_annotation()
+
+    def test_naming_rule_uses_naming_convention_title(self):
+        self.assertIn("title=NamingConvention[variable.prefix]::",
+                      self._annotation_for("variable.prefix"))
+
+    def test_misra_rule_uses_misra_title(self):
+        self.assertIn("title=MISRA[misc.trigraph]::",
+                      self._annotation_for("misc.trigraph"))
+
+    def test_sign_compatibility_rule_uses_signcompat_title(self):
+        self.assertIn("title=SignCompat[sign_compatibility]::",
+                      self._annotation_for("sign_compatibility"))
+
+    def test_spell_check_rule_uses_spellcheck_title(self):
+        self.assertIn("title=SpellCheck[spell_check]::",
+                      self._annotation_for("spell_check"))
+
+    def test_other_misc_rule_uses_misc_title(self):
+        self.assertIn("title=Misc[misc.line_length]::",
+                      self._annotation_for("misc.line_length"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- categorize GitHub Actions annotation titles from the violation rule instead of always using `NamingConvention`
- keep naming rules under `NamingConvention`, map MISRA, sign-compatibility, spell-check, and other misc rules to clearer titles
- add unit coverage for representative annotation title categories

Fixes #77.

## Validation
- `git diff --check HEAD~1..HEAD -- src/cstylecheck.py tests/test_github_annotations.py`
- Not run locally: test suite