### PR TITLE
fix(aliases): build bidirectional alias map to accept either column order

### DIFF
--- a/src/aliases.txt
+++ b/src/aliases.txt
@@ -1,24 +1,23 @@
 # Module alias file — used with --aliases FILE
 #
-# Format:  alias_stem   actual_module_stem
+# Format:  <stem_a>   <stem_b>
 #
-# Meaning: when checking a file whose stem is actual_module_stem, identifiers
-# that carry the alias_stem prefix are accepted as if they carried the
-# actual module prefix.
+# Either column order is accepted.  The mapping is bidirectional: both
+# stem_a.c and stem_b.c will accept each other's prefix.
 #
-# Example:
-#   api_param  api_param_cfg
+# Common usage — "for file drv_iis3dwb_cfg, also accept the drv_iis3dwb prefix":
+#   drv_iis3dwb_cfg   drv_iis3dwb
 #
-# → in api_param_cfg.c  the prefix api_param_ is accepted alongside
-#   api_param_cfg_.  So API_PARAM_VALUE_NORMAL_SIGNATURE passes even though
-#   the file is called api_param_cfg.c.
+# → in drv_iis3dwb_cfg.c  the prefix DRV_IIS3DWB_ is accepted alongside
+#   DRV_IIS3DWB_CFG_.
+# → in drv_iis3dwb.c  the prefix DRV_IIS3DWB_CFG_ is also accepted.
 #
 # Rules:
-#   • One alias per line.
+#   • One alias pair per line.
 #   • Lines starting with # are comments.
 #   • Blank lines are ignored.
 #   • Both words are treated case-insensitively.
-#   • A module may have multiple alias lines.
+#   • A module may appear in multiple alias lines.
 
 # api_param       api_param_cfg
 # sensor_mgr      sensor_manager

--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -277,16 +277,19 @@ def load_alias_file(path: str) -> dict:
     Load the module-alias plain-text file.
 
     Each non-blank, non-comment line must contain exactly two whitespace-
-    separated words::
+    separated words in either column order::
 
         alias_stem   actual_module_stem
+        actual_module_stem   alias_stem
 
-    Returns dict: {actual_module_stem_lower -> [alias_stem_lower, ...]}.
+    Returns dict: {stem_lower -> [other_stem_lower, ...]}, registered
+    bidirectionally so that either column order in the file is accepted.
 
     Example line::
         api_param  api_param_cfg
 
-    → when checking api_param_cfg.c the prefix api_param_ is also accepted.
+    → when checking api_param_cfg.c the prefix api_param_ is also accepted,
+      and when checking api_param.c the prefix api_param_cfg_ is also accepted.
     """
     aliases: dict = {}
     try:
@@ -302,8 +305,12 @@ def load_alias_file(path: str) -> dict:
             print(f"WARNING: alias file line {lineno}: expected 2 words, "
                   f"got {parts!r}", file=sys.stderr)
             continue
-        alias_stem, actual_stem = parts[0].lower(), parts[1].lower()
-        aliases.setdefault(actual_stem, []).append(alias_stem)
+        stem_a, stem_b = parts[0].lower(), parts[1].lower()
+        # Register bidirectionally so either column order is accepted.
+        if stem_b not in aliases.get(stem_a, []):
+            aliases.setdefault(stem_a, []).append(stem_b)
+        if stem_a not in aliases.get(stem_b, []):
+            aliases.setdefault(stem_b, []).append(stem_a)
     return aliases
 
 

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -568,5 +568,72 @@ class TestBaselineSuppression(unittest.TestCase):
         self.assertEqual(data["summary"]["total"], 0)
 
 
+# ===========================================================================
+# 11. Alias file bidirectional column order  (issue #69)
+# ===========================================================================
+
+def _alias_cfg():
+    return cfg_only(
+        file_prefix={"enabled": True, "severity": "error",
+                     "separator": "_", "case": "lower",
+                     "exempt_main": False, "exempt_patterns": []},
+        constants={"enabled": True, "severity": "error",
+                   "case": "upper_snake", "max_length": 60,
+                   "min_length": 2, "exempt_patterns": []},
+    )
+
+
+class TestAliasFileBidirectionalColumnOrder(unittest.TestCase):
+    """SWE4-TC-ALIAS-BIDIR-001 to 004 — issue #69 regression suite."""
+
+    def _load(self, content: str) -> dict:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt",
+                                        delete=False, encoding="utf-8") as fh:
+            fh.write(content)
+            name = fh.name
+        try:
+            return _mod.load_alias_file(name)
+        finally:
+            Path(name).unlink(missing_ok=True)
+
+    # SWE4-TC-ALIAS-BIDIR-001
+    def test_documented_order_builds_correct_map(self):
+        """alias_stem  actual_stem → actual_stem maps to alias_stem."""
+        m = self._load("api_param  api_param_cfg\n")
+        self.assertIn("api_param_cfg", m)
+        self.assertIn("api_param", m["api_param_cfg"])
+
+    # SWE4-TC-ALIAS-BIDIR-002
+    def test_reversed_order_builds_correct_map(self):
+        """actual_stem  alias_stem → actual_stem still maps to alias_stem."""
+        m = self._load("drv_iis3dwb_cfg  drv_iis3dwb\n")
+        self.assertIn("drv_iis3dwb_cfg", m)
+        self.assertIn("drv_iis3dwb", m["drv_iis3dwb_cfg"])
+
+    # SWE4-TC-ALIAS-BIDIR-003
+    def test_no_violation_documented_column_order(self):
+        """No constant.prefix violation — documented column order (alias actual)."""
+        alias_pfxs = ["api_param_cfg_", "api_param_"]
+        src = "#define API_PARAM_VALUE (1U)\n"
+        viols = [v for v in run(src, _alias_cfg(),
+                                filepath="api_param_cfg.h",
+                                alias_prefixes=alias_pfxs)
+                 if v.rule == "constant.prefix"]
+        self.assertEqual(viols, [])
+
+    # SWE4-TC-ALIAS-BIDIR-004
+    def test_no_violation_reversed_column_order(self):
+        """No constant.prefix violation — reversed column order (regression for #69)."""
+        m = self._load("drv_iis3dwb_cfg  drv_iis3dwb\n")
+        sep = "_"
+        alias_pfxs = ["drv_iis3dwb_cfg_"] + [a + sep for a in m.get("drv_iis3dwb_cfg", [])]
+        src = "#define DRV_IIS3DWB_REG_ISPU_DUMMYCFG2_INIT_VALUE (0x00U)\n"
+        viols = [v for v in run(src, _alias_cfg(),
+                                filepath="drv_iis3dwb_cfg.h",
+                                alias_prefixes=alias_pfxs)
+                 if v.rule == "constant.prefix"]
+        self.assertEqual(viols, [], f"Unexpected violations: {viols}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- load_alias_file() now registers alias pairs in both directions, so either column order in the aliases file produces the correct map.
- liases.txt header comment rewritten with a concrete bidirectional example to make the format unambiguous.
- 4 regression tests added (TestAliasFileBidirectionalColumnOrder) covering both column orders at the parser and end-to-end levels.

Closes #69

## Root Cause

load_alias_file() only registered one direction: for a line containing stems A and B it built {B: [A]}. A user who naturally wrote the columns in the order `actual_stem  alias_stem` instead of `alias_stem  actual_stem` produced an inverted map entry `{alias_stem: [actual_stem]}`. When the checker then looked up the file's own stem it found nothing and raised false `constant.prefix` (and other module-prefix) violations.

## Fix

For every line the parser now registers both {A: [B]} and {B: [A]}, skipping duplicates. Either column order is silently accepted with no change required to existing aliases files.

## Files Changed

| File | Change |
|---|---|
| src/cstylecheck.py | load_alias_file() builds bidirectional map |
| src/aliases.txt | Header comment rewritten with unambiguous bidirectional example |
| 	ests/test_improvements.py | TestAliasFileBidirectionalColumnOrder — 4 new regression tests |

## Test Plan

- [x] SWE4-TC-ALIAS-BIDIR-001 — documented order lias actual builds correct map entry
- [x] SWE4-TC-ALIAS-BIDIR-002 — reversed order ctual alias also builds correct map entry
- [x] SWE4-TC-ALIAS-BIDIR-003 — no constant.prefix violation with documented column order
- [x] SWE4-TC-ALIAS-BIDIR-004 — no constant.prefix violation with reversed column order (regression for #69)
- [x] Full suite: 708/708 tests pass, zero regressions

## ASPICE Traceability

- **SWE.1**: CSC-SWE1-005 (alias file loading requirement)
- **SWE.4**: SWE4-TC-ALIAS-BIDIR-001 to 004
- **SUP.9**: this PR linked to issue #69 as problem resolution evidence

🤖 Generated with [Claude Code](https://claude.ai/claude-code)