### PR TITLE
fix(ci): pin tj-actions/changed-files to SHA and moby/buildkit to v0.19.0 (issues #59 #60)

### DIFF
--- a/.github/workflows/cstylecheck_rules.yml
+++ b/.github/workflows/cstylecheck_rules.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Get changed C files (PR only)
         if: github.event_name == 'pull_request'
         id: changed
-        uses: tj-actions/changed-files@d6babd516b1d0b6a8be0e69a3ef3ed4c3737b028 # v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44
         with:
           files: |
             source/**/*.c

--- a/.github/workflows/cstylecheck_rules.yml
+++ b/.github/workflows/cstylecheck_rules.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Get changed C files (PR only)
         if: github.event_name == 'pull_request'
         id: changed
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@d6babd516b1d0b6a8be0e69a3ef3ed4c3737b028 # v44
         with:
           files: |
             source/**/*.c

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
-          driver-opts: image=moby/buildkit:latest
+          driver-opts: image=moby/buildkit:v0.19.0
 
       # ── Log in to GitHub Container Registry ─────────────────────────────────
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
﻿## Summary
- Pin `tj-actions/changed-files@v44` to commit SHA `d6babd516b1d0b6a8be0e69a3ef3ed4c3737b028` in `cstylecheck_rules.yml`.
- Pin `moby/buildkit:latest` to `moby/buildkit:v0.19.0` in `docker_publish.yml`.

## Motivation
Floating semver tags and `:latest` images are supply-chain attack vectors — a compromised tag can inject malicious code into CI. ASPICE SUP.8 requires immutable references for all tools under CM.

## Changes
| File | Before | After |
|------|--------|-------|
| `cstylecheck_rules.yml` | `tj-actions/changed-files@v44` | `tj-actions/changed-files@d6babd516b1d0b6a8be0e69a3ef3ed4c3737b028 # v44` |
| `docker_publish.yml` | `moby/buildkit:latest` | `moby/buildkit:v0.19.0` |

## Tests
CI/workflow change only — no code tests required.

Closes #59
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
