### PR TITLE
fix(annotation): categorise GitHub annotation titles by rule type (issue #77)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -145,6 +145,38 @@ _VERSION_STRING = f"{_TOOL_NAME} {_VERSION}"
 # Data structures
 # ---------------------------------------------------------------------------
 
+_MISRA_ANNOTATION_RULES: frozenset = frozenset({
+    "misc.trigraph",
+    "misc.octal_constant",
+    "misc.lowercase_l_suffix",
+})
+
+_NAMING_ANNOTATION_PREFIXES: frozenset = frozenset({
+    "constant",
+    "enum",
+    "function",
+    "include_guard",
+    "macro",
+    "reserved_name",
+    "struct",
+    "typedef",
+    "variable",
+})
+
+
+def _github_annotation_category(rule: str) -> str:
+    """Return the GitHub Actions annotation title category for *rule*."""
+    if rule in _MISRA_ANNOTATION_RULES:
+        return "MISRA"
+    if rule == "sign_compatibility":
+        return "SignCompat"
+    if rule == "spell_check":
+        return "SpellCheck"
+    if rule.split(".", 1)[0] in _NAMING_ANNOTATION_PREFIXES:
+        return "NamingConvention"
+    return "Misc"
+
+
 @dataclass
 class Violation:
     filepath: str
@@ -155,10 +187,15 @@ class Violation:
     message: str
 
     def github_annotation(self) -> str:
-        level = self.severity if self.severity in ("error", "warning", "notice") else "notice"
+        level = (
+            self.severity
+            if self.severity in ("error", "warning", "notice")
+            else "notice"
+        )
+        title = _github_annotation_category(self.rule)
         return (
             f"::{level} file={self.filepath},line={self.line},"
-            f"col={self.col},title=NamingConvention[{self.rule}]::"
+            f"col={self.col},title={title}[{self.rule}]::"
             f"{self.message}"
         )
 

--- a/tests/test_github_annotations.py
+++ b/tests/test_github_annotations.py
@@ -1,0 +1,68 @@
+"""test_github_annotations.py — regression tests for github_annotation() title
+categories (issue #77).
+
+Every rule category must produce the correct annotation title rather than the
+previously hardcoded "NamingConvention" label.
+"""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import Violation
+
+
+class TestGitHubAnnotationTitles(unittest.TestCase):
+    """SWE4-TC-ANNOT-001 to 008 — issue #77 regression suite."""
+
+    def _annotation_for(self, rule: str) -> str:
+        return Violation("source.c", 10, 4, "error", rule, "message").github_annotation()
+
+    # SWE4-TC-ANNOT-001
+    def test_naming_variable_rule_uses_naming_convention_title(self):
+        """variable.* rules must produce NamingConvention title."""
+        self.assertIn("title=NamingConvention[variable.global.prefix]::",
+                      self._annotation_for("variable.global.prefix"))
+
+    # SWE4-TC-ANNOT-002
+    def test_naming_function_rule_uses_naming_convention_title(self):
+        """function.* rules must produce NamingConvention title."""
+        self.assertIn("title=NamingConvention[function.prefix]::",
+                      self._annotation_for("function.prefix"))
+
+    # SWE4-TC-ANNOT-003
+    def test_misra_trigraph_uses_misra_title(self):
+        """misc.trigraph must produce MISRA title."""
+        self.assertIn("title=MISRA[misc.trigraph]::",
+                      self._annotation_for("misc.trigraph"))
+
+    # SWE4-TC-ANNOT-004
+    def test_misra_octal_uses_misra_title(self):
+        """misc.octal_constant must produce MISRA title."""
+        self.assertIn("title=MISRA[misc.octal_constant]::",
+                      self._annotation_for("misc.octal_constant"))
+
+    # SWE4-TC-ANNOT-005
+    def test_misra_lowercase_l_uses_misra_title(self):
+        """misc.lowercase_l_suffix must produce MISRA title."""
+        self.assertIn("title=MISRA[misc.lowercase_l_suffix]::",
+                      self._annotation_for("misc.lowercase_l_suffix"))
+
+    # SWE4-TC-ANNOT-006
+    def test_sign_compatibility_uses_signcompat_title(self):
+        """sign_compatibility must produce SignCompat title."""
+        self.assertIn("title=SignCompat[sign_compatibility]::",
+                      self._annotation_for("sign_compatibility"))
+
+    # SWE4-TC-ANNOT-007
+    def test_spell_check_uses_spellcheck_title(self):
+        """spell_check must produce SpellCheck title."""
+        self.assertIn("title=SpellCheck[spell_check]::",
+                      self._annotation_for("spell_check"))
+
+    # SWE4-TC-ANNOT-008
+    def test_other_misc_rule_uses_misc_title(self):
+        """Non-MISRA misc.* rules must produce Misc title."""
+        self.assertIn("title=Misc[misc.line_length]::",
+                      self._annotation_for("misc.line_length"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary
- Introduce `_github_annotation_category(rule)` helper to map rule names to annotation title categories.
- Replace the hardcoded `NamingConvention` title with the correct per-category label.
- Add `tests/test_github_annotations.py` with 8 regression tests (SWE4-TC-ANNOT-001..008).

## Root cause (issue #77)
`Violation.github_annotation()` used `title=NamingConvention[{rule}]` for
every violation. In the GitHub Actions annotations UI this labelled MISRA
checks, sign-compatibility warnings, spell-check notices and general misc
violations all as "NamingConvention" — incorrect and misleading.

## Fix

New module-level constants and helper:
```python
_MISRA_ANNOTATION_RULES = frozenset({"misc.trigraph", "misc.octal_constant",
                                      "misc.lowercase_l_suffix"})
_NAMING_ANNOTATION_PREFIXES = frozenset({"variable", "function", "constant",
                                          "macro", "typedef", "enum", "struct",
                                          "include_guard", "reserved_name"})

def _github_annotation_category(rule: str) -> str:
    if rule in _MISRA_ANNOTATION_RULES:    return "MISRA"
    if rule == "sign_compatibility":       return "SignCompat"
    if rule == "spell_check":              return "SpellCheck"
    if rule.split(".", 1)[0] in _NAMING_ANNOTATION_PREFIXES:
                                           return "NamingConvention"
    return "Misc"
```

`github_annotation()` now uses `title={_github_annotation_category(self.rule)}[{self.rule}]`.

## Tests
`tests/test_github_annotations.py` — 8 tests covering:
- `variable.*` and `function.*` → NamingConvention
- `misc.trigraph`, `misc.octal_constant`, `misc.lowercase_l_suffix` → MISRA
- `sign_compatibility` → SignCompat
- `spell_check` → SpellCheck
- `misc.line_length` (non-MISRA misc) → Misc

Evaluated Mirochill's open PR #106 — the fix approach is identical.
This branch supersedes that PR.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
