### PR TITLE
fix(checker): normalise CRLF line endings once in Checker.__init__()

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -940,9 +940,13 @@ class Checker:
         copyright_header=None,
     ):
         self.filepath      = filepath
-        self.source        = source
+        # Normalise line endings once at construction time so all check
+        # methods operate on LF-only source.  Without this, CRLF files from
+        # Windows produce off-by-one line-length results (\r counts as a
+        # character) and multi-line regex anchors behave unexpectedly.
+        self.source        = source.replace('\r\n', '\n').replace('\r', '\n')
         # Step 1: strip comments and string literals
-        self.clean         = preprocess(source)
+        self.clean         = preprocess(self.source)
         # Track positions of "}" that close a typedef struct/union/enum
         # body so _check_variables can exclude them from RE_VAR_DECL.
         _RE_TYPEDEF_CLOSE = re.compile(
@@ -1874,10 +1878,9 @@ class Checker:
         sev              = cr_cfg.get("severity", "error")
         template, pattern = self._copyright
 
-        # Normalise line endings so the regex (built from the template,
-        # which was also normalised) can match reliably.
-        source = self.source.replace('\r\n', '\n').replace('\r', '\n')
-
+        # self.source is already LF-normalised in __init__; no further
+        # normalisation needed here.
+        source = self.source
         m = pattern.match(source)
 
         if m is None:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -28,6 +28,23 @@ class TestLineLength(unittest.TestCase):
         line = "/* " + "x" * 100 + " */"
         self.assertFalse(has(line + "\n", LL_CFG, "misc.line_length"))
 
+    # SWE4-TC-CRLF-001
+    def test_crlf_line_exactly_at_limit_passes(self):
+        """An 80-char line with CRLF ending must not be falsely flagged.
+
+        Without normalisation, \\r counts as an extra character making a
+        visually-80-char line appear to be 81 chars long.
+        """
+        line = "x" * 80
+        self.assertFalse(has(line + "\r\n", LL_CFG, "misc.line_length"))
+
+    # SWE4-TC-CRLF-002
+    def test_crlf_over_limit_still_fails(self):
+        """An 81-char line with CRLF ending must still be flagged."""
+        line = "x" * 81
+        self.assertTrue(has(line + "\r\n", LL_CFG, "misc.line_length"))
+
+
 class TestIndentation(unittest.TestCase):
     def test_spaces_pass_when_spaces_required(self):
         self.assertTrue(clean("    int x = 0;\n", IND_CFG))


### PR DESCRIPTION
﻿## Summary

- `_check_copyright_header()` normalised CRLF → LF locally, but no other check method did the same.
- CRLF source files (Windows line endings) caused false-positive `misc.line_length` violations (`\r` counted as an extra character making 80-char lines appear to be 81), and multi-line regex anchors could behave unexpectedly.
- Fix: normalise in `Checker.__init__()` once, immediately after source is stored. Remove the now-redundant per-call normalisation in `_check_copyright_header()`.

## Test plan

- [x] `SWE4-TC-CRLF-001` — 80-char CRLF line is not falsely flagged as too long
- [x] `SWE4-TC-CRLF-002` — 81-char CRLF line is still correctly flagged
- [x] All 55 `test_copyright_header.py` tests still pass
- [x] `pytest tests/ --ignore=tests/test_cli.py -q` — 690 passed, 0 failures

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
