### PR TITLE
fix(cli): warn when --spell-words is supplied but spell_check is disabled (issue #90)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -3520,6 +3520,14 @@ def main() -> int:
         cfg_exempt  = sp_cfg.get("exempt_values", [])
         extra_words = load_spell_words(args.spell_words) if args.spell_words else set()
         spell_words = _build_spell_dict(cfg_exempt, extra_words, base_dict=spell_base)
+    elif getattr(args, "spell_words", None):
+        # spell_check is disabled but the user passed --spell-words; warn rather
+        # than silently discarding the file (issue #90).
+        print(
+            f"WARNING: --spell-words '{args.spell_words}' supplied but "
+            "spell_check.enabled is false in config — words file ignored.",
+            file=sys.stderr,
+        )
 
     # Project defines map: list of (pattern, replacement) for token substitution
     defines: list = load_defines_file(args.defines) if args.defines else []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -436,5 +436,37 @@ class TestExitCodes(unittest.TestCase):
         self.assertIn("No C files to check", out)
 
 
+# ---------------------------------------------------------------------------
+class TestSpellWordsWarning(unittest.TestCase):
+    """SUP9-TC-SPELL-001 to 002 — issue #90 regression suite.
+
+    --spell-words must emit a warning to stderr when spell_check is disabled
+    in config rather than silently discarding the words file.
+    """
+
+    # SUP9-TC-SPELL-001
+    def test_spell_words_with_disabled_check_warns_on_stderr(self):
+        """WARNING appears on stderr when --spell-words is passed but spell_check
+        is disabled (spell_check.enabled: false in tests/rules.yml)."""
+        with tempfile.TemporaryDirectory() as td:
+            words = _write(td, "extra.txt", "myproject\n")
+            src   = _write(td, "main.c",    "int main(void){ return 0; }\n")
+            cmd   = [sys.executable, CHECKER, "--config", YAML,
+                     "--spell-words", str(words), str(src)]
+            r = subprocess.run(cmd, capture_output=True, text=True)
+        self.assertIn("WARNING", r.stderr)
+        self.assertIn("spell-words", r.stderr)
+        self.assertIn("spell_check.enabled is false", r.stderr)
+
+    # SUP9-TC-SPELL-002
+    def test_spell_words_warning_does_not_affect_exit_code(self):
+        """The warning must not change the exit code — it is informational only."""
+        with tempfile.TemporaryDirectory() as td:
+            words = _write(td, "extra.txt", "myproject\n")
+            src   = _write(td, "main.c",    "int main(void){ return 0; }\n")
+            rc, _ = _run("--spell-words", str(words), files=[src])
+        self.assertEqual(rc, 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary
- Emit a `WARNING` to stderr when `--spell-words FILE` is supplied but `spell_check.enabled` is `false` in config.
- Add `TestSpellWordsWarning` to `tests/test_cli.py` (SUP9-TC-SPELL-001..002).

## Root cause (issue #90)
`main()` loaded the words file and then immediately discarded it when `spell_check.enabled` was false — no diagnostic was emitted. Users had no way to know their `--spell-words` file had no effect.

## Fix
```python
elif getattr(args, "spell_words", None):
    print(
        f"WARNING: --spell-words '{args.spell_words}' supplied but "
        "spell_check.enabled is false in config — words file ignored.",
        file=sys.stderr,
    )
```

The warning is informational only — exit code is unchanged.

## Tests
`TestSpellWordsWarning` in `test_cli.py`:
- SUP9-TC-SPELL-001: warning text appears on stderr
- SUP9-TC-SPELL-002: exit code is not affected

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
