### PR TITLE
fix(ci): replace deprecated datetime.utcnow() with timezone-aware call

### DIFF
--- a/.github/workflows/cstylecheck_rules.yml
+++ b/.github/workflows/cstylecheck_rules.yml
@@ -205,7 +205,7 @@ jobs:
           import json, datetime, os, pathlib
 
           record = {
-              "date":     datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "date":     datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
               "run":      int(os.environ["RUN_NUMBER"]),
               "sha":      os.environ["SHA"][:8],
               "errors":   int(os.environ["ERRORS"]),

--- a/tests/test_workflow_config.py
+++ b/tests/test_workflow_config.py
@@ -207,5 +207,40 @@ class TestBadgePath(unittest.TestCase):
         )
 
 
+class TestTimezoneAware(unittest.TestCase):
+    """SUP9-TC-TZ-001 to 002 — issue #56 regression suite.
+
+    datetime.datetime.utcnow() is deprecated in Python 3.12 and will be
+    removed in a future release.  The correct replacement is
+    datetime.datetime.now(datetime.timezone.utc), which produces an identical
+    ISO 8601 UTC string when formatted with strftime.  These tests verify the
+    deprecated call is absent and the timezone-aware call is present so neither
+    can silently creep back during future workflow edits.
+    """
+
+    def setUp(self):
+        self._wf_text = _WORKFLOW_RULES.read_text(encoding="utf-8")
+
+    # SUP9-TC-TZ-001
+    def test_utcnow_not_present(self):
+        """cstylecheck_rules.yml must not call the deprecated datetime.utcnow()."""
+        self.assertNotIn(
+            "utcnow()",
+            self._wf_text,
+            "Deprecated datetime.utcnow() found in cstylecheck_rules.yml — "
+            "use datetime.now(datetime.timezone.utc) instead",
+        )
+
+    # SUP9-TC-TZ-002
+    def test_timezone_aware_call_present(self):
+        """cstylecheck_rules.yml must use timezone-aware datetime.now(...)."""
+        self.assertIn(
+            "datetime.timezone.utc",
+            self._wf_text,
+            "datetime.timezone.utc not found in cstylecheck_rules.yml — "
+            "timezone-aware call may have been reverted",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary

- Replaces the deprecated `datetime.datetime.utcnow()` call in the trend record step of `cstylecheck_rules.yml` with `datetime.datetime.now(datetime.timezone.utc)`.
- `utcnow()` was deprecated in Python 3.12 and will be removed in a future release. The replacement produces an identical ISO 8601 UTC string (`"%Y-%m-%dT%H:%M:%SZ"`) — no change to `trend.jsonl` format.
- Adds `TestTimezoneAware` (SUP9-TC-TZ-001..002) to `tests/test_workflow_config.py` to guard against the deprecated call reappearing in future workflow edits.

> **Note:** This supersedes draft PR #102 (same one-line fix from a fork, no tests). PR #102 has been closed in favour of this PR which includes the regression test coverage.

## Test plan

- [x] `pytest tests/test_workflow_config.py -v` — 16/16 pass (4 concurrency + 5 checkout-token + 5 badge-path + 2 timezone-aware)
- [x] `pytest tests/ --ignore=tests/test_cli.py -q` — 690 passed, 0 failures
- [x] `grep utcnow .github/workflows/cstylecheck_rules.yml` — no matches
- [x] Output format of `trend.jsonl` records unchanged — strftime pattern identical

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
