### PR TITLE
fix(rules): detect extern-macro function declarations in misc.declared_not_defined

### DIFF
--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -509,7 +509,7 @@ def main() -> int:
     # Cross-file declared-but-not-defined check (needs all files ingested first).
     dnd_cfg = cfg.get("misc", {}).get("declared_not_defined", {})
     if dnd_cfg.get("enabled", False):
-        dndc = DeclaredNotDefinedChecker(cfg)
+        dndc = DeclaredNotDefinedChecker(cfg, defines=defines)
         for filepath in files:
             src = source_cache.get(filepath)
             if src is not None:

--- a/src/cstylecheck/sign_checker.py
+++ b/src/cstylecheck/sign_checker.py
@@ -25,6 +25,7 @@ from .checker import (
     RE_TYPEDEF_STRUCT, RE_TYPEDEF_ENUM,
     RE_VAR_DECL,
 )
+from .config import apply_defines
 
 # --- Regex patterns for sign analysis ---
 
@@ -378,19 +379,58 @@ class DeclaredNotDefinedChecker:
         re.MULTILINE,
     )
 
-    def __init__(self, cfg: dict):
+    def __init__(self, cfg: dict, defines: list = None):
         self._cfg:         dict = cfg
+        self._defines:     list = defines or []
         self._decls:       list = []   # (filepath, line, col, name, kind)
         self._func_defs:   set  = set()
         self._var_defs:    set  = set()
         self._struct_defs: set  = set()
         self._enum_defs:   set  = set()
         self._file_count:  int  = 0
+        # Pre-compile extern_macros patterns for fast substitution in ingest().
+        dnd_cfg = cfg.get("misc", {}).get("declared_not_defined", {})
+        self._extern_macro_res: list = [
+            re.compile(r'\b' + re.escape(m) + r'\b')
+            for m in dnd_cfg.get("extern_macros", [])
+        ]
+
+    def _apply_extern_substitutions(self, clean: str) -> str:
+        """
+        Substitute extern-alias macros so pattern matching can find them.
+
+        Two mechanisms are supported (applied in order):
+
+        1. **``--defines`` file** — if the user already lists the macro in
+           their project defines file (e.g. ``API_WDT_EXTERN  extern``),
+           ``apply_defines()`` performs whole-word substitution.  The
+           DeclaredNotDefinedChecker receives the same defines list as the
+           main Checker, so no extra configuration is required.
+
+        2. **``misc.declared_not_defined.extern_macros``** — a YAML list of
+           macro names that represent ``extern`` linkage for the purposes of
+           this rule only.  Useful when the macro is not in the project defines
+           file or expands to something more complex (e.g.
+           ``__declspec(dllimport)``).
+
+        Both mechanisms replace the macro with the literal token ``extern``
+        so that ``RE_FUNCTION_DECL`` and the ``extern``-keyword filter in
+        ``ingest()`` work unchanged.
+        """
+        if self._defines:
+            clean = apply_defines(clean, self._defines)
+        for pat in self._extern_macro_res:
+            clean = pat.sub("extern", clean)
+        return clean
 
     def ingest(self, filepath: str, source: str) -> None:
         """Scan one file for declarations and definitions."""
         self._file_count += 1
         clean        = preprocess(source)
+        # Apply --defines and extern_macros substitutions so that macros such
+        # as API_WDT_EXTERN (which expand to 'extern') are recognised as
+        # extern declarations by the pattern matchers below (issue #168).
+        clean        = self._apply_extern_substitutions(clean)
         line_map     = build_line_map(clean)
         brace_depths = _build_brace_depths(clean)
         src_lines    = source.splitlines()

--- a/src/rules.yml
+++ b/src/rules.yml
@@ -537,6 +537,13 @@ misc:
   declared_not_defined:
     enabled: false    # opt-in; disabled by default
     severity: warning
+    # extern_macros: list of project-specific macros that expand to 'extern'
+    # (or equivalent linkage specifiers such as __declspec(dllimport)).
+    # Add the macro name here so that declarations like:
+    #   API_WDT_EXTERN void WDT_Init(void);
+    # are treated as extern declarations by this rule (issue #168).
+    # Alternative: add the macro to your --defines file with 'API_WDT_EXTERN extern'.
+    extern_macros: []
 
   # -----------------------------------------------------------------------
   # Comment-to-code ratio (issue #68)

--- a/tests/rules.yml
+++ b/tests/rules.yml
@@ -537,6 +537,13 @@ misc:
   declared_not_defined:
     enabled: false    # opt-in; disabled by default
     severity: warning
+    # extern_macros: list of project-specific macros that expand to 'extern'
+    # (or equivalent linkage specifiers such as __declspec(dllimport)).
+    # Add the macro name here so that declarations like:
+    #   API_WDT_EXTERN void WDT_Init(void);
+    # are treated as extern declarations by this rule (issue #168).
+    # Alternative: add the macro to your --defines file with 'API_WDT_EXTERN extern'.
+    extern_macros: []
 
   # TEST FIXTURE: comment_ratio disabled (intentionally matches src/rules.yml)
   # -----------------------------------------------------------------------

--- a/tests/test_declared_not_defined.py
+++ b/tests/test_declared_not_defined.py
@@ -353,5 +353,164 @@ class TestDndLocation(unittest.TestCase):
         self.assertEqual(violations[0].line, 2)
 
 
+# ---------------------------------------------------------------------------
+# 8. Extern-macro detection (issue #168)
+# ---------------------------------------------------------------------------
+
+def _check_with_defines(files, defines_list, enabled=True, severity="warning"):
+    """
+    Ingest all (filepath, source) pairs with a defines list and return violations.
+
+    *defines_list* is a list of ``(compiled_pattern, replacement)`` tuples as
+    returned by ``load_defines_file()``.  The list is passed to the checker's
+    ``defines`` argument so that extern-alias macros are substituted before
+    pattern matching (e.g. ``API_WDT_EXTERN`` → ``extern``).
+    """
+    dndc = DeclaredNotDefinedChecker(_cfg(enabled=enabled, severity=severity),
+                                     defines=defines_list)
+    for fp, src in files:
+        dndc.ingest(fp, src)
+    return dndc.check()
+
+
+def _check_with_extern_macros(files, extern_macros, enabled=True, severity="warning"):
+    """Ingest files with extern_macros configured in the YAML config."""
+    cfg = {"misc": {"declared_not_defined": {
+        "enabled": enabled, "severity": severity,
+        "extern_macros": extern_macros,
+    }}}
+    dndc = DeclaredNotDefinedChecker(cfg)
+    for fp, src in files:
+        dndc.ingest(fp, src)
+    return dndc.check()
+
+
+class TestDndExternMacro(unittest.TestCase):
+    """
+    Tests for the extern-macro substitution feature (issue #168).
+
+    Projects commonly hide linkage specifiers behind macros such as:
+        API_WDT_EXTERN void WDT_Init(void);
+    where API_WDT_EXTERN expands to 'extern' (or __declspec(dllimport) etc.).
+
+    The rule supports two ways to teach the checker about such macros:
+      1. --defines file: 'API_WDT_EXTERN  extern' expands the macro before
+         pattern matching (applies to all rules, not just declared_not_defined).
+      2. misc.declared_not_defined.extern_macros: [API_WDT_EXTERN] in rules.yml
+         (targeted config, only affects this rule).
+    """
+
+    def _make_defines(self, macro: str, expansion: str = "extern") -> list:
+        """Build a minimal defines list like load_defines_file() produces."""
+        import re as _re
+        pattern = _re.compile(r'\b' + _re.escape(macro) + r'\b')
+        return [(pattern, expansion)]
+
+    # --- via --defines mechanism ---
+
+    def test_extern_macro_via_defines_unsatisfied(self):
+        """Macro that expands to extern (via defines) + no definition → violation."""
+        defines = self._make_defines("API_WDT_EXTERN")
+        files = [
+            ("wdt.h", "API_WDT_EXTERN void WDT_Init(void);\n"),
+            ("wdt.c", "int g_dummy = 0;\n"),
+        ]
+        rules = [v.rule for v in _check_with_defines(files, defines)]
+        self.assertIn("misc.declared_not_defined", rules)
+
+    def test_extern_macro_via_defines_satisfied(self):
+        """Macro that expands to extern (via defines) + matching definition → no violation."""
+        defines = self._make_defines("API_WDT_EXTERN")
+        files = [
+            ("wdt.h", "API_WDT_EXTERN void WDT_Init(void);\n"),
+            ("wdt.c", "void WDT_Init(void) { return; }\n"),
+        ]
+        self.assertEqual(_check_with_defines(files, defines), [])
+
+    def test_extern_macro_via_defines_no_false_positive_without_defines(self):
+        """Without defines configured the macro-pattern is NOT flagged (no spurious detect)."""
+        files = [
+            ("wdt.h", "API_WDT_EXTERN void WDT_Init(void);\n"),
+            ("wdt.c", "int g_dummy = 0;\n"),
+        ]
+        # No defines passed — bare macro not recognised as extern declaration
+        rules = [v.rule for v in _check(files)]
+        self.assertNotIn("misc.declared_not_defined", rules)
+
+    def test_defines_with_complex_expansion(self):
+        """Macro that expands to a linkage specifier other than bare 'extern' is still handled."""
+        # Some platforms use: #define API_EXTERN extern __attribute__((visibility("default")))
+        # After defines substitution the token 'extern' is present, which satisfies the filter.
+        import re as _re
+        pattern = _re.compile(r'\bAPI_EXTERN\b')
+        defines = [(pattern, 'extern __attribute__((visibility("default")))')]
+        files = [
+            ("hal.h", "API_EXTERN int HAL_Read(void);\n"),
+            ("hal.c", "int g_dummy = 0;\n"),
+        ]
+        rules = [v.rule for v in _check_with_defines(files, defines)]
+        self.assertIn("misc.declared_not_defined", rules)
+
+    # --- via extern_macros config ---
+
+    def test_extern_macros_config_unsatisfied(self):
+        """extern_macros list in config: unsatisfied declaration → violation."""
+        files = [
+            ("wdt.h", "API_WDT_EXTERN void WDT_Init(void);\n"),
+            ("wdt.c", "int g_dummy = 0;\n"),
+        ]
+        rules = [v.rule for v in _check_with_extern_macros(files, ["API_WDT_EXTERN"])]
+        self.assertIn("misc.declared_not_defined", rules)
+
+    def test_extern_macros_config_satisfied(self):
+        """extern_macros list in config: satisfied declaration → no violation."""
+        files = [
+            ("wdt.h", "API_WDT_EXTERN void WDT_Init(void);\n"),
+            ("wdt.c", "void WDT_Init(void) { return; }\n"),
+        ]
+        self.assertEqual(_check_with_extern_macros(files, ["API_WDT_EXTERN"]), [])
+
+    def test_extern_macros_empty_list_no_change(self):
+        """Empty extern_macros list: behaviour is unchanged from default."""
+        files = [
+            ("uart.h", "extern void UART_Init(void);\n"),
+            ("uart.c", "int g_dummy = 0;\n"),
+        ]
+        rules = [v.rule for v in _check_with_extern_macros(files, [])]
+        self.assertIn("misc.declared_not_defined", rules)
+
+    def test_extern_macros_multiple_macros(self):
+        """Multiple macros in extern_macros list are all recognised."""
+        files = [
+            ("a.h", "API_WDT_EXTERN void WDT_Init(void);\n"
+                    "DLL_IMPORT void HAL_Init(void);\n"),
+            ("a.c", "int g_dummy = 0;\n"),
+        ]
+        violations = _check_with_extern_macros(files, ["API_WDT_EXTERN", "DLL_IMPORT"])
+        names = [v.message for v in violations]
+        self.assertTrue(any("WDT_Init" in m for m in names))
+        self.assertTrue(any("HAL_Init" in m for m in names))
+
+    def test_extern_macros_does_not_affect_other_rules(self):
+        """extern_macros substitution only impacts declared_not_defined detection."""
+        # The satisfaction check is still about actual definitions.
+        files = [
+            ("wdt.h", "API_WDT_EXTERN void WDT_Init(void);\n"),
+            ("wdt.c", "void WDT_Init(void) { return; }\n"),
+        ]
+        violations = _check_with_extern_macros(files, ["API_WDT_EXTERN"])
+        self.assertEqual(violations, [])
+
+    def test_extern_macros_suppression_still_works(self):
+        """Inline suppression still silences an extern-macro declaration."""
+        files = [
+            ("wdt.h",
+             "API_WDT_EXTERN void WDT_Init(void);"
+             "  /* cstylecheck: disable misc.declared_not_defined */\n"),
+            ("wdt.c", "int g_dummy = 0;\n"),
+        ]
+        self.assertEqual(_check_with_extern_macros(files, ["API_WDT_EXTERN"]), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `DeclaredNotDefinedChecker` now accepts a `defines` list (the same list passed to the main Checker via `--defines`). Applying defines before pattern matching means macros like `API_WDT_EXTERN extern` auto-substitute to `extern` with no extra config.
- New `misc.declared_not_defined.extern_macros: [...]` YAML option for targeted macro registration when a full defines file is not in use.
- `cli.py` passes the active defines list to `DeclaredNotDefinedChecker`.
- `src/rules.yml` and `tests/rules.yml` updated with the new `extern_macros: []` default + explanatory comments.
- 10 new tests in `TestDndExternMacro` (39 total in the file).

## Root cause

`ingest()` called `preprocess()` on the raw source but never applied the project defines. The `extern`-keyword filter then rejected any declaration where the keyword was hidden behind a macro, producing a false negative.

## Test plan

- [x] `pytest tests/test_declared_not_defined.py` — 39/39 pass
- [x] `pytest tests/` — full suite passes

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)