### PR TITLE
feat(rules): add misc.comment_ratio rule — configurable comment density gate (closes #68)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -1129,6 +1129,7 @@ class Checker:
         if self._is_header:
             self._check_include_guard()
         self._check_misc()
+        self._check_comment_ratio()
         self._check_yoda()
         self._check_reserved_names()
         self._check_lowercase_l_suffix()   # MISRA C:2012/2023 Rule 7.3
@@ -2366,7 +2367,145 @@ class Checker:
                         f"line; found {n_after}"))
 
     # -----------------------------------------------------------------------
-    # 14. Comment spell-check
+    # 14. Comment ratio (misc.comment_ratio)
+    # -----------------------------------------------------------------------
+
+    def _check_comment_ratio(self) -> None:
+        """Enforce a minimum ratio of comment lines to code lines (issue #68).
+
+        Excluded from both counts:
+          - Blank lines
+          - The file header: all leading comment/blank lines before the first
+            non-comment, non-blank line (copyright notices, licence blocks)
+          - Doxygen blocks: /** … */ are documentation, not explanatory comments
+
+        Counted as comment lines:
+          - // line comments
+          - /* … */ regular block comments (not Doxygen)
+
+        Counted as code lines:
+          - Every non-blank, non-comment line (code, preprocessor, etc.)
+          - A line with a trailing // comment counts as a CODE line
+        """
+        misc   = self.cfg.get("misc", {})
+        cr_cfg = misc.get("comment_ratio", {})
+        if not cr_cfg.get("enabled", False):
+            return
+
+        sev      = cr_cfg.get("severity", "warning")
+        warn_thr = float(cr_cfg.get("warning_threshold", 0.15))
+        err_thr  = float(cr_cfg.get("error_threshold",  0.05))
+        min_code = int(cr_cfg.get("min_code_lines", 10))
+
+        lines = self.source.splitlines()
+
+        # ----------------------------------------------------------------
+        # Phase 1: locate the end of the file header.
+        # The header region = all leading comment/blank lines before the
+        # first non-comment, non-blank line.
+        # ----------------------------------------------------------------
+        header_end_idx = 0
+        in_hdr_block   = False
+        found_code     = False
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if not stripped:                      # blank
+                continue
+            if in_hdr_block:
+                if "*/" in line:
+                    in_hdr_block = False
+                continue
+            if stripped.startswith("/*"):
+                if "*/" not in stripped[2:]:      # multi-line block comment
+                    in_hdr_block = True
+                continue                           # still in header
+            if stripped.startswith("//"):
+                continue                           # line comment — still header
+            # First actual code line: header ends here
+            header_end_idx = i
+            found_code     = True
+            break
+
+        if not found_code:
+            return   # entire file is comments/blank — nothing to measure
+
+        # ----------------------------------------------------------------
+        # Phase 2: classify lines from header_end_idx onwards.
+        # ----------------------------------------------------------------
+        comment_lines = 0
+        code_lines    = 0
+        in_doxygen    = False
+        in_block_cmt  = False
+
+        for i, line in enumerate(lines):
+            if i < header_end_idx:
+                continue
+
+            stripped = line.strip()
+            if not stripped:
+                continue   # blank — excluded
+
+            if in_doxygen:
+                if "*/" in line:
+                    in_doxygen = False
+                continue   # doxygen continuation — excluded
+
+            if in_block_cmt:
+                comment_lines += 1
+                if "*/" in line:
+                    in_block_cmt = False
+                continue
+
+            # Opening of a Doxygen block ( /** … )
+            if stripped.startswith("/**"):
+                if "*/" not in stripped[3:]:
+                    in_doxygen = True
+                # Doxygen opener line itself is excluded
+                continue
+
+            # Opening of a regular block comment ( /* … )
+            if stripped.startswith("/*"):
+                comment_lines += 1
+                if "*/" not in stripped[2:]:
+                    in_block_cmt = True
+                continue
+
+            # Line comment
+            if stripped.startswith("//"):
+                comment_lines += 1
+                continue
+
+            # Non-blank, non-comment line (code, preprocessor, …)
+            code_lines += 1
+
+        # Guard: skip files with too few code lines (trivial files, stubs, etc.)
+        if code_lines < min_code:
+            return
+
+        ratio = comment_lines / code_lines
+
+        if ratio < err_thr:
+            emit_sev        = "error"
+            threshold       = err_thr
+            threshold_label = "error"
+        elif ratio < warn_thr:
+            emit_sev        = sev
+            threshold       = warn_thr
+            threshold_label = "warning"
+        else:
+            return   # ratio meets the warning threshold — all good
+
+        pl = lambda n: "s" if n != 1 else ""  # noqa: E731
+        self.result.add(Violation(
+            self.filepath, 1, 1, emit_sev, "misc.comment_ratio",
+            f"comment ratio {ratio:.2f} is below {threshold_label} threshold "
+            f"{threshold} "
+            f"({comment_lines} comment line{pl(comment_lines)} / "
+            f"{code_lines} code line{pl(code_lines)})"
+        ))
+
+    # -----------------------------------------------------------------------
+    # 15. Comment spell-check
     # -----------------------------------------------------------------------
 
     def _check_spelling(self) -> None:

--- a/src/rules.yml
+++ b/src/rules.yml
@@ -512,6 +512,38 @@ misc:
     enabled: true
     severity: error   # MISRA C:2023 promotes this to Required
 
+  # -----------------------------------------------------------------------
+  # Comment-to-code ratio (issue #68)
+  # -----------------------------------------------------------------------
+  # Measures the ratio of explanatory comment lines to code lines within
+  # each scanned file.  Violations are raised when the ratio falls below
+  # the configured thresholds.
+  #
+  # Excluded from both counts:
+  #   - Blank lines
+  #   - The file header: all leading comment/blank lines before the first
+  #     non-comment, non-blank line (copyright notices, licence blocks)
+  #   - Doxygen blocks: /** … */ are documentation, not explanatory comments
+  #
+  # Counted as comment lines:
+  #   // line comments and /* … */ regular block comment lines
+  #
+  # Counted as code lines:
+  #   Every non-blank, non-comment line (code, preprocessor, etc.)
+  #   A line with a trailing // comment still counts as a code line
+  #
+  # Example violation messages:
+  #   uart.c:1: warning [misc.comment_ratio] comment ratio 0.08 is below
+  #             warning threshold 0.15 (8 comment lines / 96 code lines)
+  #   spi.c:1:  error   [misc.comment_ratio] comment ratio 0.02 is below
+  #             error threshold 0.05 (1 comment line / 48 code lines)
+  comment_ratio:
+    enabled: false          # opt-in; disabled by default
+    severity: warning       # severity for below-warning-threshold violations
+    warning_threshold: 0.15 # ratio below which a WARNING is raised  (15%)
+    error_threshold: 0.05   # ratio below which an ERROR is raised    (5%)
+    min_code_lines: 10      # skip files with fewer code lines (avoids trivial-file false positives)
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -58,6 +58,9 @@ _ALL_OFF: dict = {
         "lowercase_l_suffix":    {"enabled": False},
         "octal_constant":        {"enabled": False},
         "trigraph":              {"enabled": False},
+        # Comment ratio check (issue #68) -- disabled so existing tests
+        # are not affected by the new per-file comment density check.
+        "comment_ratio":         {"enabled": False},
     },
     "reserved_names":    {"enabled": False},
     "sign_compatibility":{"enabled": False},

--- a/tests/rules.yml
+++ b/tests/rules.yml
@@ -39,7 +39,7 @@ variables:
   # NOTE: intentionally set to false in tests/ copy -- TestAllowLoopVarsShort
   # in test_misc_improvements.py verifies default-is-false behaviour.
   # src/ canonical copy sets this to true (project default).
-  allow_loop_vars_short: false
+  allow_loop_vars_short: false  # TEST FIXTURE: must stay false (default-is-false test)
 
   # Uppercase abbreviations that are allowed anywhere in an otherwise
   # lower_snake name.  Add any project-standard abbreviations here.
@@ -513,12 +513,37 @@ misc:
     severity: error   # MISRA C:2023 promotes this to Required
 
   # TEST FIXTURE: comment_ratio disabled (intentionally matches src/rules.yml)
+  # -----------------------------------------------------------------------
+  # Comment-to-code ratio (issue #68)
+  # -----------------------------------------------------------------------
+  # Measures the ratio of explanatory comment lines to code lines within
+  # each scanned file.  Violations are raised when the ratio falls below
+  # the configured thresholds.
+  #
+  # Excluded from both counts:
+  #   - Blank lines
+  #   - The file header: all leading comment/blank lines before the first
+  #     non-comment, non-blank line (copyright notices, licence blocks)
+  #   - Doxygen blocks: /** … */ are documentation, not explanatory comments
+  #
+  # Counted as comment lines:
+  #   // line comments and /* … */ regular block comment lines
+  #
+  # Counted as code lines:
+  #   Every non-blank, non-comment line (code, preprocessor, etc.)
+  #   A line with a trailing // comment still counts as a code line
+  #
+  # Example violation messages:
+  #   uart.c:1: warning [misc.comment_ratio] comment ratio 0.08 is below
+  #             warning threshold 0.15 (8 comment lines / 96 code lines)
+  #   spi.c:1:  error   [misc.comment_ratio] comment ratio 0.02 is below
+  #             error threshold 0.05 (1 comment line / 48 code lines)
   comment_ratio:
-    enabled: false
-    severity: warning
-    warning_threshold: 0.15
-    error_threshold: 0.05
-    min_code_lines: 10
+    enabled: false          # opt-in; disabled by default
+    severity: warning       # severity for below-warning-threshold violations
+    warning_threshold: 0.15 # ratio below which a WARNING is raised  (15%)
+    error_threshold: 0.05   # ratio below which an ERROR is raised    (5%)
+    min_code_lines: 10      # skip files with fewer code lines (avoids trivial-file false positives)
 
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name

--- a/tests/rules.yml
+++ b/tests/rules.yml
@@ -512,6 +512,14 @@ misc:
     enabled: true
     severity: error   # MISRA C:2023 promotes this to Required
 
+  # TEST FIXTURE: comment_ratio disabled (intentionally matches src/rules.yml)
+  comment_ratio:
+    enabled: false
+    severity: warning
+    warning_threshold: 0.15
+    error_threshold: 0.05
+    min_code_lines: 10
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.

--- a/tests/test_comment_ratio.py
+++ b/tests/test_comment_ratio.py
@@ -1,0 +1,255 @@
+"""test_comment_ratio.py — tests for misc.comment_ratio rule (issue #68).
+
+The rule measures the ratio of explanatory comment lines to code lines.
+
+Exclusion rules:
+  - Blank lines are excluded from both counts.
+  - File header (all leading comment/blank lines before the first code line)
+    is excluded — copyright notices must not artificially inflate the ratio.
+  - Doxygen blocks (/** … */) are excluded — they are documentation, not
+    explanatory inline comments.
+"""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, run
+
+RULE = "misc.comment_ratio"
+
+
+def _cfg(enabled=True, warning_threshold=0.15, error_threshold=0.05,
+         min_code_lines=5, severity="warning"):
+    return cfg_only(misc={
+        "comment_ratio": {
+            "enabled": enabled,
+            "severity": severity,
+            "warning_threshold": warning_threshold,
+            "error_threshold": error_threshold,
+            "min_code_lines": min_code_lines,
+        }
+    })
+
+
+CFG = _cfg()   # default config: warning>=0.15, error>=0.05, min_code=5
+
+
+def _code(n, start=0):
+    """Return n code lines (simple function calls)."""
+    return "".join(f"func_{i}();\n" for i in range(start, start + n))
+
+
+def _comment(n, start=0):
+    """Return n inline // comment lines."""
+    return "".join(f"// explanation {i}\n" for i in range(start, start + n))
+
+
+def _mixed(code_n, comment_n):
+    """One code line first (ends header), then comment lines, then more code."""
+    return _code(1) + _comment(comment_n) + _code(code_n - 1, start=1)
+
+
+# ---------------------------------------------------------------------------
+# Basic pass/fail
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioBasic(unittest.TestCase):
+
+    def test_disabled_produces_no_violation(self):
+        src = _code(10)
+        self.assertFalse(has(src, _cfg(enabled=False), RULE))
+
+    def test_zero_comments_raises_violation(self):
+        # 0 comment / 10 code = 0.00 < 0.15
+        src = _code(10)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_sufficient_comments_passes(self):
+        # 2 comment / 10 code = 0.20 >= 0.15
+        src = _mixed(10, 2)
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_exactly_at_warning_threshold_passes(self):
+        # 15 comment / 100 code = 0.15 (exactly at threshold — not below)
+        src = _mixed(100, 15)
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_one_below_warning_threshold_fails(self):
+        # 14 comment / 100 code = 0.14 < 0.15
+        src = _mixed(100, 14)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_single_violation_emitted(self):
+        # Only one violation per file regardless of how far below threshold
+        src = _code(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertEqual(len(viols), 1)
+
+
+# ---------------------------------------------------------------------------
+# Severity levels
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioSeverity(unittest.TestCase):
+
+    def test_below_error_threshold_emits_error(self):
+        # 0 comment / 10 code = 0.00 < 0.05 (error threshold)
+        src = _code(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "error")
+
+    def test_between_thresholds_emits_configured_severity(self):
+        # 1 comment / 10 code = 0.10 — between 0.05 (error) and 0.15 (warning)
+        src = _mixed(10, 1)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "warning")
+
+    def test_custom_severity_used(self):
+        src = _mixed(10, 1)   # between thresholds → uses severity setting
+        cfg = _cfg(severity="info")
+        viols = [v for v in run(src, cfg) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "info")
+
+
+# ---------------------------------------------------------------------------
+# min_code_lines guard
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioMinCodeLines(unittest.TestCase):
+
+    def test_fewer_than_min_code_lines_skipped(self):
+        # 0 comment / 4 code = 0.00 but min_code_lines=5 → no violation
+        src = _code(4)
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_exactly_min_code_lines_is_checked(self):
+        # 0 comment / 5 code = 0.00 < 0.15 → violation
+        src = _code(5)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_custom_min_code_lines(self):
+        src = _code(3)
+        cfg = _cfg(min_code_lines=3)
+        self.assertTrue(has(src, cfg, RULE))   # exactly 3 code lines — checked
+
+
+# ---------------------------------------------------------------------------
+# File header exclusion
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioHeaderExclusion(unittest.TestCase):
+
+    def test_block_header_not_counted_as_comments(self):
+        # A large copyright block should NOT make the body look well-commented.
+        big_header = "/*\n" + " * copyright line\n" * 50 + " */\n"
+        body = _code(10)   # 0 inline comments
+        src = big_header + body
+        # Header excluded → 0 comment / 10 code → violation
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_inline_comments_in_body_counted_after_header(self):
+        header = "/* Copyright 2026 ACME. All rights reserved. */\n"
+        body   = _mixed(10, 2)   # 2 inline comments in body
+        src    = header + body
+        # Header excluded; body has 2/10 = 0.20 >= 0.15 → no violation
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_line_comment_header_not_counted(self):
+        # // comments at the top (before first code line) are also header
+        line_header = "// File: uart_driver.c\n// Author: ACME\n"
+        body = _code(10)
+        src  = line_header + body
+        # Header excluded → 0 / 10 → violation
+        self.assertTrue(has(src, CFG, RULE))
+
+
+# ---------------------------------------------------------------------------
+# Doxygen exclusion
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioDoxygenExclusion(unittest.TestCase):
+
+    def test_doxygen_block_not_counted_as_comment(self):
+        # Functions with Doxygen headers but no inline comments
+        dox = "/**\n * @brief Do something.\n * @param x Value.\n * @return none.\n */\n"
+        code = "void mod_DoSomething(int x) {\n    x = x + 1U;\n}\n"
+        # 5 doxygen-only functions: 0 regular comments / 10 code lines → violation
+        src = (dox + code) * 5
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_doxygen_single_line_not_counted(self):
+        # One-liner Doxygen: /** @brief foo */
+        src = "/** @brief one-liner */\n" + _code(10)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_doxygen_then_regular_comment_counted(self):
+        # Doxygen opener followed by a regular // comment on the next function
+        dox  = "/**\n * @brief Init.\n */\n"
+        code = _code(1)
+        cmt  = "// important safety note\n"
+        # 1 dox block (excluded) + 1 code + 1 comment + 9 more code = 1/10
+        src  = dox + code + cmt + _code(9, start=1)
+        # 1 comment / 10 code = 0.10 — between error and warning thresholds
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "warning")
+
+
+# ---------------------------------------------------------------------------
+# Block comment counting
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioBlockComments(unittest.TestCase):
+
+    def test_multiline_block_comment_each_line_counted(self):
+        # A 3-line regular block comment: /*, middle, */
+        block = "/*\n * This is why.\n */\n"
+        src   = _code(1) + block + _code(9, start=1)
+        # 3 block comment lines / 10 code = 0.30 >= 0.15 → no violation
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_single_line_block_comment_counted(self):
+        src = _code(1) + "/* inline note */\n" + _code(9, start=1)
+        # 1 comment / 10 code = 0.10 — between thresholds
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "warning")
+
+    def test_code_line_with_trailing_comment_counts_as_code(self):
+        # "func(); // trailing comment" is a CODE line, not a comment line
+        src = "func_0(); // why we call this\n" + _code(9, start=1)
+        # 0 pure comment lines / 10 code → violation (trailing comment = code)
+        self.assertTrue(has(src, CFG, RULE))
+
+
+# ---------------------------------------------------------------------------
+# Violation message content
+# ---------------------------------------------------------------------------
+
+class TestCommentRatioMessage(unittest.TestCase):
+
+    def test_message_contains_ratio_and_counts(self):
+        src = _code(10)   # 0 comments / 10 code
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        msg = viols[0].message
+        self.assertIn("0.00", msg)
+        self.assertIn("0 comment", msg)
+        self.assertIn("10 code", msg)
+
+    def test_message_mentions_threshold(self):
+        src = _mixed(10, 1)   # 1/10 = 0.10 — between thresholds
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertIn("0.15", viols[0].message)   # warning threshold
+
+    def test_violation_reported_at_line_1(self):
+        src = _code(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].line, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Implements the `misc.comment_ratio` rule specified in issue #68. Measures the ratio of explanatory comment lines to code lines in each scanned file and emits a violation when the ratio falls below configured thresholds.

### How it works

**Excluded from both counts:**
- Blank lines
- File header — all leading comment/blank lines before the first code line (copyright/licence notices must not inflate the ratio)
- Doxygen blocks (`/** … */`) — documentation, not explanatory comments

**Counted as comment lines:** `//` line comments and `/* … */` regular block comment lines

**Counted as code lines:** every non-blank, non-comment line; a line with a trailing `//` comment counts as code

### Configuration (disabled by default)
```yaml
misc:
  comment_ratio:
    enabled: false          # opt-in
    severity: warning
    warning_threshold: 0.15 # 15% — WARNING below this ratio
    error_threshold:   0.05 #  5% — ERROR below this ratio
    min_code_lines:    10   # skip files with fewer code lines
```

### Violation messages
```
uart.c:1: warning [misc.comment_ratio] comment ratio 0.08 is below warning threshold 0.15 (8 comment lines / 96 code lines)
spi.c:1:  error   [misc.comment_ratio] comment ratio 0.02 is below error threshold 0.05 (1 comment line / 48 code lines)
```

### Acceptance criteria (from issue #68)
- [x] Rule is disabled by default (opt-in via `rules.yml`)
- [x] Copyright / licence header block (before first code line) excluded from both counts
- [x] Doxygen function and file comment blocks (`/** … */`) excluded
- [x] `warning_threshold` and `error_threshold` independently configurable
- [x] `min_code_lines` guard prevents false positives on tiny header files
- [x] `--github-actions` flag emits correctly-titled annotations (inherited from `Violation.github_annotation()`)
- [x] 24 unit tests covering all acceptance criteria

## Files changed
- `src/cstylecheck.py` — `Checker._check_comment_ratio()` + call in `run_all()`
- `src/rules.yml` — `misc.comment_ratio` section
- `tests/rules.yml` — mirrored addition (YAML-004 sync)
- `tests/harness.py` — `comment_ratio` added to `_ALL_OFF`
- `tests/test_comment_ratio.py` — 24 tests (new file)

## Test plan
- [x] 24 new tests pass locally
- [x] 740 existing tests continue to pass
- [ ] CI passes on this PR

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)