### PR TITLE
fix(checker): correct 'lower' and 'upper' case patterns — reject underscores

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -620,8 +620,8 @@ _CASE_PATTERNS = {
     "upper_snake": re.compile(r"^[A-Z][A-Z0-9_]*$"),
     "camel":       re.compile(r"^[a-z][a-zA-Z0-9]*$"),
     "pascal":      re.compile(r"^[A-Z][a-zA-Z0-9]*$"),
-    "lower":       re.compile(r"^[a-z][a-z0-9_]*$"),
-    "upper":       re.compile(r"^[A-Z][A-Z0-9_]*$"),
+    "lower":       re.compile(r"^[a-z][a-z0-9]*$"),    # no underscores
+    "upper":       re.compile(r"^[A-Z][A-Z0-9]*$"),    # no underscores
 }
 
 

--- a/tests/test_case_patterns.py
+++ b/tests/test_case_patterns.py
@@ -1,0 +1,46 @@
+"""test_case_patterns.py — regression tests for _CASE_PATTERNS (issue #74).
+
+lower and upper styles must not accept underscores; lower_snake / upper_snake
+must continue to accept them.
+"""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from cstylecheck import matches_case
+
+
+class TestCasePatterns(unittest.TestCase):
+    """SWE4-TC-CASE-STYLE-001 to 006 — issue #74 regression suite."""
+
+    # SWE4-TC-CASE-STYLE-001
+    def test_lower_rejects_underscore(self):
+        """'lower' must not accept names with underscores."""
+        self.assertFalse(matches_case("bad_name", "lower"))
+
+    # SWE4-TC-CASE-STYLE-002
+    def test_lower_accepts_alphanumeric(self):
+        """'lower' must accept names with only lowercase letters and digits."""
+        self.assertTrue(matches_case("goodname1", "lower"))
+
+    # SWE4-TC-CASE-STYLE-003
+    def test_upper_rejects_underscore(self):
+        """'upper' must not accept names with underscores."""
+        self.assertFalse(matches_case("BAD_NAME", "upper"))
+
+    # SWE4-TC-CASE-STYLE-004
+    def test_upper_accepts_alphanumeric(self):
+        """'upper' must accept names with only uppercase letters and digits."""
+        self.assertTrue(matches_case("GOODNAME1", "upper"))
+
+    # SWE4-TC-CASE-STYLE-005
+    def test_lower_snake_still_accepts_underscore(self):
+        """'lower_snake' must still accept names with underscores."""
+        self.assertTrue(matches_case("good_name", "lower_snake"))
+
+    # SWE4-TC-CASE-STYLE-006
+    def test_upper_snake_still_accepts_underscore(self):
+        """'upper_snake' must still accept names with underscores."""
+        self.assertTrue(matches_case("GOOD_NAME", "upper_snake"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary

- `_CASE_PATTERNS["lower"]` and `_CASE_PATTERNS["upper"]` were compiled to the same regex as `lower_snake` / `upper_snake` — underscores were permitted when they should not be.
- Any rule specifying `case: lower` or `case: upper` silently behaved like `case: lower_snake` / `case: upper_snake`.
- Fix: remove `_` from both patterns: `^[a-z][a-z0-9]*$` and `^[A-Z][A-Z0-9]*$`.

> **Note:** The fix was also present on `feature/74-fix-lower-case-patterns` (correct code change), but that branch contained large amounts of unrelated history. This PR delivers a clean cherry-pick onto `develop`.

## Test plan

- [x] `SWE4-TC-CASE-STYLE-001` — `lower` rejects `bad_name` (underscore)
- [x] `SWE4-TC-CASE-STYLE-002` — `lower` accepts `goodname1`
- [x] `SWE4-TC-CASE-STYLE-003` — `upper` rejects `BAD_NAME` (underscore)
- [x] `SWE4-TC-CASE-STYLE-004` — `upper` accepts `GOODNAME1`
- [x] `SWE4-TC-CASE-STYLE-005` — `lower_snake` still accepts `good_name`
- [x] `SWE4-TC-CASE-STYLE-006` — `upper_snake` still accepts `GOOD_NAME`
- [x] `pytest tests/ --ignore=tests/test_cli.py -q` — 694 passed, 0 failures

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
