### PR TITLE
refactor(ci): extract inline Python from cstylecheck_rules.yml into scripts/

### DIFF
--- a/.github/workflows/cstylecheck_rules.yml
+++ b/.github/workflows/cstylecheck_rules.yml
@@ -193,6 +193,7 @@ jobs:
             git checkout gh-pages
             git checkout ${{ github.sha }} -- .github 2>/dev/null || true
             git checkout ${{ github.sha }} -- README.md 2>/dev/null || true
+            git checkout ${{ github.sha }} -- scripts/ 2>/dev/null || true
           else
             git checkout --orphan gh-pages
             git rm -rf . 2>/dev/null || true
@@ -200,23 +201,7 @@ jobs:
           mkdir -p cstylecheck
 
       - name: Append trend record
-        shell: python
-        run: |
-          import json, datetime, os, pathlib
-
-          record = {
-              "date":     datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-              "run":      int(os.environ["RUN_NUMBER"]),
-              "sha":      os.environ["SHA"][:8],
-              "errors":   int(os.environ["ERRORS"]),
-              "warnings": int(os.environ["WARNINGS"]),
-              "infos":    int(os.environ["INFOS"]),
-              "files":    int(os.environ["FILES"]),
-          }
-          f = pathlib.Path("cstylecheck/trend.jsonl")
-          with f.open("a") as fh:
-              fh.write(json.dumps(record) + "\n")
-          print(f"Appended: {record}")
+        run: python scripts/ci/append_trend_record.py
         env:
           RUN_NUMBER: ${{ github.run_number }}
           SHA:        ${{ github.sha }}
@@ -226,106 +211,7 @@ jobs:
           FILES:      ${{ needs.stylecheck.outputs.files }}
 
       - name: Generate trend HTML page and badge JSON
-        shell: python
-        run: |
-          import json, os, pathlib, re
-
-          trend_file = pathlib.Path("cstylecheck/trend.jsonl")
-          records    = [json.loads(l) for l in trend_file.read_text().splitlines() if l.strip()]
-          recent     = records[-60:]   # keep last 60 data points on the chart
-
-          errors   = int(os.environ["ERRORS"])
-          warnings = int(os.environ["WARNINGS"])
-          repo     = os.environ["REPO"]
-          owner, reponame = repo.split("/")
-          pages_base = f"https://{owner}.github.io/{reponame}"
-
-          # --- Badge JSON (served by shields.io endpoint) ---
-          total   = errors + warnings
-          colour  = "brightgreen" if total == 0 else "yellow" if errors == 0 else "red"
-          message = "clean" if total == 0 else f"{errors}E {warnings}W"
-          badge   = {"schemaVersion": 1, "label": "naming", "message": message, "color": colour}
-          pathlib.Path("cstylecheck/badge.json").write_text(json.dumps(badge, indent=2))
-
-          # --- Chart data ---
-          labels = [r["date"][:10] + " #" + str(r.get("run","?")) for r in recent]
-          e_vals = [r["errors"]   for r in recent]
-          w_vals = [r["warnings"] for r in recent]
-          i_vals = [r["infos"]    for r in recent]
-
-          rows = "".join(
-              f'<tr><td>{r["date"][:10]}</td><td>#{r.get("run","?")}</td>'
-              f'<td><code>{r["sha"]}</code></td><td>{r["files"]}</td>'
-              f'<td style="color:{"red" if r["errors"] else "green"}">{r["errors"]}</td>'
-              f'<td style="color:{"orange" if r["warnings"] else "green"}">{r["warnings"]}</td>'
-              f'<td>{r["infos"]}</td></tr>'
-              for r in reversed(recent)
-          )
-
-          html = f"""<!doctype html>
-          <html lang="en"><head>
-          <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width,initial-scale=1">
-          <title>{reponame} -- Naming Convention Trend</title>
-          <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-          <style>
-            body {{ font-family: system-ui, sans-serif; max-width: 960px;
-                   margin: 0 auto; padding: 1rem 1.5rem; color: #222; }}
-            h1   {{ font-size: 1.4rem; }}
-            table {{ border-collapse: collapse; width: 100%; font-size: 0.85rem; }}
-            th, td {{ border: 1px solid #ccc; padding: 4px 8px; text-align: right; }}
-            th {{ background: #f5f5f5; text-align: center; }}
-            td:nth-child(1), td:nth-child(2), td:nth-child(3) {{ text-align: left; }}
-            .stat {{ display: inline-block; margin: 0 1rem; font-size: 1.1rem; }}
-            canvas {{ margin: 1.5rem 0; }}
-          </style>
-          </head><body>
-          <h1>📋 {reponame}: Naming Convention Trend</h1>
-          <p>
-            <span class="stat">🔴 <strong style="color:{'red' if errors else 'green'}">{errors}</strong> errors</span>
-            <span class="stat">🟡 <strong style="color:{'orange' if warnings else 'green'}">{warnings}</strong> warnings</span>
-            <span class="stat">📁 {os.environ["FILES"]} files</span>
-            <span class="stat">🔢 {len(records)} runs recorded</span>
-          </p>
-          <canvas id="chart" height="120"></canvas>
-          <script>
-          new Chart(document.getElementById('chart'), {{
-            type: 'line',
-            data: {{
-              labels: {json.dumps(labels)},
-              datasets: [
-                {{ label: 'Errors',   data: {json.dumps(e_vals)}, fill: true,
-                   borderColor: '#d32f2f', backgroundColor: 'rgba(211,47,47,0.15)',
-                   tension: 0.3, pointRadius: 3 }},
-                {{ label: 'Warnings', data: {json.dumps(w_vals)}, fill: true,
-                   borderColor: '#f57c00', backgroundColor: 'rgba(245,124,0,0.12)',
-                   tension: 0.3, pointRadius: 3 }},
-                {{ label: 'Info',     data: {json.dumps(i_vals)}, fill: true,
-                   borderColor: '#1976d2', backgroundColor: 'rgba(25,118,210,0.10)',
-                   tension: 0.3, pointRadius: 3 }},
-              ]
-            }},
-            options: {{
-              responsive: true,
-              interaction: {{ mode: 'index', intersect: false }},
-              plugins: {{ legend: {{ position: 'top' }},
-                         tooltip: {{ mode: 'index' }} }},
-              scales: {{ y: {{ beginAtZero: true, ticks: {{ stepSize: 1 }} }} }}
-            }}
-          }});
-          </script>
-          <h2>Run history (last {len(recent)} runs)</h2>
-          <table>
-          <tr><th>Date</th><th>Run</th><th>SHA</th><th>Files</th>
-              <th>Errors</th><th>Warnings</th><th>Info</th></tr>
-          {rows}
-          </table>
-          <p><small>Source: <a href="https://github.com/{repo}">{repo}</a></small></p>
-          </body></html>"""
-
-          pathlib.Path("cstylecheck/index.html").write_text(html)
-          print(f"Trend page: {pages_base}/cstylecheck/")
-          print(f"Badge URL:  https://img.shields.io/endpoint?url={pages_base}/cstylecheck/badge.json")
+        run: python scripts/ci/generate_trend.py
         env:
           ERRORS:   ${{ needs.stylecheck.outputs.errors }}
           WARNINGS: ${{ needs.stylecheck.outputs.warnings }}
@@ -355,31 +241,7 @@ jobs:
           git fetch origin ${{ github.ref_name }}
           git worktree add /tmp/main-wt origin/${{ github.ref_name }}
 
-          python - << 'EOF'
-          import json, os, pathlib, re
-
-          repo    = os.environ["REPO"]
-          owner, reponame = repo.split("/")
-          pages_base = f"https://{owner}.github.io/{reponame}"
-          trend_url  = f"{pages_base}/cstylecheck/"
-          badge_url  = f"https://img.shields.io/endpoint?url={pages_base}/cstylecheck/badge.json"
-          badge_md   = f"[![Naming Convention]({badge_url})]({trend_url})"
-
-          # Operate in the worktree, not in the gh-pages working directory.
-          readme = pathlib.Path("/tmp/main-wt/README.md")
-          if not readme.exists():
-              print("No README.md -- skipping")
-          else:
-              text    = readme.read_text()
-              pattern = r"\[!\[Naming Convention\]\([^)]+\)\]\([^)]+\)"
-              if re.search(pattern, text):
-                  text = re.sub(pattern, badge_md, text, count=1)
-              else:
-                  text = re.sub(r"(^#[^\n]+\n)", rf"\1\n{badge_md}\n",
-                                text, count=1, flags=re.MULTILINE)
-              readme.write_text(text)
-              print(f"README updated: {badge_md}")
-          EOF
+          python scripts/ci/update_readme_badge.py /tmp/main-wt
 
           cd /tmp/main-wt
           git add README.md

--- a/docs/aspice/CStyleCheck_SUP8_CM_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP8_CM_Plan.md
@@ -138,6 +138,9 @@ All items in the following table are placed under configuration control.
 | CI-026 | Project README | `README.md` | Documentation |
 | CI-027 | This CM Plan | `CStyleCheck_SUP8_CM_Plan.md` | Documentation |
 | CI-028 | AI Authorship Deviation Record | `docs/aspice/CStyleCheck_DEV001_AI_Authorship_Deviation.md` | Documentation |
+| CI-029 | CI trend-record append script | `scripts/ci/append_trend_record.py` | CI script |
+| CI-030 | CI trend HTML and badge generation script | `scripts/ci/generate_trend.py` | CI script |
+| CI-031 | CI README badge update script | `scripts/ci/update_readme_badge.py` | CI script |
 
 ### 6.2 Identification Scheme
 

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -88,6 +88,9 @@ This document defines the detailed design of each software unit in **CStyleCheck
 | UNIT-44 | `matches_case_abbrev` | `cstylecheck.py:623` | COMP-05 (shared) |
 | UNIT-45 | `module_name` | `cstylecheck.py:654` | COMP-05 (shared) |
 | UNIT-46 | `main` | `cstylecheck.py:3191` | Entry point |
+| UNIT-47 | `append_trend_record` (script) | `scripts/ci/append_trend_record.py` | CI script |
+| UNIT-48 | `generate_trend` (script) | `scripts/ci/generate_trend.py` | CI script |
+| UNIT-49 | `update_readme_badge` (script) | `scripts/ci/update_readme_badge.py` | CI script |
 
 ---
 

--- a/scripts/ci/append_trend_record.py
+++ b/scripts/ci/append_trend_record.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+scripts/ci/append_trend_record.py
+==================================
+Append a single CI run record to cstylecheck/trend.jsonl.
+
+Called by the "trend" job in cstylecheck_rules.yml:
+    run: python scripts/ci/append_trend_record.py
+
+Environment variables consumed (all set by the calling workflow step):
+    RUN_NUMBER  int   GitHub Actions run number
+    SHA         str   full commit SHA (truncated to 8 chars internally)
+    ERRORS      int   number of naming errors
+    WARNINGS    int   number of naming warnings
+    INFOS       int   number of info-level findings
+    FILES       int   number of files checked
+"""
+
+import datetime
+import json
+import os
+import pathlib
+
+record = {
+    "date":     datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "run":      int(os.environ["RUN_NUMBER"]),
+    "sha":      os.environ["SHA"][:8],
+    "errors":   int(os.environ["ERRORS"]),
+    "warnings": int(os.environ["WARNINGS"]),
+    "infos":    int(os.environ["INFOS"]),
+    "files":    int(os.environ["FILES"]),
+}
+
+trend_file = pathlib.Path("cstylecheck/trend.jsonl")
+with trend_file.open("a") as fh:
+    fh.write(json.dumps(record) + "\n")
+
+print(f"Appended: {record}")

--- a/scripts/ci/generate_trend.py
+++ b/scripts/ci/generate_trend.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+scripts/ci/generate_trend.py
+=============================
+Generate the gh-pages trend HTML dashboard (cstylecheck/index.html) and
+shields.io badge JSON (cstylecheck/badge.json) from trend.jsonl data.
+
+Called by the "trend" job in cstylecheck_rules.yml:
+    run: python scripts/ci/generate_trend.py
+
+Environment variables consumed (all set by the calling workflow step):
+    ERRORS    int   number of naming errors in the latest run
+    WARNINGS  int   number of naming warnings in the latest run
+    INFOS     int   number of info-level findings in the latest run
+    FILES     int   number of files checked in the latest run
+    REPO      str   GitHub repository in "owner/reponame" format
+"""
+
+import json
+import os
+import pathlib
+
+# ---------------------------------------------------------------------------
+# Load trend data
+# ---------------------------------------------------------------------------
+trend_file = pathlib.Path("cstylecheck/trend.jsonl")
+records = [json.loads(line) for line in trend_file.read_text().splitlines() if line.strip()]
+recent = records[-60:]   # keep last 60 data points on the chart
+
+errors   = int(os.environ["ERRORS"])
+warnings = int(os.environ["WARNINGS"])
+infos    = int(os.environ["INFOS"])
+files    = os.environ["FILES"]
+repo     = os.environ["REPO"]
+owner, reponame = repo.split("/")
+pages_base = f"https://{owner}.github.io/{reponame}"
+
+# ---------------------------------------------------------------------------
+# Badge JSON (served by shields.io endpoint)
+# ---------------------------------------------------------------------------
+total   = errors + warnings
+colour  = "brightgreen" if total == 0 else "yellow" if errors == 0 else "red"
+message = "clean" if total == 0 else f"{errors}E {warnings}W"
+badge   = {"schemaVersion": 1, "label": "naming", "message": message, "color": colour}
+pathlib.Path("cstylecheck/badge.json").write_text(json.dumps(badge, indent=2))
+
+# ---------------------------------------------------------------------------
+# Chart data
+# ---------------------------------------------------------------------------
+labels = [r["date"][:10] + " #" + str(r.get("run", "?")) for r in recent]
+e_vals = [r["errors"]   for r in recent]
+w_vals = [r["warnings"] for r in recent]
+i_vals = [r["infos"]    for r in recent]
+
+rows = "".join(
+    f'<tr><td>{r["date"][:10]}</td><td>#{r.get("run","?")}</td>'
+    f'<td><code>{r["sha"]}</code></td><td>{r["files"]}</td>'
+    f'<td style="color:{"red" if r["errors"] else "green"}">{r["errors"]}</td>'
+    f'<td style="color:{"orange" if r["warnings"] else "green"}">{r["warnings"]}</td>'
+    f'<td>{r["infos"]}</td></tr>'
+    for r in reversed(recent)
+)
+
+# ---------------------------------------------------------------------------
+# Trend HTML page
+# ---------------------------------------------------------------------------
+html = f"""<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{reponame} -- Naming Convention Trend</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 960px;
+         margin: 0 auto; padding: 1rem 1.5rem; color: #222; }}
+  h1   {{ font-size: 1.4rem; }}
+  table {{ border-collapse: collapse; width: 100%; font-size: 0.85rem; }}
+  th, td {{ border: 1px solid #ccc; padding: 4px 8px; text-align: right; }}
+  th {{ background: #f5f5f5; text-align: center; }}
+  td:nth-child(1), td:nth-child(2), td:nth-child(3) {{ text-align: left; }}
+  .stat {{ display: inline-block; margin: 0 1rem; font-size: 1.1rem; }}
+  canvas {{ margin: 1.5rem 0; }}
+</style>
+</head><body>
+<h1>📋 {reponame}: Naming Convention Trend</h1>
+<p>
+  <span class="stat">🔴 <strong style="color:{'red' if errors else 'green'}">{errors}</strong> errors</span>
+  <span class="stat">🟡 <strong style="color:{'orange' if warnings else 'green'}">{warnings}</strong> warnings</span>
+  <span class="stat">📁 {files} files</span>
+  <span class="stat">🔢 {len(records)} runs recorded</span>
+</p>
+<canvas id="chart" height="120"></canvas>
+<script>
+new Chart(document.getElementById('chart'), {{
+  type: 'line',
+  data: {{
+    labels: {json.dumps(labels)},
+    datasets: [
+      {{ label: 'Errors',   data: {json.dumps(e_vals)}, fill: true,
+         borderColor: '#d32f2f', backgroundColor: 'rgba(211,47,47,0.15)',
+         tension: 0.3, pointRadius: 3 }},
+      {{ label: 'Warnings', data: {json.dumps(w_vals)}, fill: true,
+         borderColor: '#f57c00', backgroundColor: 'rgba(245,124,0,0.12)',
+         tension: 0.3, pointRadius: 3 }},
+      {{ label: 'Info',     data: {json.dumps(i_vals)}, fill: true,
+         borderColor: '#1976d2', backgroundColor: 'rgba(25,118,210,0.10)',
+         tension: 0.3, pointRadius: 3 }},
+    ]
+  }},
+  options: {{
+    responsive: true,
+    interaction: {{ mode: 'index', intersect: false }},
+    plugins: {{ legend: {{ position: 'top' }},
+               tooltip: {{ mode: 'index' }} }},
+    scales: {{ y: {{ beginAtZero: true, ticks: {{ stepSize: 1 }} }} }}
+  }}
+}});
+</script>
+<h2>Run history (last {len(recent)} runs)</h2>
+<table>
+<tr><th>Date</th><th>Run</th><th>SHA</th><th>Files</th>
+    <th>Errors</th><th>Warnings</th><th>Info</th></tr>
+{rows}
+</table>
+<p><small>Source: <a href="https://github.com/{repo}">{repo}</a></small></p>
+</body></html>"""
+
+pathlib.Path("cstylecheck/index.html").write_text(html)
+print(f"Trend page: {pages_base}/cstylecheck/")
+print(f"Badge URL:  https://img.shields.io/endpoint?url={pages_base}/cstylecheck/badge.json")

--- a/scripts/ci/update_readme_badge.py
+++ b/scripts/ci/update_readme_badge.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+scripts/ci/update_readme_badge.py
+===================================
+Update the Naming Convention badge link in README.md.
+
+Called by the "Update README badge and push to source branch" step in
+cstylecheck_rules.yml (from inside the /tmp/main-wt git worktree):
+
+    python scripts/ci/update_readme_badge.py /tmp/main-wt
+
+Positional argument:
+    worktree_path   Absolute path to the checked-out source-branch worktree
+                    whose README.md should be updated.
+
+Environment variables consumed:
+    REPO    str   GitHub repository in "owner/reponame" format
+"""
+
+import os
+import pathlib
+import re
+import sys
+
+if len(sys.argv) < 2:
+    print("Usage: update_readme_badge.py <worktree_path>", file=sys.stderr)
+    sys.exit(1)
+
+worktree_path = pathlib.Path(sys.argv[1])
+repo          = os.environ["REPO"]
+owner, reponame = repo.split("/")
+pages_base = f"https://{owner}.github.io/{reponame}"
+trend_url  = f"{pages_base}/cstylecheck/"
+badge_url  = f"https://img.shields.io/endpoint?url={pages_base}/cstylecheck/badge.json"
+badge_md   = f"[![Naming Convention]({badge_url})]({trend_url})"
+
+readme = worktree_path / "README.md"
+if not readme.exists():
+    print("No README.md -- skipping")
+    sys.exit(0)
+
+text    = readme.read_text()
+pattern = r"\[!\[Naming Convention\]\([^)]+\)\]\([^)]+\)"
+if re.search(pattern, text):
+    text = re.sub(pattern, badge_md, text, count=1)
+else:
+    text = re.sub(r"(^#[^\n]+\n)", rf"\1\n{badge_md}\n",
+                  text, count=1, flags=re.MULTILINE)
+readme.write_text(text)
+print(f"README updated: {badge_md}")


### PR DESCRIPTION
﻿## Summary

- Extracted three long inline Python blocks from `cstylecheck_rules.yml` into standalone scripts:
  - `scripts/ci/append_trend_record.py` — appends a JSONL run record to `cstylecheck/trend.jsonl`
  - `scripts/ci/generate_trend.py` — generates `cstylecheck/index.html` and `cstylecheck/badge.json`
  - `scripts/ci/update_readme_badge.py` — updates the Naming Convention badge in `README.md`
- Updated `cstylecheck_rules.yml` to call scripts via `run: python scripts/ci/<script>.py` with the same env vars; added `git checkout ${{ github.sha }} -- scripts/` to the gh-pages checkout step
- Added `UNIT-47`, `UNIT-48`, `UNIT-49` to `CSC-SWE3-001` unit catalogue
- Added `CI-029`, `CI-030`, `CI-031` to `CSC-SUP8-001` CI configuration item list

Scripts are now independently testable, syntax-highlighted, and tracked under CM.

## Test plan

- [ ] `scripts/ci/append_trend_record.py` runs cleanly with required env vars
- [ ] `scripts/ci/generate_trend.py` produces valid HTML and badge JSON
- [ ] `scripts/ci/update_readme_badge.py` accepts a worktree path argument and updates README.md
- [ ] CI `CStyleCheck` workflow (trend job) passes on next push to main/master
- [ ] `CSC-SWE3-001` unit catalogue includes UNIT-47/48/49
- [ ] `CSC-SUP8-001` CI list includes CI-029/030/031

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
