### PR TITLE
fix(checker): allow digit segments in lower_snake variable names

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -647,7 +647,7 @@ def matches_case_abbrev(name: str, style: str, abbrevs: set) -> bool:
             continue
         if seg.upper() in abbrevs:
             continue   # allowed abbreviation — any capitalisation
-        if not re.match(r"^[a-z][a-z0-9]*$", seg):
+        if not re.match(r"^[a-z0-9]+$", seg):
             return False
     return True
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -102,6 +102,27 @@ class TestLocalVariables(unittest.TestCase):
         self.assertFalse(has(src, VARS_NOFP, "variable.local.case",
                              filepath=f"{MOD}.c"))
 
+    # SWE4-TC-CASE-DIGIT-001
+    def test_lower_snake_trailing_digit_passes(self):
+        """pll_ctrl_1 is valid lower_snake — trailing digit segment must pass."""
+        src = "void f(void){ uint32_t pll_ctrl_1 = 0U; (void)pll_ctrl_1; }"
+        self.assertFalse(has(src, VARS_NOFP, "variable.local.case",
+                             filepath=f"{MOD}.c"))
+
+    # SWE4-TC-CASE-DIGIT-002
+    def test_lower_snake_digit_in_middle_passes(self):
+        """state_1_active is valid lower_snake — mid-name digit segment must pass."""
+        src = "void f(void){ uint32_t state_1_active = 0U; (void)state_1_active; }"
+        self.assertFalse(has(src, VARS_NOFP, "variable.local.case",
+                             filepath=f"{MOD}.c"))
+
+    # SWE4-TC-CASE-DIGIT-003
+    def test_lower_snake_digit_letter_segment_passes(self):
+        """i2c_bus_2 is valid lower_snake — digit-leading segment must pass."""
+        src = "void f(void){ uint8_t i2c_bus_2 = 0U; (void)i2c_bus_2; }"
+        self.assertFalse(has(src, VARS_NOFP, "variable.local.case",
+                             filepath=f"{MOD}.c"))
+
 
 class TestParameterVariables(unittest.TestCase):
     """Parameter case is only caught via RE_VAR_DECL, which requires a


### PR DESCRIPTION
﻿## Summary

- `matches_case_abbrev()` split names on `_` and required every segment to match `^[a-z][a-z0-9]*$` — i.e. start with a letter.
- Pure-digit or digit-leading segments (`1` in `pll_ctrl_1`, `2` in `i2c_bus_2`) failed this check, producing false-positive case violations for valid `lower_snake` names.
- The top-level `matches_case()` regex `^[a-z][a-z0-9_]*$` already accepted these names, so the two functions were inconsistent.
- Fix: widen the per-segment regex to `^[a-z0-9]+$`, matching exactly what the top-level pattern permits after splitting on `_`.

## Test plan

- [x] `SWE4-TC-CASE-DIGIT-001` — `pll_ctrl_1` no longer flagged
- [x] `SWE4-TC-CASE-DIGIT-002` — `state_1_active` no longer flagged
- [x] `SWE4-TC-CASE-DIGIT-003` — `i2c_bus_2` no longer flagged
- [x] `pytest tests/ --ignore=tests/test_cli.py -q` — 691 passed, 0 failures

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
