### PR TITLE
feat: add misc.declared_not_defined cross-file rule (issue #114)

### DIFF
--- a/src/cstylecheck.py
+++ b/src/cstylecheck.py
@@ -3002,6 +3002,202 @@ class SignChecker:
 
 
 # ---------------------------------------------------------------------------
+# DeclaredNotDefinedChecker (cross-file declared-but-not-defined check)
+# ---------------------------------------------------------------------------
+
+class DeclaredNotDefinedChecker:
+    """
+    Cross-file declared-but-not-defined checker (misc.declared_not_defined).
+
+    Identifies C objects that are declared (via 'extern' or a forward typedef)
+    but for which no matching definition can be found across all files in a
+    single checker invocation.
+
+    Single-file runs always emit no violations — the definition may exist in
+    an unscanned translation unit (e.g. a BSP provided at link time).
+
+    Usage:
+        dndc = DeclaredNotDefinedChecker(cfg)
+        for filepath, source in all_files:
+            dndc.ingest(filepath, source)
+        violations = dndc.check()
+    """
+
+    # extern <type> <name> ;  — variable/constant declaration (no parens → not a function)
+    _RE_EXTERN_VAR = re.compile(
+        r"(?:^|\n)[ \t]*extern[ \t]+"
+        r"(?:(?:const|volatile|unsigned|signed|long|short"
+        r"|struct|enum|union)[ \t]+)*"
+        r"[A-Za-z_]\w*(?:[ \t]*\*+)?[ \t]*"
+        r"([A-Za-z_]\w*)"               # variable name — group 1
+        r"(?![ \t]*\()"                  # NOT followed by ( → not a function
+        r"[ \t]*(?:\[[^\]]*\][ \t]*)*"  # optional array brackets
+        r"[ \t]*;",
+        re.MULTILINE,
+    )
+
+    # typedef struct Tag Tag;  — forward struct typedef (no body brace between names)
+    _RE_FWD_STRUCT = re.compile(
+        r"(?:^|\n)[ \t]*typedef[ \t]+struct[ \t]+"
+        r"([A-Za-z_]\w*)[ \t]+"         # struct tag name — group 1
+        r"([A-Za-z_]\w*)[ \t]*;",       # alias name — group 2
+        re.MULTILINE,
+    )
+
+    # typedef enum Tag Tag;  — forward enum typedef (no body brace between names)
+    _RE_FWD_ENUM = re.compile(
+        r"(?:^|\n)[ \t]*typedef[ \t]+enum[ \t]+"
+        r"([A-Za-z_]\w*)[ \t]+"         # enum tag name — group 1
+        r"([A-Za-z_]\w*)[ \t]*;",       # alias name — group 2
+        re.MULTILINE,
+    )
+
+    # Non-extern, non-static file-scope variable definition (any identifier casing).
+    # Ends with = ; or [ so function definitions (ending with {) are excluded.
+    _RE_VAR_DEF = re.compile(
+        r"(?:^|\n)[ \t]*"
+        r"(?!(?:extern|static|typedef|if|else|while|for|do|switch|return"
+        r"|break|continue|goto|sizeof|case|assert)\b)"
+        r"(?:(?:volatile|const|unsigned|signed|long|short"
+        r"|struct|enum|union)[ \t]+)*"
+        r"(?:(?:long[ \t]+long|long|short)[ \t]+)?"
+        r"[A-Za-z_]\w*(?:[ \t]*\*+)?[ \t]*"
+        r"([A-Za-z_]\w*)"               # defined name — group 1
+        r"(?![ \t]*\()"                  # NOT a function definition
+        r"[ \t]*(?:=|;|\[)",
+        re.MULTILINE,
+    )
+
+    def __init__(self, cfg: dict):
+        self._cfg:         dict = cfg
+        self._decls:       list = []   # (filepath, line, col, name, kind)
+        self._func_defs:   set  = set()
+        self._var_defs:    set  = set()
+        self._struct_defs: set  = set()
+        self._enum_defs:   set  = set()
+        self._file_count:  int  = 0
+
+    def ingest(self, filepath: str, source: str) -> None:
+        """Scan one file for declarations and definitions."""
+        self._file_count += 1
+        clean        = preprocess(source)
+        line_map     = build_line_map(clean)
+        brace_depths = _build_brace_depths(clean)
+        src_lines    = source.splitlines()
+
+        def _suppressed(lineno: int) -> bool:
+            raw = src_lines[lineno - 1] if 0 < lineno <= len(src_lines) else ""
+            return "cstylecheck: disable misc.declared_not_defined" in raw
+
+        # --- Collect definitions (satisfy declarations) ---
+
+        for m in RE_FUNCTION_DEF.finditer(clean):
+            self._func_defs.add(m.group(1))
+
+        for m in RE_TYPEDEF_STRUCT.finditer(clean):
+            name = m.group(3)
+            if name:
+                self._struct_defs.add(name)
+
+        for m in RE_TYPEDEF_ENUM.finditer(clean):
+            name = m.group(2)
+            if name:
+                self._enum_defs.add(name)
+
+        # File-scope non-extern/non-static variable definitions (brace depth 0)
+        for m in self._RE_VAR_DEF.finditer(clean):
+            pos = m.start()
+            if pos < len(brace_depths) and brace_depths[pos] == 0:
+                self._var_defs.add(m.group(1))
+
+        # RE_VAR_DECL captures lowercase names; also add them for completeness.
+        for m in RE_VAR_DECL.finditer(clean):
+            if "extern" not in m.group(1) and "static" not in m.group(1):
+                pos = m.start()
+                if pos < len(brace_depths) and brace_depths[pos] == 0:
+                    self._var_defs.add(m.group(4))
+
+        # --- Collect declarations (to be satisfied by definitions) ---
+
+        # Extern function declarations
+        for m in RE_FUNCTION_DECL.finditer(clean):
+            if not re.search(r"\bextern\b", m.group(0)):
+                continue
+            pos = m.start()
+            if pos < len(brace_depths) and brace_depths[pos] != 0:
+                continue   # inside a nested scope — skip
+            fname  = m.group(1)
+            line, col = offset_to_line_col(line_map, m.start(1))
+            if _suppressed(line):
+                continue
+            self._decls.append((filepath, line, col, fname, "function"))
+
+        # Extern variable declarations
+        for m in self._RE_EXTERN_VAR.finditer(clean):
+            pos = m.start()
+            if pos < len(brace_depths) and brace_depths[pos] != 0:
+                continue
+            vname  = m.group(1)
+            line, col = offset_to_line_col(line_map, m.start(1))
+            if _suppressed(line):
+                continue
+            self._decls.append((filepath, line, col, vname, "variable"))
+
+        # Forward typedef struct declarations
+        for m in self._RE_FWD_STRUCT.finditer(clean):
+            pos = m.start()
+            if pos < len(brace_depths) and brace_depths[pos] != 0:
+                continue
+            tname  = m.group(2)   # the typedef alias name
+            line, col = offset_to_line_col(line_map, m.start(2))
+            if _suppressed(line):
+                continue
+            self._decls.append((filepath, line, col, tname, "typedef_struct"))
+
+        # Forward typedef enum declarations
+        for m in self._RE_FWD_ENUM.finditer(clean):
+            pos = m.start()
+            if pos < len(brace_depths) and brace_depths[pos] != 0:
+                continue
+            tname  = m.group(2)   # the typedef alias name
+            line, col = offset_to_line_col(line_map, m.start(2))
+            if _suppressed(line):
+                continue
+            self._decls.append((filepath, line, col, tname, "typedef_enum"))
+
+    def check(self) -> list:
+        """Return violations for all declared-but-not-defined objects."""
+        cfg = self._cfg.get("misc", {}).get("declared_not_defined", {})
+        if not cfg.get("enabled", False):
+            return []
+        if self._file_count < 2:
+            # Single-file run: definition may exist in an unscanned TU
+            return []
+        sev        = cfg.get("severity", "warning")
+        seen:       set  = set()
+        violations: list = []
+        for filepath, line, col, name, kind in self._decls:
+            if name in seen:
+                continue
+            seen.add(name)
+            if kind == "function":
+                defined = name in self._func_defs
+            elif kind == "variable":
+                defined = name in self._var_defs
+            elif kind == "typedef_struct":
+                defined = name in self._struct_defs
+            else:   # typedef_enum
+                defined = name in self._enum_defs
+            if not defined:
+                violations.append(Violation(
+                    filepath, line, col, sev,
+                    "misc.declared_not_defined",
+                    f"'{name}' is declared but no definition found in scanned files",
+                ))
+        return violations
+
+
+# ---------------------------------------------------------------------------
 # Module-prefix stripping helper (used in variable checks)
 # ---------------------------------------------------------------------------
 
@@ -3660,6 +3856,23 @@ def main() -> int:
         all_violations.extend(sign_violations)
         if output_format == "text":
             for v in sorted(sign_violations, key=lambda x: (x.filepath, x.line, x.col)):
+                if args.github_actions:
+                    tee.print(v.github_annotation())
+                else:
+                    tee.print(v)
+
+    # Cross-file declared-but-not-defined check (needs all files ingested first).
+    dnd_cfg = cfg.get("misc", {}).get("declared_not_defined", {})
+    if dnd_cfg.get("enabled", False):
+        dndc = DeclaredNotDefinedChecker(cfg)
+        for filepath in files:
+            src = source_cache.get(filepath)
+            if src is not None:
+                dndc.ingest(filepath, src)
+        dnd_violations = dndc.check()
+        all_violations.extend(dnd_violations)
+        if output_format == "text":
+            for v in sorted(dnd_violations, key=lambda x: (x.filepath, x.line, x.col)):
                 if args.github_actions:
                     tee.print(v.github_annotation())
                 else:

--- a/src/rules.yml
+++ b/src/rules.yml
@@ -512,6 +512,32 @@ misc:
     enabled: true
     severity: error   # MISRA C:2023 promotes this to Required
 
+  # -----------------------------------------------------------------------
+  # Declared but not defined (issue #114)
+  # -----------------------------------------------------------------------
+  # Cross-file check: identifies C objects that are declared (via 'extern'
+  # or a forward typedef) but for which no matching definition is found in
+  # any of the files passed in the same checker invocation.
+  #
+  # Covers:
+  #   - extern function declarations  →  function body definition
+  #   - extern variable declarations  →  file-scope variable definition
+  #   - typedef struct Tag Tag;       →  full typedef struct { … } Tag;
+  #   - typedef enum  Tag Tag;        →  full typedef enum  { … } Tag;
+  #
+  # Single-file invocations always produce no violations (the definition
+  # may exist in an unscanned translation unit such as a BSP library).
+  #
+  # Symbols intentionally left undefined (e.g. platform HAL stubs) can be
+  # suppressed with an inline comment on the declaration line:
+  #   extern void HAL_UART_Init(void);  /* cstylecheck: disable misc.declared_not_defined */
+  #
+  # Default severity is 'warning' (not 'error') because the definition may
+  # reside in unscanned BSP or COTS files not included in the checker run.
+  declared_not_defined:
+    enabled: false    # opt-in; disabled by default
+    severity: warning
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -30,6 +30,7 @@ _build_spell_dict       = _mod._build_spell_dict
 _BUILTIN_DICT           = _mod._BUILTIN_DICT
 _load_dict_file         = _mod._load_dict_file
 SignChecker             = _mod.SignChecker
+DeclaredNotDefinedChecker = _mod.DeclaredNotDefinedChecker
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,7 @@ _ALL_OFF: dict = {
         "lowercase_l_suffix":    {"enabled": False},
         "octal_constant":        {"enabled": False},
         "trigraph":              {"enabled": False},
+        "declared_not_defined":  {"enabled": False},
     },
     "reserved_names":    {"enabled": False},
     "sign_compatibility":{"enabled": False},

--- a/tests/rules.yml
+++ b/tests/rules.yml
@@ -512,6 +512,32 @@ misc:
     enabled: true
     severity: error   # MISRA C:2023 promotes this to Required
 
+  # -----------------------------------------------------------------------
+  # Declared but not defined (issue #114)
+  # -----------------------------------------------------------------------
+  # Cross-file check: identifies C objects that are declared (via 'extern'
+  # or a forward typedef) but for which no matching definition is found in
+  # any of the files passed in the same checker invocation.
+  #
+  # Covers:
+  #   - extern function declarations  →  function body definition
+  #   - extern variable declarations  →  file-scope variable definition
+  #   - typedef struct Tag Tag;       →  full typedef struct { … } Tag;
+  #   - typedef enum  Tag Tag;        →  full typedef enum  { … } Tag;
+  #
+  # Single-file invocations always produce no violations (the definition
+  # may exist in an unscanned translation unit such as a BSP library).
+  #
+  # Symbols intentionally left undefined (e.g. platform HAL stubs) can be
+  # suppressed with an inline comment on the declaration line:
+  #   extern void HAL_UART_Init(void);  /* cstylecheck: disable misc.declared_not_defined */
+  #
+  # Default severity is 'warning' (not 'error') because the definition may
+  # reside in unscanned BSP or COTS files not included in the checker run.
+  declared_not_defined:
+    enabled: false    # opt-in; disabled by default
+    severity: warning
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.

--- a/tests/test_declared_not_defined.py
+++ b/tests/test_declared_not_defined.py
@@ -1,0 +1,357 @@
+"""
+tests/test_declared_not_defined.py
+===================================
+Tests for the misc.declared_not_defined cross-file rule (issue #114).
+
+The rule detects C objects that are declared (via 'extern' or a forward
+typedef) but for which no matching definition is found across all files
+in a single checker invocation.
+
+Key behaviours tested:
+  - Disabled by default (opt-in)
+  - Single-file run → no violations
+  - extern function: satisfied vs unsatisfied
+  - extern variable: satisfied vs unsatisfied
+  - forward typedef struct/enum: satisfied vs unsatisfied
+  - inline suppression comment
+  - no false positive for static functions
+  - custom severity
+"""
+
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import DeclaredNotDefinedChecker
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _cfg(enabled=True, severity="warning"):
+    return {"misc": {"declared_not_defined": {"enabled": enabled,
+                                               "severity": severity}}}
+
+
+def _check(files, enabled=True, severity="warning"):
+    """Ingest all (filepath, source) pairs and return violation list."""
+    dndc = DeclaredNotDefinedChecker(_cfg(enabled=enabled, severity=severity))
+    for fp, src in files:
+        dndc.ingest(fp, src)
+    return dndc.check()
+
+
+def _rules(files, **kw):
+    return [v.rule for v in _check(files, **kw)]
+
+
+def _msgs(files, **kw):
+    return [v.message for v in _check(files, **kw)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic enable/disable and single-file guard
+# ---------------------------------------------------------------------------
+
+class TestDndBasic(unittest.TestCase):
+
+    def test_disabled_no_violations(self):
+        """Rule disabled → no violations even if declarations are unsatisfied."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertEqual(_check(files, enabled=False), [])
+
+    def test_single_file_no_violations(self):
+        """Single-file run → no violations (definition may be in unscanned TU)."""
+        files = [("uart.h", "extern void UART_Init(void);\n")]
+        self.assertEqual(_check(files), [])
+
+    def test_two_files_triggers_check(self):
+        """Two-file run with unsatisfied extern → one violation."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertIn("misc.declared_not_defined", _rules(files))
+
+
+# ---------------------------------------------------------------------------
+# 2. Extern function declarations
+# ---------------------------------------------------------------------------
+
+class TestDndExternFunction(unittest.TestCase):
+
+    def test_extern_func_satisfied(self):
+        """extern function declaration satisfied by definition → no violation."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "void UART_Init(void) { return; }\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_extern_func_unsatisfied(self):
+        """extern function declaration with no definition → violation."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "void other_func(void) { return; }\n"),
+        ]
+        self.assertIn("misc.declared_not_defined", _rules(files))
+
+    def test_extern_func_message_contains_name(self):
+        """Violation message names the undeclared symbol."""
+        files = [
+            ("uart.h", "extern int UART_ReadByte(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        msgs = _msgs(files)
+        self.assertTrue(any("UART_ReadByte" in m for m in msgs))
+
+    def test_extern_func_satisfied_in_third_file(self):
+        """Definition in any scanned file satisfies the declaration."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+            ("uart.c", "void UART_Init(void) { return; }\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_non_extern_func_no_violation(self):
+        """Bare prototype without 'extern' is not flagged by this rule."""
+        files = [
+            ("uart.h", "void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        # Bare prototype without extern → rule does not track it
+        self.assertEqual(_check(files), [])
+
+    def test_static_func_no_violation(self):
+        """static function definition does not generate an extern declaration."""
+        files = [
+            ("uart.c", "static void helper(void) { return; }\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_each_name_reported_once(self):
+        """Same declaration in two headers → violation reported only once."""
+        files = [
+            ("a.h", "extern void UART_Init(void);\n"),
+            ("b.h", "extern void UART_Init(void);\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        count = sum(1 for r in _rules(files) if r == "misc.declared_not_defined")
+        self.assertEqual(count, 1)
+
+
+# ---------------------------------------------------------------------------
+# 3. Extern variable declarations
+# ---------------------------------------------------------------------------
+
+class TestDndExternVariable(unittest.TestCase):
+
+    def test_extern_var_satisfied(self):
+        """extern variable satisfied by file-scope definition → no violation."""
+        files = [
+            ("uart.h", "extern int g_uart_baud_rate;\n"),
+            ("uart.c", "int g_uart_baud_rate = 9600;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_extern_var_unsatisfied(self):
+        """extern variable with no file-scope definition → violation."""
+        files = [
+            ("uart.h", "extern int g_uart_baud_rate;\n"),
+            ("uart.c", "int g_other = 0;\n"),
+        ]
+        self.assertIn("misc.declared_not_defined", _rules(files))
+
+    def test_extern_const_var_satisfied(self):
+        """extern const variable satisfied by const definition → no violation."""
+        files = [
+            ("config.h", "extern const int BAUD_RATE;\n"),
+            ("config.c", "const int BAUD_RATE = 9600;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_extern_const_var_unsatisfied(self):
+        """extern const variable with no definition → violation."""
+        files = [
+            ("config.h", "extern const int BAUD_RATE;\n"),
+            ("config.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertIn("misc.declared_not_defined", _rules(files))
+
+    def test_extern_var_message_contains_name(self):
+        """Violation message names the undeclared variable."""
+        files = [
+            ("config.h", "extern int g_timeout;\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        msgs = _msgs(files)
+        self.assertTrue(any("g_timeout" in m for m in msgs))
+
+
+# ---------------------------------------------------------------------------
+# 4. Forward typedef struct / enum
+# ---------------------------------------------------------------------------
+
+class TestDndForwardTypedef(unittest.TestCase):
+
+    def test_fwd_struct_satisfied(self):
+        """Forward typedef struct satisfied by full definition → no violation."""
+        files = [
+            ("uart.h", "typedef struct Uart Uart;\n"),
+            ("uart.c", "typedef struct Uart { int baud; } Uart;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_fwd_struct_unsatisfied(self):
+        """Forward typedef struct with no full definition → violation."""
+        files = [
+            ("uart.h", "typedef struct Uart Uart;\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertIn("misc.declared_not_defined", _rules(files))
+
+    def test_fwd_struct_message_contains_name(self):
+        """Violation message names the undeclared typedef."""
+        files = [
+            ("uart.h", "typedef struct UartConfig UartConfig;\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        msgs = _msgs(files)
+        self.assertTrue(any("UartConfig" in m for m in msgs))
+
+    def test_fwd_enum_satisfied(self):
+        """Forward typedef enum satisfied by full definition → no violation."""
+        files = [
+            ("state.h", "typedef enum State State;\n"),
+            ("state.c", "typedef enum State { IDLE, RUNNING } State;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_fwd_enum_unsatisfied(self):
+        """Forward typedef enum with no full definition → violation."""
+        files = [
+            ("state.h", "typedef enum State State;\n"),
+            ("state.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertIn("misc.declared_not_defined", _rules(files))
+
+    def test_full_struct_not_flagged_as_forward(self):
+        """typedef struct with body is a definition, not a forward declaration."""
+        files = [
+            ("uart.h", "typedef struct Uart { int baud; } Uart;\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+
+# ---------------------------------------------------------------------------
+# 5. Inline suppression
+# ---------------------------------------------------------------------------
+
+class TestDndSuppression(unittest.TestCase):
+
+    def test_inline_suppression_extern_func(self):
+        """Inline suppression comment silences the violation for that symbol."""
+        files = [
+            ("hal.h",
+             "extern void HAL_Init(void);  "
+             "/* cstylecheck: disable misc.declared_not_defined */\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_inline_suppression_extern_var(self):
+        """Inline suppression on extern variable silences violation."""
+        files = [
+            ("hal.h",
+             "extern int HAL_baudRate;  "
+             "/* cstylecheck: disable misc.declared_not_defined */\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertEqual(_check(files), [])
+
+    def test_suppression_only_affects_that_line(self):
+        """Suppression on one declaration does not suppress another."""
+        files = [
+            ("hal.h",
+             "extern void HAL_Init(void);  "
+             "/* cstylecheck: disable misc.declared_not_defined */\n"
+             "extern void HAL_Deinit(void);\n"),
+            ("main.c", "int g_dummy = 0;\n"),
+        ]
+        rules = _rules(files)
+        # HAL_Init suppressed, HAL_Deinit should be flagged
+        self.assertIn("misc.declared_not_defined", rules)
+        count = rules.count("misc.declared_not_defined")
+        self.assertEqual(count, 1)
+
+
+# ---------------------------------------------------------------------------
+# 6. Severity
+# ---------------------------------------------------------------------------
+
+class TestDndSeverity(unittest.TestCase):
+
+    def test_default_severity_warning(self):
+        """Default severity is 'warning'."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        violations = _check(files)
+        self.assertTrue(all(v.severity == "warning" for v in violations))
+
+    def test_custom_severity_error(self):
+        """severity: error is respected."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        violations = _check(files, severity="error")
+        self.assertTrue(all(v.severity == "error" for v in violations))
+
+    def test_violation_rule_id(self):
+        """Violation carries the correct rule ID."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        violations = _check(files)
+        self.assertTrue(all(v.rule == "misc.declared_not_defined"
+                            for v in violations))
+
+
+# ---------------------------------------------------------------------------
+# 7. Location attributes
+# ---------------------------------------------------------------------------
+
+class TestDndLocation(unittest.TestCase):
+
+    def test_violation_filepath_is_declaration_file(self):
+        """Violation filepath points to the file containing the declaration."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        violations = _check(files)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].filepath, "uart.h")
+
+    def test_violation_line_number(self):
+        """Violation line number points to the declaration line."""
+        src = "/* header */\nextern void UART_Init(void);\n"
+        files = [
+            ("uart.h", src),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        violations = _check(files)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].line, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `DeclaredNotDefinedChecker` — a two-pass cross-file rule that detects C objects declared (via `extern` or a forward typedef) but for which no matching definition is found across the scanned file set
- Covers: extern function declarations, extern variable declarations, forward `typedef struct Tag Tag;`, forward `typedef enum Tag Tag;`
- Single-file runs always emit no violations (definition may be in an unscanned TU such as a BSP)
- Inline suppression: `/* cstylecheck: disable misc.declared_not_defined */` on the declaration line
- Disabled by default (`enabled: false`); opt-in via `misc.declared_not_defined.enabled: true`
- Default severity: `warning` (not `error`) — definition may be in unscanned BSP/COTS files

## Implementation

- `DeclaredNotDefinedChecker` class in `src/cstylecheck.py` following the same two-pass pattern as `SignChecker`
- Called from `main()` after the `SignChecker` block (only when enabled)
- Rule configuration added to `src/rules.yml` and `tests/rules.yml` (in sync)
- `DeclaredNotDefinedChecker` exported from `tests/harness.py`; `declared_not_defined` added to `_ALL_OFF`

## Test plan

- [x] Rule disabled → no violations
- [x] Single-file run → no violations
- [x] `extern` function satisfied by definition → no violation
- [x] `extern` function with no definition → violation with correct name in message
- [x] Definition in any of three scanned files satisfies declaration
- [x] Non-`extern` bare prototype → not flagged
- [x] `static` function → no false positive
- [x] Same declaration in two headers → violation reported once only
- [x] `extern` variable satisfied / unsatisfied
- [x] `extern const` variable satisfied / unsatisfied
- [x] Forward `typedef struct` satisfied / unsatisfied
- [x] Forward `typedef enum` satisfied / unsatisfied
- [x] Full `typedef struct { … }` not flagged as forward declaration
- [x] Inline suppression on `extern` function and variable
- [x] Suppression on one line does not suppress adjacent declaration
- [x] Default severity `warning`; custom severity `error`; correct rule ID
- [x] Violation filepath = declaration file; correct line number
- [x] 29 new tests; all 788 tests pass; YAML sync check passes

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)