### PR TITLE
fix(checker): eliminate global mutation of C_KEYWORDS/C_STDLIB_NAMES in main() (issue #79)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -938,6 +938,8 @@ class Checker:
         defines: list = None,
         extra_banned: frozenset = None,
         copyright_header=None,
+        c_keywords: frozenset = None,
+        c_stdlib_names: frozenset = None,
     ):
         self.filepath      = filepath
         self.source        = source
@@ -978,6 +980,14 @@ class Checker:
         self._extra_banned: frozenset = extra_banned or frozenset()
         # tuple (template_text, compiled_re) from --copyright, or None
         self._copyright = copyright_header
+        # Keyword / stdlib sets — use explicit overrides when provided so that
+        # main() does not need to mutate the module-level globals (issue #79).
+        self._c_keywords: frozenset = (
+            c_keywords if c_keywords is not None else C_KEYWORDS
+        )
+        self._c_stdlib_names: frozenset = (
+            c_stdlib_names if c_stdlib_names is not None else C_STDLIB_NAMES
+        )
 
     # -----------------------------------------------------------------------
     # Internal helpers
@@ -2540,9 +2550,9 @@ class Checker:
 
     def _is_reserved(self, name: str) -> tuple:
         """Return (True, category_string) if *name* is a reserved identifier."""
-        if name in C_KEYWORDS:
+        if name in self._c_keywords:
             return True, "C/C++ keyword"
-        if name in C_STDLIB_NAMES:
+        if name in self._c_stdlib_names:
             return True, "C standard library name"
         if name in self._extra_banned:
             return True, "project-banned name"
@@ -3444,16 +3454,19 @@ def main() -> int:
     cfg  = load_config(args.config)
 
     # Spell-check word set — None means the check is entirely disabled
-    # Override dictionary files from CLI if provided
-    global C_KEYWORDS, C_STDLIB_NAMES, _BUILTIN_DICT
-    if getattr(args, "keywords_file", None):
-        C_KEYWORDS = _load_dict_file(args.keywords_file)
-    if getattr(args, "stdlib_file", None):
-        C_STDLIB_NAMES = _load_dict_file(args.stdlib_file)
+    # Build local overrides from CLI flags without mutating module-level globals
+    # (mutating globals is not thread-safe — issue #79).
+    keywords_set = (
+        _load_dict_file(args.keywords_file)
+        if getattr(args, "keywords_file", None) else C_KEYWORDS
+    )
+    stdlib_set = (
+        _load_dict_file(args.stdlib_file)
+        if getattr(args, "stdlib_file", None) else C_STDLIB_NAMES
+    )
     spell_base = None
     if getattr(args, "spell_dict", None):
         spell_base = _load_dict_file(args.spell_dict)
-        _BUILTIN_DICT = spell_base
 
     spell_words = None
     sp_cfg = cfg.get("spell_check", {})
@@ -3564,6 +3577,8 @@ def main() -> int:
             defines=defines,
             extra_banned=extra_banned,
             copyright_header=copyright_header,
+            c_keywords=keywords_set,
+            c_stdlib_names=stdlib_set,
         )
         result  = checker.run_all()
         all_violations.extend(result.violations)

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -92,7 +92,9 @@ def run(source: str,
         disabled_rules: frozenset = frozenset(),
         defines: list = None,
         extra_banned: frozenset = frozenset(),
-        copyright_header=None) -> list:
+        copyright_header=None,
+        c_keywords: frozenset = None,
+        c_stdlib_names: frozenset = None) -> list:
     """Run checker on *source* and return Violation list."""
     c = Checker(
         filepath, source, cfg,
@@ -102,6 +104,8 @@ def run(source: str,
         defines=defines,
         extra_banned=extra_banned,
         copyright_header=copyright_header,
+        c_keywords=c_keywords,
+        c_stdlib_names=c_stdlib_names,
     )
     return c.run_all().violations
 

--- a/tests/test_thread_safe_globals.py
+++ b/tests/test_thread_safe_globals.py
@@ -1,0 +1,69 @@
+"""test_thread_safe_globals.py — regression tests for thread-safe keyword and
+stdlib overrides (issue #79).
+
+main() previously mutated C_KEYWORDS / C_STDLIB_NAMES / _BUILTIN_DICT as
+module-level globals when CLI override flags were supplied.  Those sets are
+now stored as instance variables on Checker so concurrent invocations do not
+race on shared state.
+"""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+import cstylecheck
+from harness import cfg_only, has, clean
+
+
+_RESERVED_CFG = cfg_only(reserved_names={"enabled": True, "severity": "error"})
+
+
+class TestThreadSafeKeywords(unittest.TestCase):
+    """SWE4-TC-THREAD-001 to 004 — issue #79 regression suite."""
+
+    # SWE4-TC-THREAD-001
+    def test_custom_keywords_override_used_by_checker(self):
+        """A Checker created with c_keywords override uses those words, not globals."""
+        custom_kw = frozenset({"mykeyword"})
+        from harness import run
+        src = "void f(void){ uint32_t mykeyword = 0U; (void)mykeyword; }\n"
+        viols = run(src, _RESERVED_CFG, filepath="mod.c",
+                    c_keywords=custom_kw)
+        rules = [v.rule for v in viols]
+        self.assertIn("reserved_name", rules,
+                      "Custom keyword 'mykeyword' should be flagged")
+
+    # SWE4-TC-THREAD-002
+    def test_module_global_c_keywords_unchanged_after_checker(self):
+        """Creating a Checker with c_keywords override must not mutate C_KEYWORDS."""
+        before = frozenset(cstylecheck.C_KEYWORDS)
+        custom_kw = frozenset({"mykeyword"})
+        from harness import run
+        src = "void f(void){ uint32_t mykeyword = 0U; (void)mykeyword; }\n"
+        run(src, _RESERVED_CFG, filepath="mod.c", c_keywords=custom_kw)
+        self.assertEqual(cstylecheck.C_KEYWORDS, before,
+                         "C_KEYWORDS global must not be mutated by Checker")
+
+    # SWE4-TC-THREAD-003
+    def test_custom_stdlib_override_used_by_checker(self):
+        """A Checker created with c_stdlib_names override uses those words."""
+        custom_stdlib = frozenset({"my_stdlib_fn"})
+        from harness import run
+        src = "void f(void){ uint32_t my_stdlib_fn = 0U; (void)my_stdlib_fn; }\n"
+        viols = run(src, _RESERVED_CFG, filepath="mod.c",
+                    c_stdlib_names=custom_stdlib)
+        rules = [v.rule for v in viols]
+        self.assertIn("reserved_name", rules,
+                      "Custom stdlib name 'my_stdlib_fn' should be flagged")
+
+    # SWE4-TC-THREAD-004
+    def test_module_global_c_stdlib_names_unchanged_after_checker(self):
+        """Creating a Checker with c_stdlib_names override must not mutate C_STDLIB_NAMES."""
+        before = frozenset(cstylecheck.C_STDLIB_NAMES)
+        custom_stdlib = frozenset({"my_stdlib_fn"})
+        from harness import run
+        src = "void f(void){ uint32_t my_stdlib_fn = 0U; (void)my_stdlib_fn; }\n"
+        run(src, _RESERVED_CFG, filepath="mod.c", c_stdlib_names=custom_stdlib)
+        self.assertEqual(cstylecheck.C_STDLIB_NAMES, before,
+                         "C_STDLIB_NAMES global must not be mutated by Checker")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary
- Remove the `global C_KEYWORDS, C_STDLIB_NAMES, _BUILTIN_DICT` statement from `main()`.
- Add `c_keywords` / `c_stdlib_names` parameters to `Checker.__init__()` so CLI overrides are passed per-instance, not as module-state mutations.
- `_is_reserved()` now reads `self._c_keywords` / `self._c_stdlib_names` instead of the module globals.
- Also remove the redundant `_BUILTIN_DICT = spell_base` assignment (the value was already passed as `base_dict=spell_base` to `_build_spell_dict()`).
- Add `tests/test_thread_safe_globals.py` (SWE4-TC-THREAD-001..004).

## Root cause (issue #79)
`main()` mutated three module-level globals:
```python
global C_KEYWORDS, C_STDLIB_NAMES, _BUILTIN_DICT
if getattr(args, "keywords_file", None):
    C_KEYWORDS = _load_dict_file(args.keywords_file)
```
This contradicts the existing thread-safety note in `SignChecker.check()` and produces a race condition under `pytest-xdist` or any parallel test runner.

## Fix
```python
# Before (main):
global C_KEYWORDS, C_STDLIB_NAMES, _BUILTIN_DICT
C_KEYWORDS = _load_dict_file(args.keywords_file)
...
checker = Checker(filepath, source, cfg, ...)

# After (main):
keywords_set = _load_dict_file(args.keywords_file) if ... else C_KEYWORDS
stdlib_set   = _load_dict_file(args.stdlib_file)   if ... else C_STDLIB_NAMES
...
checker = Checker(filepath, source, cfg, c_keywords=keywords_set,
                  c_stdlib_names=stdlib_set, ...)
```

`Checker.__init__()` stores the values as `self._c_keywords` / `self._c_stdlib_names`, falling back to the module-level constants when `None`.

## Tests
`tests/test_thread_safe_globals.py` — 4 tests:
- Custom `c_keywords` used by checker (SWE4-TC-THREAD-001)
- `C_KEYWORDS` global unchanged after checker runs (SWE4-TC-THREAD-002)
- Custom `c_stdlib_names` used by checker (SWE4-TC-THREAD-003)
- `C_STDLIB_NAMES` global unchanged after checker runs (SWE4-TC-THREAD-004)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
