### PR TITLE
fix(checker): strip single-quoted char literals in strip_strings()

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -701,11 +701,18 @@ def strip_comments(source: str) -> str:
 
 
 def strip_strings(source: str) -> str:
-    return re.sub(
+    # Blank double-quoted string literals (preserve length for offset tracking)
+    source = re.sub(
         r'"(?:[^"\\]|\\.)*"',
         lambda m: '""' + " " * (len(m.group()) - 2),
         source,
     )
+    # Normalise single-quoted character literals to 'x' so tokens inside them
+    # cannot trigger unsigned-suffix or other digit-sensitive checks, while
+    # preserving the char-literal shape so the yoda checker still recognises
+    # 'x' as a constant token (its RHS scanner skips spaces but not letters).
+    source = re.sub(r"'(?:[^'\\]|\\.)'", lambda m: "'x'", source)
+    return source
 
 
 def preprocess(source: str) -> str:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -101,5 +101,24 @@ class TestUnsignedSuffix(unittest.TestCase):
         self.assertFalse(has("void f(void){ buf[2] = 0U; }\n",
                               US_CFG, "misc.unsigned_suffix"))
 
+    # SWE4-TC-STRIP-001
+    def test_char_literal_null_no_unsigned_suffix_violation(self):
+        """'\\0' inside a char literal must not trigger unsigned-suffix check."""
+        src = "void f(void){ char c = '\\0'; (void)c; }\n"
+        self.assertFalse(has(src, US_CFG, "misc.unsigned_suffix"))
+
+    # SWE4-TC-STRIP-002
+    def test_char_literal_letter_no_unsigned_suffix_violation(self):
+        """'a' inside a char literal must not trigger unsigned-suffix check."""
+        src = "void f(void){ char c = 'a'; (void)c; }\n"
+        self.assertFalse(has(src, US_CFG, "misc.unsigned_suffix"))
+
+    # SWE4-TC-STRIP-003
+    def test_char_literal_newline_no_unsigned_suffix_violation(self):
+        """'\\n' inside a char literal must not trigger unsigned-suffix check."""
+        src = "void f(void){ char c = '\\n'; (void)c; }\n"
+        self.assertFalse(has(src, US_CFG, "misc.unsigned_suffix"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary

- `strip_strings()` only blanked double-quoted string literals, leaving single-quoted character literals (`'0'`, `'\n'`, `'a'`) in the preprocessed source.
- Digit tokens inside char literals (`'0'`) could trigger false-positive `misc.unsigned_suffix` violations.
- Extends `strip_strings()` with a second pass that normalises char literals to `'x'`.

### Why `'x'` and not `' '`

The yoda checker's RHS token scanner (line ~2395) reads until it hits whitespace. Replacing `'A'` with `' '` (space) means the scanner only captures the leading `'`, which `_is_constant_token` doesn't recognise — breaking detection of non-yoda char comparisons like `ch == 'A'`. Using `'x'` keeps the shape intact so yoda detection still works, while `x` (non-digit) eliminates the unsigned-suffix false positive.

## Test plan

- [x] `SWE4-TC-STRIP-001` — `'\0'` in char literal: no unsigned-suffix violation
- [x] `SWE4-TC-STRIP-002` — `'a'` in char literal: no unsigned-suffix violation
- [x] `SWE4-TC-STRIP-003` — `'\n'` in char literal: no unsigned-suffix violation
- [x] `test_var_eq_char_literal` (yoda) still passes — `ch == 'A'` still flagged correctly
- [x] `pytest tests/ --ignore=tests/test_cli.py -q` — 691 passed, 0 failures

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
