### PR TITLE
chore(docs): add codespell CI gate and fix Contributions typo

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,33 @@
+# .codespellrc — codespell configuration for CStyleCheck
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+#
+# Run manually:  codespell
+# CI gate:       codespell --check-filenames (see .github/workflows/cstylecheck_tests.yml)
+
+[codespell]
+# Files and directories to skip
+skip = .git,__pycache__,.pytest_cache,*.pyc,*.json,*.xml,coverage.xml
+
+# Words to ignore (false positives in this codebase):
+#
+#   statics     — C language concept: file-scope static variables and functions.
+#                 Many comments and rule descriptions use "statics" correctly.
+#
+#   statu       — Intentional code examples in docs and tests showing the
+#                 possessive-stripping bug fix (status → statu after bad strip).
+#
+#   HSI,HSE,    — STM32 microcontroller clock source acronyms listed in the
+#   LSI,LSE       spell-check exempt_words in rules.yml.  These are valid
+#                 hardware identifiers, not typos.
+#
+#   Initilise   — Intentional misspelling in Rules-and-Configuration.md showing
+#                 an example of what spell-check is designed to catch.
+#
+#   recive      — Intentional misspelling in SWE6 qualification test description
+#                 (uart_recive_data test fixture).
+#
+#   unparseable — Accepted alternative spelling of "unparsable"; used in SWE1.
+ignore-words-list = statics,statu,HSI,HSE,LSI,LSE,Initilise,recive,unparseable
+
+# Quiet level 2: only report errors, not warnings
+quiet-level = 2

--- a/.github/workflows/cstylecheck_tests.yml
+++ b/.github/workflows/cstylecheck_tests.yml
@@ -128,6 +128,17 @@ jobs:
         if: matrix.python-version == '3.11'
         run: ruff check src/ tests/
 
+      # -----------------------------------------------------------------------
+      # Spell-check — catches typos in source code, docs, and YAML files.
+      # False-positive words are suppressed in .codespellrc (issue #161).
+      # Only runs on one Python version to avoid duplicate reports.
+      # -----------------------------------------------------------------------
+      - name: Spell check
+        if: matrix.python-version == '3.11'
+        run: |
+          pip install codespell --quiet
+          codespell
+
       - name: Upload coverage
         if: matrix.python-version == '3.11'
         uses: actions/upload-artifact@v6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The purpose of this project is three-fold:
 - As an experiment to prompt Claude to generate all content - eg documents, webpages, issues, code, workflow - no manual correction of files
 - For a human to review all the work - either manually or with the help of an AI
 
-Conributions are very welcome.
+Contributions are very welcome.
 
 ![Logo](logo/cstylecheck.jpg)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest-cov>=4.1,<6.0      # coverage reporting
 mypy>=1.0                  # static type checking
 types-PyYAML>=6.0          # mypy stubs for PyYAML
 ruff>=0.1                  # fast Python linter
+codespell>=2.2             # spell-check source, docs, and config files


### PR DESCRIPTION
## Summary

- Fixes the known `Conributions` → `Contributions` typo in README.md
- Adds `.codespellrc` config suppressing legitimate false positives (`statics`, `statu`, STM32 acronyms, intentional code-example misspellings)
- Adds a **Spell check** step to `cstylecheck_tests.yml` (Python 3.11 only) — fails CI on any new unrecognised typo
- Adds `codespell>=2.2` to `requirements.txt`

## False positives suppressed in `.codespellrc`

| Word | Reason |
|------|--------|
| `statics` | C file-scope storage class (not "statistics") |
| `statu` | Intentional code examples showing possessive-strip bug fix |
| `HSI`, `HSE`, `LSI`, `LSE` | STM32 clock-source acronyms in `rules.yml` |
| `Initilise` | Intentional example in `Rules-and-Configuration.md` |
| `recive` | Intentional misspelling in SWE6 qualification-test fixture |
| `unparseable` | Accepted alternative spelling; used in SWE1 |

## Test plan

- [x] `codespell` runs clean locally with `.codespellrc` in place
- [x] `pytest tests/` — full suite passes (no test changes needed)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)