### PR TITLE
docs(design): renumber checker section headers to match run_all() order (issue #78)

### DIFF
--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -72,9 +72,9 @@ This document defines the detailed design of each software unit in **CStyleCheck
 | UNIT-28 | `Checker._check_structs` | `cstylecheck.py:1739` | COMP-05d |
 | UNIT-29 | `Checker._check_include_guard` | `cstylecheck.py:1879` | COMP-05e |
 | UNIT-30 | `Checker._check_misc` | `cstylecheck.py:1912` | COMP-05f |
-| UNIT-31 | `Checker._check_yoda` | `cstylecheck.py:2245` | COMP-05f |
-| UNIT-32 | `Checker._check_spelling` | `cstylecheck.py:2226` | COMP-05f |
-| UNIT-33 | `Checker._check_reserved_names` | `cstylecheck.py:2348` | COMP-05f |
+| UNIT-31 | `Checker._check_yoda` | `cstylecheck.py:2369` | COMP-05f |
+| UNIT-32 | `Checker._check_reserved_names` | `cstylecheck.py:2596` | COMP-05f |
+| UNIT-33 | `Checker._check_spelling` | `cstylecheck.py:2350` | COMP-05f |
 | UNIT-34 | `SignChecker._check_calls` | `cstylecheck.py:2688` | COMP-05g |
 | UNIT-35 | `load_baseline` | `cstylecheck.py:3006` | COMP-06 |
 | UNIT-36 | `write_baseline` | `cstylecheck.py:3021` | COMP-06 |
@@ -231,7 +231,7 @@ This document defines the detailed design of each software unit in **CStyleCheck
 
 **Algorithm:** Call each enabled `_check_*` method in fixed order; each appends to `self.result.violations`. Return `self.result`.
 
-**Order:** `_check_defines`, `_check_variables`, `_check_functions`, `_check_typedefs`, `_check_enums`, `_check_structs`, `_check_include_guard`, `_check_misc`, `_check_yoda`, `_check_spelling`, `_check_reserved_names`, `_check_copyright_header`, `_check_block_comment_spacing`, `_check_eof_comment`
+**Order:** `_check_copyright_header`, `_check_defines`, `_check_variables`, `_check_functions`, `_check_typedefs`, `_check_enums`, `_check_structs`, `_check_include_guard` (headers only), `_check_misc`, `_check_yoda`, `_check_reserved_names`, `_check_lowercase_l_suffix`, `_check_octal_constants`, `_check_trigraphs`, `_check_spelling` (when dictionary configured)
 
 ---
 

--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -2186,7 +2186,7 @@ class Checker:
                         f"'U' or 'u' suffix (or assign to a signed type)"))
 
     # -----------------------------------------------------------------------
-    # 9. Block-comment spacing
+    # 8a. Block-comment spacing
     # Checks that the number of blank lines between the closing */ of a
     # multi-line block comment and the next non-blank line is within the
     # configured [min, max] range.
@@ -2231,7 +2231,7 @@ class Checker:
                         f"Block comment has {_blanks} blank line(s) after '*/'; "
                         f"maximum is {bcs_max}"))
 
-        # EOF comment
+        # 8b. EOF comment
         # The last non-blank line must equal the configured template string
         # (with {filename} replaced by the file's base name, case-adjusted).
         # Exactly one blank line must follow it as the final line of the file.
@@ -2307,7 +2307,7 @@ class Checker:
                         f"line; found {n_after}"))
 
     # -----------------------------------------------------------------------
-    # 10. Comment spell-check
+    # 14. Comment spell-check
     # -----------------------------------------------------------------------
 
     def _check_spelling(self) -> None:
@@ -2326,7 +2326,7 @@ class Checker:
 
 
     # -----------------------------------------------------------------------
-    # 11. Yoda conditions  (constant on the LHS of == and !=)
+    # 9. Yoda conditions  (constant on the LHS of == and !=)
     # -----------------------------------------------------------------------
 
     def _check_yoda(self) -> None:
@@ -2422,7 +2422,7 @@ class Checker:
         return bool(re.fullmatch(r"[a-z_][a-zA-Z0-9_]*", t))
 
     # -----------------------------------------------------------------------
-    # 12. MISRA C:2012/2023 Rule 7.3 — lowercase 'l' suffix forbidden
+    # 11. MISRA C:2012/2023 Rule 7.3 — lowercase 'l' suffix forbidden
     #
     # The letter 'l' (lowercase L) is visually indistinguishable from the
     # digit '1' in many fonts.  MISRA C:2012 Rule 7.3 and MISRA C:2023
@@ -2458,7 +2458,7 @@ class Checker:
                 )
 
     # -----------------------------------------------------------------------
-    # 13. MISRA C:2012/2023 Rule 7.1 — octal integer constants forbidden
+    # 12. MISRA C:2012/2023 Rule 7.1 — octal integer constants forbidden
     #
     # An integer literal that starts with '0' followed by one or more
     # octal digits (0–7) is an octal constant.  This is a common source
@@ -2498,7 +2498,7 @@ class Checker:
             )
 
     # -----------------------------------------------------------------------
-    # 14. MISRA C:2012/2023 Rule 4.2 — trigraphs forbidden
+    # 13. MISRA C:2012/2023 Rule 4.2 — trigraphs forbidden
     #
     # Trigraphs are three-character sequences beginning with '??' that the
     # C preprocessor replaces with a single character before parsing.  They
@@ -2535,7 +2535,7 @@ class Checker:
             ))
 
     # -----------------------------------------------------------------------
-    # 11. Reserved / banned name check
+    # 10. Reserved / banned name check
     # -----------------------------------------------------------------------
 
     def _is_reserved(self, name: str) -> tuple:


### PR DESCRIPTION
﻿## Summary
- Renumber checker section header comments in `src/cstylecheck.py` to match `run_all()` invocation order.
- Fix duplicate "# 11." label on both `_check_yoda` and `_check_reserved_names`.
- Update `UNIT-31/32/33` table and `run_all()` order description in `CStyleCheck_SWE3_Detailed_Design.md`.

## Root cause (issue #78)
Two methods carried the same `# 11.` header comment:
- `_check_yoda` (line ~2329)
- `_check_reserved_names` (line ~2538)

Additionally, `_check_spelling` was labelled `# 10.` but is invoked **last** in `run_all()`, after the MISRA checks numbered 12–14.

## Fix — new numbering aligned to `run_all()` call order

| # | Section |
|---|---------|
| 0 | `_check_copyright_header` |
| 1–7 | defines → include_guard (unchanged) |
| 8 | `_check_misc` |
| 8a | Block-comment spacing (sub-section) |
| 8b | EOF comment (sub-section) |
| 9 | `_check_yoda` |
| 10 | `_check_reserved_names` |
| 11 | `_check_lowercase_l_suffix` (MISRA 7.3) |
| 12 | `_check_octal_constants` (MISRA 7.1) |
| 13 | `_check_trigraphs` (MISRA 4.2) |
| 14 | `_check_spelling` |

## Tests
Comment / documentation change only — no runtime behaviour changed. No new tests required.

Evaluated Mirochill's draft PR #103 — the renumbering approach is identical.
This branch supersedes that draft PR.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
