### PR TITLE
refactor(checker): remove redundant local re import in _v() (issue #75)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -989,8 +989,7 @@ class Checker:
 
     def _v(self, pos: int, sev: str, rule: str, msg: str) -> None:
         if self._ident_disabled:
-            import re as _re
-            _m = _re.search(r"'([^']+)'", msg)
+            _m = re.search(r"'([^']+)'", msg)
             if _m and rule in self._ident_disabled.get(_m.group(1), frozenset()):
                 return
         self.result.add(self._violation(pos, sev, rule, msg))


### PR DESCRIPTION
﻿## Summary
- Remove the redundant `import re as _re` from `Checker._v()` (line 992).
- Use the existing module-level `re` import directly — no behaviour change.

## Root cause (issue #75)
`Checker._v()` executed a local `import re as _re` on every call when
`_ident_disabled` was set, despite `re` being available at module scope.
While Python caches module imports, the redundant statement is executed on
every violation emission and is confusing during code review.

## Fix
```python
# Before
import re as _re
_m = _re.search(r"'([^']+)'", msg)

# After
_m = re.search(r"'([^']+)'", msg)
```

## Tests
All existing `test_exclusions.py` per-identifier tests exercise this code
path; no new tests are required for a pure refactor with no behaviour change.

Evaluated Mirochill's draft PR #104 — the fix is correct and identical.
This branch supersedes that draft PR.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
