### PR TITLE
test(ci): add badge-path regression tests to prevent stylecheck/ path drift

### DIFF
--- a/tests/test_workflow_config.py
+++ b/tests/test_workflow_config.py
@@ -4,6 +4,7 @@ These tests verify critical workflow properties that cannot be exercised by
 running the checker itself.  They guard against accidental removal of safety
 or correctness settings during future YAML edits.
 """
+import re
 import unittest
 from pathlib import Path
 
@@ -58,6 +59,76 @@ class TestConcurrencyControl(unittest.TestCase):
         self.assertTrue(
             conc.get("cancel-in-progress", False),
             "cancel-in-progress is not True in concurrency block",
+        )
+
+
+class TestBadgePath(unittest.TestCase):
+    """SUP9-TC-BADGE-001 to 005 — issue #42 regression suite.
+
+    The original bug: the trend job wrote files to 'stylecheck/' while the
+    README badge URL pointed to 'cstylecheck/'.  These tests pin the correct
+    directory name throughout the workflow and README so the mismatch cannot
+    silently recur.
+    """
+
+    def setUp(self):
+        try:
+            import yaml as _yaml
+            self._yaml = _yaml
+        except ImportError:
+            self.skipTest("PyYAML not available")
+        self._wf_text  = _WORKFLOW.read_text(encoding="utf-8")
+        self._wf       = self._yaml.safe_load(self._wf_text)
+        self._readme   = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    # SUP9-TC-BADGE-001
+    def test_trend_directory_is_cstylecheck(self):
+        """Workflow must use 'cstylecheck/' for trend data — not 'stylecheck/'."""
+        self.assertIn("cstylecheck/trend.jsonl", self._wf_text,
+                      "trend.jsonl path is not under cstylecheck/")
+        # Use negative-lookbehind so we only match bare 'stylecheck/' and not
+        # the correct 'cstylecheck/' (which contains 'stylecheck' as a suffix).
+        self.assertIsNone(
+            re.search(r"(?<!c)stylecheck/trend\.jsonl", self._wf_text),
+            "Old 'stylecheck/' path still present in workflow",
+        )
+
+    # SUP9-TC-BADGE-002
+    def test_badge_json_path_is_cstylecheck(self):
+        """badge.json must be written to cstylecheck/ — not stylecheck/."""
+        self.assertIn("cstylecheck/badge.json", self._wf_text,
+                      "badge.json path is not under cstylecheck/")
+        self.assertIsNone(
+            re.search(r"(?<!c)stylecheck/badge\.json", self._wf_text),
+            "Old 'stylecheck/' path still present in workflow",
+        )
+
+    # SUP9-TC-BADGE-003
+    def test_index_html_path_is_cstylecheck(self):
+        """index.html must be written to cstylecheck/ — not stylecheck/."""
+        self.assertIn("cstylecheck/index.html", self._wf_text,
+                      "index.html path is not under cstylecheck/")
+        self.assertIsNone(
+            re.search(r"(?<!c)stylecheck/index\.html", self._wf_text),
+            "Old 'stylecheck/' path still present in workflow",
+        )
+
+    # SUP9-TC-BADGE-004
+    def test_git_add_targets_cstylecheck(self):
+        """'git add' in the trend commit step must target cstylecheck/."""
+        self.assertIn("git add cstylecheck/", self._wf_text,
+                      "'git add cstylecheck/' not found in workflow")
+        self.assertNotIn("git add stylecheck/", self._wf_text,
+                         "'git add stylecheck/' (wrong path) still present")
+
+    # SUP9-TC-BADGE-005
+    def test_readme_badge_url_points_to_cstylecheck(self):
+        """README Naming Convention badge URL must reference cstylecheck/badge.json."""
+        self.assertIn("cstylecheck/badge.json", self._readme,
+                      "README badge URL does not reference cstylecheck/badge.json")
+        self.assertIsNone(
+            re.search(r"(?<!c)stylecheck/badge\.json", self._readme),
+            "README badge URL references old stylecheck/ path",
         )
 
 


### PR DESCRIPTION
﻿## Summary

- The original bug (#42) caused the GitHub Pages badge to 404 because the trend job wrote files to `stylecheck/` while the README badge URL pointed to `cstylecheck/badge.json`.
- The path corrections were already applied in a prior PR (merged to `develop` / `main`).
- This PR adds **regression tests** (`TestBadgePath`, 5 tests, SUP9-TC-BADGE-001..005) to `tests/test_workflow_config.py` so the path mismatch cannot silently recur after future workflow edits.

## Root cause

`stylecheck` is a suffix of `cstylecheck`, so naive `assertNotIn("stylecheck/...", text)` checks would false-positive on every legitimate `cstylecheck/` reference.  The fix uses a negative-lookbehind regex (`(?<!c)stylecheck/`) that only matches the old bare path.

## Test plan

- [x] `pytest tests/test_workflow_config.py -v` — 9/9 pass (4 concurrency + 5 badge-path)
- [x] `pytest tests/ --ignore=tests/test_cli.py -q` — 683 passed, 0 failures
- [x] Tests confirm `cstylecheck/trend.jsonl`, `cstylecheck/badge.json`, `cstylecheck/index.html`, `git add cstylecheck/`, and README badge URL all reference the correct directory

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
