### PR TITLE
fix(ci): add concurrency group to prevent parallel trend-data races

### DIFF
--- a/.github/workflows/cstylecheck_rules.yml
+++ b/.github/workflows/cstylecheck_rules.yml
@@ -38,6 +38,13 @@ on:
 
   workflow_dispatch:
 
+# Serialise runs on the same branch so concurrent pushes cannot race to
+# append trend records, causing data loss or a non-fast-forward gh-pages push.
+# The latest run wins; any in-progress run for the same ref is cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ---------------------------------------------------------------------------
   # Job 1: Run the checker

--- a/tests/test_workflow_config.py
+++ b/tests/test_workflow_config.py
@@ -1,0 +1,65 @@
+"""test_workflow_config.py — structural tests for CI workflow configuration.
+
+These tests verify critical workflow properties that cannot be exercised by
+running the checker itself.  They guard against accidental removal of safety
+or correctness settings during future YAML edits.
+"""
+import unittest
+from pathlib import Path
+
+_REPO_ROOT   = Path(__file__).resolve().parent.parent
+_WORKFLOW    = _REPO_ROOT / ".github" / "workflows" / "cstylecheck_rules.yml"
+
+
+def _load_yaml():
+    try:
+        import yaml
+    except ImportError:
+        return None
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+class TestConcurrencyControl(unittest.TestCase):
+    """SUP9-TC-CONC-001 to 004 — issue #51 regression suite.
+
+    Verifies that the workflow has a concurrency group so parallel pushes
+    cannot race to corrupt trend.jsonl or cause a non-fast-forward gh-pages
+    push failure.
+    """
+
+    def setUp(self):
+        self._wf = _load_yaml()
+        if self._wf is None:
+            self.skipTest("PyYAML not available")
+
+    # SUP9-TC-CONC-001
+    def test_workflow_file_exists(self):
+        """Workflow file must exist at the expected path."""
+        self.assertTrue(_WORKFLOW.exists(), f"Missing: {_WORKFLOW}")
+
+    # SUP9-TC-CONC-002
+    def test_concurrency_key_present(self):
+        """Top-level 'concurrency' key must be present."""
+        self.assertIn("concurrency", self._wf,
+                      "concurrency block missing from cstylecheck_rules.yml")
+
+    # SUP9-TC-CONC-003
+    def test_concurrency_group_set(self):
+        """concurrency.group must be a non-empty string."""
+        group = self._wf.get("concurrency", {}).get("group", "")
+        self.assertTrue(group, "concurrency.group is empty or missing")
+        self.assertIn("github.workflow", group)
+        self.assertIn("github.ref", group)
+
+    # SUP9-TC-CONC-004
+    def test_cancel_in_progress_enabled(self):
+        """cancel-in-progress must be True so the latest push wins."""
+        conc = self._wf.get("concurrency", {})
+        self.assertTrue(
+            conc.get("cancel-in-progress", False),
+            "cancel-in-progress is not True in concurrency block",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds a `concurrency:` block at workflow level in `cstylecheck_rules.yml` so that only one run per branch/ref is active at a time.
- `cancel-in-progress: true` ensures the latest push wins; no stale runner holds the lock.
- 4 structural regression tests added (`TestConcurrencyControl`) in `tests/test_workflow_config.py` to prevent accidental future removal.

Closes #51

## Root Cause

Two rapid pushes to `main` both triggered the `trend` job. Each independently checked out `gh-pages`, appended a record to `trend.jsonl`, and attempted to push. The second push landed a non-fast-forward rejection or silently overwrote the first record, corrupting the audit trail and violating the SUP.8 baseline-integrity requirement.

## Fix

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Placed between the `on:` and `jobs:` blocks. GitHub Actions queues later runs for the same group and cancels any in-progress run, so `trend.jsonl` is never written concurrently.

## Files Changed

| File | Change |
|---|---|
| `.github/workflows/cstylecheck_rules.yml` | Add `concurrency:` block |
| `tests/test_workflow_config.py` | `TestConcurrencyControl` — 4 structural tests |

## Test Plan

- [x] `SUP9-TC-CONC-001` — workflow file exists at expected path
- [x] `SUP9-TC-CONC-002` — `concurrency` key is present
- [x] `SUP9-TC-CONC-003` — `group` references both `github.workflow` and `github.ref`
- [x] `SUP9-TC-CONC-004` — `cancel-in-progress` is `true`
- [x] Full suite: 712/712 passed, zero regressions

## ASPICE Traceability

- **CSC-SUP8-001**: trend data integrity (audit trail) now guaranteed by serialised writes
- **SUP.9**: this PR linked to issue #51 as problem resolution evidence

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
