### PR TITLE
refactor(main): remove dead _vb_prev_dir assignments in main() (issue #76)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -3498,7 +3498,6 @@ def main() -> int:
     # Discover files
     # Discover files lazily — emit progress immediately rather than
     # blocking until the entire glob tree is walked.
-    _vb_prev_dir = ""
     files: list = []
     for _fp in discover_files(
         args.files,
@@ -3524,7 +3523,6 @@ def main() -> int:
 
     output_format  = getattr(args, "output_format", "text")
     all_violations: list = []
-    _vb_prev_dir = ""
     # Cache source text keyed by filepath to avoid reading each file twice
     # (once for Checker, once for SignChecker).
     source_cache: dict = {}


### PR DESCRIPTION
﻿## Summary
- Remove the two dead `_vb_prev_dir = ""` assignments from `main()`.
- Both were write-only — the variable was never read after either assignment.

## Root cause (issue #76)
`_vb_prev_dir` was assigned at two locations in `main()`:
- Line 3501: before the file-discovery loop
- Line 3526: before the analysis loop

Neither assignment was ever consumed. The variable is a remnant of a
verbose-progress refactor that was never completed.

## Fix
Remove both assignments. No logic reads `_vb_prev_dir`, so no behaviour
changes.

## Tests
Dead-code removal — no test change required. All existing tests continue to
pass.

Evaluated Mirochill's draft PR #105 — the fix is identical.
This branch supersedes that draft PR.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
