### PR TITLE
feat(rules): add misc.whitespace_ratio rule — blank-line density gate

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -295,6 +295,7 @@ class Checker:
             self._check_include_guard()
         self._check_misc()
         self._check_comment_ratio()
+        self._check_whitespace_ratio()
         self._check_yoda()
         self._check_reserved_names()
         self._check_lowercase_l_suffix()   # MISRA C:2012/2023 Rule 7.3
@@ -1670,7 +1671,134 @@ class Checker:
         ))
 
     # -----------------------------------------------------------------------
-    # 15. Comment spell-check
+    # 15. Whitespace (blank-line) ratio  (misc.whitespace_ratio)
+    # -----------------------------------------------------------------------
+
+    def _check_whitespace_ratio(self) -> None:
+        """Enforce a minimum ratio of blank lines to code lines (issue #143).
+
+        Measures how 'airy' the file body is relative to its code density.
+        Very few blank lines relative to code lines indicates dense,
+        hard-to-read code.
+
+        Excluded from both counts:
+          - The file header: all leading comment/blank lines before the first
+            non-comment, non-blank line (copyright notices, licence blocks)
+          - Comment-only lines (// and /* … */) — they are not blank and are
+            not code, so they are excluded from both counts
+
+        Counted as blank lines (numerator):
+          - Empty lines and whitespace-only lines in the code body
+
+        Counted as code lines (denominator):
+          - Every non-blank, non-comment line (code, preprocessor, etc.)
+          - A line with a trailing // comment counts as a CODE line
+        """
+        misc   = self.cfg.get("misc", {})
+        wr_cfg = misc.get("whitespace_ratio", {})
+        if not wr_cfg.get("enabled", False):
+            return
+
+        sev       = wr_cfg.get("severity", "warning")
+        warn_thr  = float(wr_cfg.get("warning_threshold", 0.10))
+        err_thr   = float(wr_cfg.get("error_threshold",  0.01))
+        min_lines = int(wr_cfg.get("min_lines", 20))
+
+        lines = self.source.splitlines()
+
+        # ----------------------------------------------------------------
+        # Phase 1: locate the end of the file header.
+        # Same logic as _check_comment_ratio: the header region is all
+        # leading comment/blank lines before the first code line.
+        # ----------------------------------------------------------------
+        header_end_idx = 0
+        in_hdr_block   = False
+        found_code     = False
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if not stripped:                      # blank — skip during header scan
+                continue
+            if in_hdr_block:
+                if "*/" in line:
+                    in_hdr_block = False
+                continue
+            if stripped.startswith("/*"):
+                if "*/" not in stripped[2:]:      # multi-line block comment
+                    in_hdr_block = True
+                continue                           # still in header
+            if stripped.startswith("//"):
+                continue                           # line comment — still header
+            # First actual code line: header ends here
+            header_end_idx = i
+            found_code     = True
+            break
+
+        if not found_code:
+            return   # entire file is comments/blank — nothing to measure
+
+        # ----------------------------------------------------------------
+        # Phase 2: classify lines from header_end_idx onwards.
+        # ----------------------------------------------------------------
+        blank_lines  = 0
+        code_lines   = 0
+        in_block_cmt = False
+
+        for i, line in enumerate(lines):
+            if i < header_end_idx:
+                continue
+
+            stripped = line.strip()
+
+            if in_block_cmt:
+                if "*/" in line:
+                    in_block_cmt = False
+                continue   # block comment continuation — excluded from both
+
+            if not stripped:
+                blank_lines += 1   # blank line — counts toward numerator
+                continue
+
+            # Opening of a block comment (/* or /**)
+            if stripped.startswith("/*"):
+                if "*/" not in stripped[2:]:
+                    in_block_cmt = True
+                continue   # comment-only line — excluded from denominator
+
+            # Line comment
+            if stripped.startswith("//"):
+                continue   # excluded from denominator
+
+            # Non-blank, non-comment line — this is code
+            code_lines += 1
+
+        # Guard: skip files with too few code lines (trivial files, stubs)
+        if code_lines < min_lines:
+            return
+
+        ratio = blank_lines / code_lines
+
+        if ratio < err_thr:
+            emit_sev        = "error"
+            threshold       = err_thr
+            threshold_label = "error"
+        elif ratio < warn_thr:
+            emit_sev        = sev
+            threshold       = warn_thr
+            threshold_label = "warning"
+        else:
+            return   # ratio meets the warning threshold — all good
+
+        pl = lambda n: "s" if n != 1 else ""  # noqa: E731
+        self.result.add(Violation(
+            self.filepath, 1, 1, emit_sev, "misc.whitespace_ratio",
+            f"whitespace ratio {ratio:.2f} is below {threshold_label} threshold "
+            f"{threshold} "
+            f"({blank_lines} blank line{pl(blank_lines)} / "
+            f"{code_lines} code line{pl(code_lines)})"
+        ))
+
+    # -----------------------------------------------------------------------
+    # 16. Comment spell-check
     # -----------------------------------------------------------------------
 
     def _check_spelling(self) -> None:

--- a/src/rules.yml
+++ b/src/rules.yml
@@ -570,6 +570,39 @@ misc:
     error_threshold: 0.05   # ratio below which an ERROR is raised    (5%)
     min_code_lines: 10      # skip files with fewer code lines (avoids trivial-file false positives)
 
+  # -----------------------------------------------------------------------
+  # Whitespace (blank-line) ratio (issue #143)
+  # -----------------------------------------------------------------------
+  # Measures the ratio of blank lines to code lines in the file body.
+  # Very few blank lines relative to code indicates dense, hard-to-read code.
+  #
+  # Excluded from both counts:
+  #   - The file header: all leading comment/blank lines before the first
+  #     non-comment, non-blank line (copyright notices, licence blocks)
+  #   - Comment-only lines (// and /* … */) — excluded from denominator
+  #
+  # Counted as blank lines (numerator):
+  #   Empty and whitespace-only lines in the code body
+  #
+  # Counted as code lines (denominator):
+  #   Every non-blank, non-comment line (code, preprocessor, etc.)
+  #   A line with a trailing // comment still counts as a code line
+  #
+  # Default error threshold is approximately 0.1 × warning threshold,
+  # per the original issue specification ("Error if < 0.1 of warning level").
+  #
+  # Example violation messages:
+  #   uart.c:1: warning [misc.whitespace_ratio] whitespace ratio 0.06 is below
+  #             warning threshold 0.1 (6 blank lines / 95 code lines)
+  #   cfg.c:1:  error   [misc.whitespace_ratio] whitespace ratio 0.008 is below
+  #             error threshold 0.01 (1 blank line / 122 code lines)
+  whitespace_ratio:
+    enabled: false          # opt-in; disabled by default
+    severity: warning       # severity for below-warning-threshold violations
+    warning_threshold: 0.10 # ratio below which a WARNING is raised  (10%)
+    error_threshold: 0.01   # ratio below which an ERROR is raised    (1%)
+    min_lines: 20           # skip files with fewer code lines (avoids trivial-file false positives)
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -63,6 +63,9 @@ _ALL_OFF: dict = {
         # Comment ratio check (issue #68) -- disabled so existing tests
         # are not affected by the new per-file comment density check.
         "comment_ratio":         {"enabled": False},
+        # Whitespace ratio check (issue #143) -- disabled so existing tests
+        # are not affected by the new blank-line density check.
+        "whitespace_ratio":      {"enabled": False},
     },
     "reserved_names":    {"enabled": False},
     "sign_compatibility":{"enabled": False},

--- a/tests/rules.yml
+++ b/tests/rules.yml
@@ -571,6 +571,39 @@ misc:
     error_threshold: 0.05   # ratio below which an ERROR is raised    (5%)
     min_code_lines: 10      # skip files with fewer code lines (avoids trivial-file false positives)
 
+  # -----------------------------------------------------------------------
+  # Whitespace (blank-line) ratio (issue #143)
+  # -----------------------------------------------------------------------
+  # Measures the ratio of blank lines to code lines in the file body.
+  # Very few blank lines relative to code indicates dense, hard-to-read code.
+  #
+  # Excluded from both counts:
+  #   - The file header: all leading comment/blank lines before the first
+  #     non-comment, non-blank line (copyright notices, licence blocks)
+  #   - Comment-only lines (// and /* … */) — excluded from denominator
+  #
+  # Counted as blank lines (numerator):
+  #   Empty and whitespace-only lines in the code body
+  #
+  # Counted as code lines (denominator):
+  #   Every non-blank, non-comment line (code, preprocessor, etc.)
+  #   A line with a trailing // comment still counts as a code line
+  #
+  # Default error threshold is approximately 0.1 × warning threshold,
+  # per the original issue specification ("Error if < 0.1 of warning level").
+  #
+  # Example violation messages:
+  #   uart.c:1: warning [misc.whitespace_ratio] whitespace ratio 0.06 is below
+  #             warning threshold 0.1 (6 blank lines / 95 code lines)
+  #   cfg.c:1:  error   [misc.whitespace_ratio] whitespace ratio 0.008 is below
+  #             error threshold 0.01 (1 blank line / 122 code lines)
+  whitespace_ratio:
+    enabled: false          # opt-in; disabled by default
+    severity: warning       # severity for below-warning-threshold violations
+    warning_threshold: 0.10 # ratio below which a WARNING is raised  (10%)
+    error_threshold: 0.01   # ratio below which an ERROR is raised    (1%)
+    min_lines: 20           # skip files with fewer code lines (avoids trivial-file false positives)
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.

--- a/tests/test_whitespace_ratio.py
+++ b/tests/test_whitespace_ratio.py
@@ -1,0 +1,271 @@
+"""test_whitespace_ratio.py — tests for misc.whitespace_ratio rule (issue #143).
+
+The rule measures the ratio of blank lines to code lines in the file body.
+
+Counting rules:
+  - Blank lines (empty / whitespace-only) in the code body → numerator.
+  - Non-blank, non-comment lines (code, preprocessor) → denominator.
+  - Comment-only lines (// and /* … */) are excluded from both counts.
+  - The file header (all leading comment/blank lines before the first code line)
+    is excluded — copyright notices must not artificially inflate the ratio.
+  - A code line with a trailing // comment is still a code line (denominator).
+"""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, run
+
+RULE = "misc.whitespace_ratio"
+
+
+def _cfg(enabled=True, warning_threshold=0.10, error_threshold=0.01,
+         min_lines=5, severity="warning"):
+    return cfg_only(misc={
+        "whitespace_ratio": {
+            "enabled": enabled,
+            "severity": severity,
+            "warning_threshold": warning_threshold,
+            "error_threshold": error_threshold,
+            "min_lines": min_lines,
+        }
+    })
+
+
+CFG = _cfg()   # default: warning>=0.10, error>=0.01, min_lines=5
+
+
+def _code(n, start=0):
+    """Return n code lines (simple function calls)."""
+    return "".join(f"func_{i}();\n" for i in range(start, start + n))
+
+
+def _blank(n):
+    """Return n blank lines."""
+    return "\n" * n
+
+
+def _comment(n, start=0):
+    """Return n comment-only lines."""
+    return "".join(f"// note {i}\n" for i in range(start, start + n))
+
+
+# ---------------------------------------------------------------------------
+# Basic pass / fail
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRatioBasic(unittest.TestCase):
+
+    def test_disabled_produces_no_violation(self):
+        # Even with zero blank lines, disabled rule must not fire.
+        src = _code(10)
+        self.assertFalse(has(src, _cfg(enabled=False), RULE))
+
+    def test_zero_blank_lines_raises_violation(self):
+        # 0 blank / 10 code = 0.00 < 0.01 (error threshold)
+        src = _code(10)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_sufficient_blank_lines_passes(self):
+        # 1 blank / 10 code = 0.10 == warn_thr → not below → no violation
+        src = _code(1) + _blank(1) + _code(9, start=1)
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_exactly_at_warning_threshold_passes(self):
+        # 1 blank / 10 code = 0.10 (exactly at threshold — not below)
+        src = _code(1) + _blank(1) + _code(9, start=1)
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_one_below_warning_threshold_fails(self):
+        # 1 blank / 20 code = 0.05 < 0.10 but >= 0.01 → warning
+        src = _code(1) + _blank(1) + _code(19, start=1)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_single_violation_emitted_per_file(self):
+        # Only one violation per file regardless of how far below threshold
+        src = _code(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertEqual(len(viols), 1)
+
+
+# ---------------------------------------------------------------------------
+# Severity levels
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRatioSeverity(unittest.TestCase):
+
+    def test_below_error_threshold_emits_error(self):
+        # 0 blank / 10 code = 0.00 < 0.01 (error threshold)
+        src = _code(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "error")
+
+    def test_between_thresholds_emits_configured_severity(self):
+        # 1 blank / 20 code = 0.05 — between 0.01 (error) and 0.10 (warning)
+        src = _code(1) + _blank(1) + _code(19, start=1)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "warning")
+
+    def test_custom_severity_used_between_thresholds(self):
+        # When between error and warning thresholds, the configured severity is used
+        src = _code(1) + _blank(1) + _code(19, start=1)
+        cfg = _cfg(severity="info")
+        viols = [v for v in run(src, cfg) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "info")
+
+    def test_exactly_at_error_threshold_is_warning_not_error(self):
+        # ratio == err_thr is NOT below error threshold → warning, not error
+        # 1 blank / 100 code = 0.01 == err_thr
+        src = _code(1) + _blank(1) + _code(99, start=1)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "warning")
+
+
+# ---------------------------------------------------------------------------
+# min_lines guard
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRatioMinLines(unittest.TestCase):
+
+    def test_fewer_than_min_lines_skipped(self):
+        # 4 code lines < min_lines=5 → file skipped, no violation
+        src = _code(4)
+        self.assertFalse(has(src, CFG, RULE))
+
+    def test_exactly_min_lines_is_checked(self):
+        # 5 code lines == min_lines=5 → file checked → violation (0 blanks)
+        src = _code(5)
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_custom_min_lines(self):
+        # With min_lines=3, a 3-line file is checked
+        src = _code(3)
+        cfg = _cfg(min_lines=3)
+        self.assertTrue(has(src, cfg, RULE))
+
+    def test_comments_do_not_contribute_to_min_lines(self):
+        # 4 code lines + 10 comment lines → code_lines=4 < min_lines=5 → skipped
+        src = _comment(10) + _code(4)
+        self.assertFalse(has(src, CFG, RULE))
+
+
+# ---------------------------------------------------------------------------
+# File header exclusion
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRatioHeaderExclusion(unittest.TestCase):
+
+    def test_blank_lines_in_block_header_not_counted(self):
+        # Blank lines inside the copyright block must NOT inflate the numerator.
+        # Header: /* Copyright ... */ with internal blank lines
+        header = "/*\n\n * Copyright 2026 ACME Corp.\n\n */\n"
+        body = _code(10)   # 0 blank lines in body
+        src = header + body
+        # Header excluded → blank=0, code=10 → violation
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_blank_lines_between_header_comments_not_counted(self):
+        # Blank lines between // header comments are also in the header region
+        header = "// File: foo.c\n\n// Author: ACME\n"
+        body = _code(10)
+        src = header + body
+        # Header excluded → blank=0, code=10 → violation
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_blank_lines_in_body_counted_after_header(self):
+        header = "/* Copyright 2026 ACME. All rights reserved. */\n"
+        body   = _code(1) + _blank(1) + _code(9, start=1)   # 1 blank / 10 code
+        src    = header + body
+        # Header excluded; body has 1/10 = 0.10 == warn_thr → no violation
+        self.assertFalse(has(src, CFG, RULE))
+
+
+# ---------------------------------------------------------------------------
+# Comment line exclusion
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRatioCommentExclusion(unittest.TestCase):
+
+    def test_line_comments_excluded_from_denominator(self):
+        # 5 code + 10 comment-only = denominator is 5 only, not 15
+        # ratio = 0/5 = 0.00 < 0.01 → error
+        src = _code(5) + _comment(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "error")
+
+    def test_block_comments_excluded_from_denominator(self):
+        # A block comment does not count toward code lines
+        block = "/*\n * This is a block comment.\n */\n"
+        src   = _code(5) + block * 5   # 5 code + 5 block comments (15 lines)
+        # denominator = 5 code, numerator = 0 blank → ratio=0.00 → error
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].severity, "error")
+
+    def test_code_line_with_trailing_comment_counts_as_code(self):
+        # "func(); // reason" is a CODE line, not blank and not a comment line
+        src = "func_0(); // why we call this\n" + _code(9, start=1)
+        # code_lines=10, blank_lines=0 → ratio=0.00 → error
+        self.assertTrue(has(src, CFG, RULE))
+
+    def test_mixed_blanks_and_comments_ratio_correct(self):
+        # 10 code, 2 blank, 5 comments → ratio = 2/10 = 0.20 >= 0.10 → clean
+        src = _code(5) + _blank(1) + _comment(5) + _blank(1) + _code(5, start=5)
+        self.assertFalse(has(src, CFG, RULE))
+
+
+# ---------------------------------------------------------------------------
+# Violation message content
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRatioMessage(unittest.TestCase):
+
+    def test_message_contains_ratio_and_counts(self):
+        src = _code(10)   # 0 blank / 10 code
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        msg = viols[0].message
+        self.assertIn("0.00", msg)
+        self.assertIn("0 blank", msg)
+        self.assertIn("10 code", msg)
+
+    def test_message_mentions_threshold(self):
+        # 1 blank / 20 code = 0.05 — between thresholds → warning threshold in msg
+        src = _code(1) + _blank(1) + _code(19, start=1)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertIn("0.1", viols[0].message)   # warning threshold
+
+    def test_message_says_error_threshold_when_below_error(self):
+        src = _code(10)   # 0/10 → below error threshold
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertIn("error", viols[0].message)
+
+    def test_violation_reported_at_line_1(self):
+        src = _code(10)
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertEqual(viols[0].line, 1)
+
+    def test_singular_blank_line_grammar(self):
+        # "1 blank line" not "1 blank lines"
+        src = _code(1) + _blank(1) + _code(19, start=1)   # 1 blank / 20 code
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertIn("1 blank line", viols[0].message)
+        self.assertNotIn("1 blank lines", viols[0].message)
+
+    def test_plural_blank_lines_grammar(self):
+        # "2 blank lines" not "2 blank line"
+        src = _code(1) + _blank(2) + _code(39, start=1)   # 2 blank / 40 code = 0.05
+        viols = [v for v in run(src, CFG) if v.rule == RULE]
+        self.assertTrue(viols)
+        self.assertIn("2 blank lines", viols[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Implements `misc.whitespace_ratio` per issue #143: measures ratio of blank lines to code lines in each scanned file
- Raises a warning when ratio < `warning_threshold` (default 10%) and an error when ratio < `error_threshold` (default 1%)
- File header (copyright/licence block before first code line) is excluded; comment-only lines are excluded from both counts
- Rule is opt-in (`enabled: false` by default), supports per-file exclusion via `exclusions.yml`
- **Fixes CI path trigger bug** (F-008): `src/cstylecheck/**` added to push/PR triggers; mypy target corrected to `src/cstylecheck/`
- **ASPICE internal audit CSC-AUD-001** (closes #136): populates PA2 §6 with N/P/L/F verdicts for all 17 processes; creates `docs/aspice/audits/` with full audit report

## Changes

| File | Change |
|---|---|
| `src/cstylecheck/checker.py` | New `_check_whitespace_ratio()` method; called from `run_all()` |
| `src/rules.yml` | New `misc.whitespace_ratio` block with defaults and inline documentation |
| `tests/rules.yml` | Mirror of `src/rules.yml` addition (YAML sync maintained) |
| `tests/harness.py` | `_ALL_OFF` updated with `whitespace_ratio: {enabled: false}` |
| `tests/test_whitespace_ratio.py` | 27 new unit tests across 6 classes |
| `.github/workflows/cstylecheck_tests.yml` | Add `src/cstylecheck/**` to path triggers; fix mypy target |
| `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-05-28.md` | New — CSC-AUD-001 audit report |
| `docs/aspice/CStyleCheck_PA2_Capability_Records.md` | v1.4 — §6 verdicts populated; §5.4 version table updated |
| `docs/aspice/CStyleCheck_Analysis_Report.md` | Post-audit status addendum (§7) added |

## Test plan

- [x] `python -m pytest tests/test_whitespace_ratio.py -v` — 27/27 pass
- [x] `python -m pytest --tb=short -q` — 839 passed, 0 regressions
- [x] `python -m ruff check src/ tests/` — All checks passed
- [x] `diff src/rules.yml tests/rules.yml | grep '^[<>]' | grep -v '...'` — no unexpected differences

## ASPICE audit results

**Overall CL2 verdict: Largely Achieved — not yet awarded.**
- 14 processes: **L** (Largely Achieved)
- 3 processes: **P** (SYS.4, SYS.5, SWE.5 — blocked by #152: test execution evidence)
- 0 processes: N or F
- 12 new ASPICE gap issues raised: #146–#157

Closes #143
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)