### PR TITLE
chore(aspice): add ASPICE peer review template and populated review record v1.2

### DIFF
--- a/docs/aspice/CStyleCheck_Review_Record_v1.2.md
+++ b/docs/aspice/CStyleCheck_Review_Record_v1.2.md
@@ -1,0 +1,373 @@
+# CStyleCheck — ASPICE Peer Review Record v1.2
+
+*Produced using CSC-REVIEW-TEMPLATE-001 v1.0*
+
+---
+
+## 1. Review Identification
+
+| Field | Value |
+|---|---|
+| **Review ID** | CSC-REVIEW-001 |
+| **Review Type** | Peer Review — Work Product Quality Check |
+| **Review Date** | 2026-05-29 |
+| **Reviewer** | Claude (AI-assisted) — see CSC-DEV-001 |
+| **Author / Review Owner** | Dermot Murphy |
+| **Baseline Commit / Tag** | `v1.2.1` (commit `0769128`) |
+| **Review Scope** | All 21 ASPICE work products at v1.2.1 |
+| **Reference Standard** | Automotive SPICE® PAM v4.0 · ASPICE GP 2.2.3 |
+| **Related Documents** | CSC-PA2-001 v1.6, CSC-AUD-002, CSC-DEV-001, CSC-DEV-002 |
+| **Status** | Approved (pending Review Owner signature) |
+
+---
+
+## 2. Review Scope
+
+| # | Document ID | Title | Version | Review Status |
+|---|---|---|---|---|
+| 1 | CSC-SYS2-001 | System Requirements Analysis | 1.4 | Reviewed — 1 finding |
+| 2 | CSC-SYS3-001 | System Architecture Design | 1.3 | Reviewed — Pass |
+| 3 | CSC-SYS4-001 | System Integration Test | 1.2 | Reviewed — 1 finding |
+| 4 | CSC-SYS5-001 | System Qualification Test | 1.2 | Reviewed — 1 finding |
+| 5 | CSC-SWE1-001 | Software Requirements Analysis | 1.4 | Reviewed — Pass |
+| 6 | CSC-SWE2-001 | Software Architecture Design | 1.3 | Reviewed — Pass |
+| 7 | CSC-SWE3-001 | Software Detailed Design | 1.4 | Reviewed — Pass |
+| 8 | CSC-SWE4-001 | Software Unit Verification | 1.4 | Reviewed — 1 finding (Observation) |
+| 9 | CSC-SWE5-001 | Software Integration Test | 1.3 | Reviewed — Pass |
+| 10 | CSC-SWE6-001 | Software Qualification Test | 1.3 | Reviewed — Pass |
+| 11 | CSC-MAN3-001 | Project Management | 1.3 | Reviewed — Pass |
+| 12 | CSC-MAN5-001 | Risk Management | 1.2 | Reviewed — 1 finding |
+| 13 | CSC-SUP1-001 | Quality Assurance | 1.3 | Reviewed — 1 finding |
+| 14 | CSC-SUP8-001 | Configuration Management | 1.3 | Reviewed — Pass |
+| 15 | CSC-SUP9-001 | Problem Resolution Management | 1.3 | Reviewed — Pass |
+| 16 | CSC-SUP10-001 | Change Request Management | 1.2 | Reviewed — Pass |
+| 17 | CSC-ACQ4-001 | Supplier Monitoring | 1.2 | Reviewed — Pass |
+| 18 | CSC-SVD-001 | Software Version Description | 1.2 | Reviewed — Pass |
+| 19 | CSC-PA2-001 | Capability Records | 1.6 | Reviewed — Pass |
+| 20 | CSC-DEV-001 | AI Authorship Deviation Record | 1.1 | Reviewed — Pass |
+| 21 | CSC-DEV-002 | Independent Review Deviation Record | 1.0 | Reviewed — Pass |
+
+---
+
+## 3. Per-Document Checklist Results
+
+### CSC-SYS2-001 — System Requirements Analysis v1.4
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All 7 sections present; no unresolved placeholders |
+| C2 — Consistency | ⚠️ | §3.1 states 48 implemented rules; README and codebase confirm 53 — discrepancy (Finding RR-001-001) |
+| C3 — Traceability | ✅ | Requirements trace to SYS.3 and SWE.1 traceability matrices |
+| C4 — Correctness | ⚠️ | Rule count 48 is stale vs actual 53 (see C2 finding) |
+| C5 — Clarity | ✅ | Terminology consistent throughout |
+| **Overall** | Conditional Pass | One Minor finding: rule count must be updated |
+
+---
+
+### CSC-SYS3-001 — System Architecture Design v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All sections present; 10-module architecture fully documented |
+| C2 — Consistency | ✅ | Module list matches `src/cstylecheck/` package at v1.2.1 |
+| C3 — Traceability | ✅ | Subsystems trace to SYS.2 requirements |
+| C4 — Correctness | ✅ | File paths and module names match actual codebase |
+| C5 — Clarity | ✅ | Component boundaries clearly described |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SYS4-001 — System Integration Test v1.2
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ⚠️ | 14 test cases defined; §5 execution table has some `<fill at execution>` entries (Finding RR-001-002) |
+| C2 — Consistency | ✅ | Test case IDs consistent with SWE.5 |
+| C3 — Traceability | ✅ | Test cases trace to SYS.2 requirements |
+| C4 — Correctness | ✅ | Test step descriptions match actual tool behaviour |
+| C5 — Clarity | ✅ | Pass/fail criteria unambiguous |
+| **Overall** | Conditional Pass | Minor: execution table should be populated per release |
+
+---
+
+### CSC-SYS5-001 — System Qualification Test v1.2
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ⚠️ | Qualification test cases defined; results table has placeholder entries (Finding RR-001-003) |
+| C2 — Consistency | ✅ | Test cases consistent with SWE.6 |
+| C3 — Traceability | ✅ | Traces to SYS.2 non-functional requirements |
+| C4 — Correctness | ✅ | Docker image test steps accurate |
+| C5 — Clarity | ✅ | |
+| **Overall** | Conditional Pass | Minor: results table should be populated per release |
+
+---
+
+### CSC-SWE1-001 — Software Requirements Analysis v1.4
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | 70+ requirements covering all 53 rule IDs; traceability matrix present |
+| C2 — Consistency | ✅ | Rule IDs match `src/rules.yml` at v1.2.1; test names match `tests/` |
+| C3 — Traceability | ✅ | Every requirement traces to SYS.2 and to SWE.3 / SWE.4 |
+| C4 — Correctness | ✅ | `yoda_conditions` (plural) key used correctly |
+| C5 — Clarity | ✅ | Acceptance criteria for each requirement clear and testable |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SWE2-001 — Software Architecture Design v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All 10 package sub-modules documented; interfaces described |
+| C2 — Consistency | ✅ | Module dependencies match actual import graph in source |
+| C3 — Traceability | ✅ | Components trace to SWE.1 requirements |
+| C4 — Correctness | ✅ | Component names and file paths match `src/cstylecheck/` |
+| C5 — Clarity | ✅ | Data flow diagrams clear |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SWE3-001 — Software Detailed Design v1.4
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | Per-module and per-function design entries present for all 10 modules |
+| C2 — Consistency | ✅ | Function signatures match `src/cstylecheck/*.py` |
+| C3 — Traceability | ✅ | Design entries trace to SWE.1 requirements |
+| C4 — Correctness | ✅ | `RE_FUNCTION_DECL`, `DeclaredNotDefinedChecker`, and other class names match source |
+| C5 — Clarity | ✅ | Algorithm descriptions at appropriate level of detail |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SWE4-001 — Software Unit Verification v1.4
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All 31 test modules listed; 839 tests enumerated |
+| C2 — Consistency | ✅ | Test counts match actual `pytest tests/` run; coverage gate 85% matches CI config |
+| C3 — Traceability | ✅ | Test modules trace to SWE.1 and SWE.3 |
+| C4 — Correctness | ✅ | Test file names accurate at v1.2.1 |
+| C5 — Clarity | ⚠️ | §4 describes target as "90% statement coverage" but CI enforces 85% combined statement+branch — minor phrasing inconsistency (Finding RR-001-004, Observation) |
+| **Overall** | Pass (with Observation) | |
+
+---
+
+### CSC-SWE5-001 — Software Integration Test v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | Integration test cases and results populated |
+| C2 — Consistency | ✅ | Test cases reference correct module boundaries |
+| C3 — Traceability | ✅ | Traces to SWE.1 and SWE.2 |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SWE6-001 — Software Qualification Test v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | QT-001 through QT-040+ present with results |
+| C2 — Consistency | ✅ | Docker image test references v1.2.1 |
+| C3 — Traceability | ✅ | Tests trace to SYS.2 and SWE.1 |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-MAN3-001 — Project Management v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | WBS-01 through WBS-16 with planned/actual dates and effort |
+| C2 — Consistency | ✅ | Dates consistent with GitHub release history |
+| C3 — Traceability | ✅ | WBS activities link to releases and GitHub milestones |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-MAN5-001 — Risk Management v1.2
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | 6 risks identified |
+| C2 — Consistency | ✅ | Risk IDs consistent throughout |
+| C3 — Traceability | ✅ | Risks linked to GitHub issues |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ⚠️ | RISK-003 (solo-developer SPOF) and RISK-005 (AI tool dependency) mitigation descriptions are high-level and lack concrete owner/review schedule (Finding RR-001-005) |
+| **Overall** | Conditional Pass | Minor: risk mitigations need concrete owners |
+
+---
+
+### CSC-SUP1-001 — Quality Assurance v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | QA plan, CI gates, PR review process documented |
+| C2 — Consistency | ✅ | CI gate values match `cstylecheck_tests.yml` |
+| C3 — Traceability | ✅ | |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ⚠️ | No formal peer review template referenced; reviews are informal (Finding RR-001-006 — addressed by this document set, issue #169) |
+| **Overall** | Conditional Pass | Minor: reference to peer review template to be added once #169 is merged |
+
+---
+
+### CSC-SUP8-001 — Configuration Management v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All 4 workflows listed including wiki_publish.yml |
+| C2 — Consistency | ✅ | Docker tags and GHCR paths accurate at v1.2.1 |
+| C3 — Traceability | ✅ | |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SUP9-001 — Problem Resolution Management v1.3
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | Defect lifecycle, resolution times, sample records present |
+| C2 — Consistency | ✅ | Issue IDs cited are real open/closed GitHub issues |
+| C3 — Traceability | ✅ | |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SUP10-001 — Change Request Management v1.2
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | CR process, impact analysis, and approval gate documented |
+| C2 — Consistency | ✅ | |
+| C3 — Traceability | ✅ | |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-ACQ4-001 — Supplier Monitoring v1.2
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | 5 external suppliers listed with monitoring plan |
+| C2 — Consistency | ✅ | SHA-pinned action versions consistent with workflow files |
+| C3 — Traceability | ✅ | |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-SVD-001 — Software Version Description v1.2
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All 10 package modules listed; Docker tags, test files, document versions all present |
+| C2 — Consistency | ✅ | Version 1.2.1 (SVD covers the 1.2.x series); test count 839 matches CI |
+| C3 — Traceability | ✅ | Baseline commit `3edc392` cited |
+| C4 — Correctness | ✅ | File paths and module names verified against `src/cstylecheck/` |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-PA2-001 — Capability Records v1.6
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | All 21 work products listed with version and release status |
+| C2 — Consistency | ✅ | All entries show "Released / v1.2.0 tag" or "Released / v1.2.1 tag" |
+| C3 — Traceability | ✅ | Document versions match those cited in the SVD and audit records |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-DEV-001 — AI Authorship Deviation Record v1.1
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | Deviation rationale, scope, controls, and approval present |
+| C2 — Consistency | ✅ | Referenced in all work products |
+| C3 — Traceability | ✅ | Links to issue #52 |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+### CSC-DEV-002 — Independent Review Deviation Record v1.0
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ | Deviation rationale, compensating controls, and approval present |
+| C2 — Consistency | ✅ | Referenced in PA2 and all review sign-off blocks |
+| C3 — Traceability | ✅ | Links to issue #61 |
+| C4 — Correctness | ✅ | |
+| C5 — Clarity | ✅ | |
+| **Overall** | Pass | |
+
+---
+
+## 4. Findings
+
+| Finding ID | Document | Criterion | Severity | Description | Disposition |
+|---|---|---|---|---|---|
+| RR-001-001 | CSC-SYS2-001 | C2, C4 | Minor | §3.1 rule count stated as 48; actual count is 53 (three new rules added in v1.2.0: `misc.comment_ratio`, `misc.whitespace_ratio`, `misc.declared_not_defined`). Requires correction. | Open — tracked in issue #163 |
+| RR-001-002 | CSC-SYS4-001 | C1 | Minor | §5 execution table contains `<fill at execution>` placeholder entries. Execution evidence should be populated at each release. | Open — tracked in issue #152 |
+| RR-001-003 | CSC-SYS5-001 | C1 | Minor | §5 results table contains placeholder entries (tester, date, commit SHA). | Open — tracked in issue #152 |
+| RR-001-004 | CSC-SWE4-001 | C5 | Observation | §4 describes coverage target as "90% statement coverage"; the CI gate enforces "85% combined statement + branch". The metric label is slightly inconsistent. | Open — tracked in issue #151 |
+| RR-001-005 | CSC-MAN5-001 | C5 | Minor | RISK-003 (solo-developer SPOF) and RISK-005 (AI tool dependency) mitigation descriptions are high-level with no concrete owners or review schedule. | Open — tracked in issue #155 |
+| RR-001-006 | CSC-SUP1-001 | C5 | Minor | QA plan references peer reviews but no formal review template is cited. This review record and `CStyleCheck_Review_Template.md` address this gap. | In progress — issue #169 (this PR) |
+
+---
+
+## 5. Review Summary
+
+| Item | Value |
+|---|---|
+| **Total work products reviewed** | 21 |
+| **Work products with no findings** | 15 |
+| **Work products with findings** | 6 |
+| **Total findings** | 6 |
+| **— Major** | 0 |
+| **— Minor** | 5 |
+| **— Observation** | 1 |
+| **Open actions** | 6 (tracked via GitHub issues) |
+| **Review verdict** | **Conditional Pass** |
+
+**Verdict rationale:**
+
+All 21 ASPICE work products are substantially complete, consistent, and correctly describe the v1.2.1 codebase. No Major findings were identified. The five Minor findings are all known, tracked items with existing GitHub issues; they do not prevent the v1.2.1 release from meeting CL2 requirements. The Observation on coverage metric wording is cosmetic. The review is approved as Conditional Pass pending resolution of the Minor findings in the v1.3.0 cycle.
+
+---
+
+## 6. Sign-off
+
+| Role | Name | Date | Notes |
+|---|---|---|---|
+| Reviewer | Claude (AI-assisted) | 2026-05-29 | *Per CSC-DEV-001 (AI authorship deviation)* |
+| Author / Review Owner | Dermot Murphy | — | *Pending — solo developer, see CSC-DEV-002* |
+
+> **Note (CSC-DEV-002):** CStyleCheck is developed by a solo engineer. The independent peer-review requirement of ASPICE GP 2.2.3 cannot be satisfied by a separate human reviewer in the conventional sense. This review was conducted by the AI tool (Claude) acting in the reviewer role, as formally documented in CSC-DEV-002. The Review Owner signature above constitutes the required management approval of this review record.
+
+---
+
+*Document: CSC-REVIEW-001 · Version 1.0 · 2026-05-29*  
+*Location: `docs/aspice/CStyleCheck_Review_Record_v1.2.md`*  
+*Template: CSC-REVIEW-TEMPLATE-001 v1.0*

--- a/docs/aspice/CStyleCheck_Review_Template.md
+++ b/docs/aspice/CStyleCheck_Review_Template.md
@@ -1,0 +1,139 @@
+# CStyleCheck — ASPICE Peer Review Template
+
+*Template ID: CSC-REVIEW-TEMPLATE-001 · Version 1.0*
+
+> **Instructions for use:**
+> 1. Copy this file to a new document named `CStyleCheck_Review_Record_<version>.md`
+> 2. Fill in all fields in §1–§3 before starting the review
+> 3. Work through the checklist in §4 for each work product
+> 4. Record every finding in §5
+> 5. Complete §6 (summary) and §7 (sign-off) after all items are reviewed
+> 6. Commit the completed record to `docs/aspice/` on the `develop` branch
+
+---
+
+## 1. Review Identification
+
+| Field | Value |
+|---|---|
+| **Review ID** | CSC-REVIEW-`<nnn>` |
+| **Review Type** | Peer Review — Work Product Quality Check |
+| **Review Date** | YYYY-MM-DD |
+| **Reviewer** | `<name>` |
+| **Author / Review Owner** | Dermot Murphy |
+| **Baseline Commit / Tag** | `<git tag or commit SHA>` |
+| **Review Scope** | All ASPICE work products at `<version>` |
+| **Reference Standard** | Automotive SPICE® PAM v4.0 · ASPICE GP 2.2.3 |
+| **Related Documents** | CSC-PA2-001 vX.Y, CSC-DEV-001, CSC-DEV-002 |
+| **Status** | Draft / Under Review / Approved |
+
+---
+
+## 2. Review Scope
+
+List every work product included in this review (drawn from CSC-PA2-001).
+
+| # | Document ID | Title | Version | File Path |
+|---|---|---|---|---|
+| 1 | CSC-SYS2-001 | System Requirements Analysis | x.x | `docs/aspice/CStyleCheck_SYS2_System_Requirements.md` |
+| 2 | CSC-SYS3-001 | System Architecture Design | x.x | `docs/aspice/CStyleCheck_SYS3_System_Architecture.md` |
+| 3 | CSC-SYS4-001 | System Integration Test | x.x | `docs/aspice/CStyleCheck_SYS4_System_Integration_Test.md` |
+| 4 | CSC-SYS5-001 | System Qualification Test | x.x | `docs/aspice/CStyleCheck_SYS5_System_Verification.md` |
+| 5 | CSC-SWE1-001 | Software Requirements Analysis | x.x | `docs/aspice/CStyleCheck_SWE1_SW_Requirements.md` |
+| 6 | CSC-SWE2-001 | Software Architecture Design | x.x | `docs/aspice/CStyleCheck_SWE2_SW_Architecture.md` |
+| 7 | CSC-SWE3-001 | Software Detailed Design | x.x | `docs/aspice/CStyleCheck_SWE3_Detailed_Design.md` |
+| 8 | CSC-SWE4-001 | Software Unit Verification | x.x | `docs/aspice/CStyleCheck_SWE4_Unit_Verification.md` |
+| 9 | CSC-SWE5-001 | Software Integration Test | x.x | `docs/aspice/CStyleCheck_SWE5_Integration_Test.md` |
+| 10 | CSC-SWE6-001 | Software Qualification Test | x.x | `docs/aspice/CStyleCheck_SWE6_Qualification_Test.md` |
+| 11 | CSC-MAN3-001 | Project Management | x.x | `docs/aspice/CStyleCheck_MAN3_Project_Management.md` |
+| 12 | CSC-MAN5-001 | Risk Management | x.x | `docs/aspice/CStyleCheck_MAN5_Risk_Management.md` |
+| 13 | CSC-SUP1-001 | Quality Assurance | x.x | `docs/aspice/CStyleCheck_SUP1_Quality_Assurance.md` |
+| 14 | CSC-SUP8-001 | Configuration Management | x.x | `docs/aspice/CStyleCheck_SUP8_Configuration_Management.md` |
+| 15 | CSC-SUP9-001 | Problem Resolution Management | x.x | `docs/aspice/CStyleCheck_SUP9_Problem_Resolution_Plan.md` |
+| 16 | CSC-SUP10-001 | Change Request Management | x.x | `docs/aspice/CStyleCheck_SUP10_Change_Request_Mgmt.md` |
+| 17 | CSC-ACQ4-001 | Supplier Monitoring | x.x | `docs/aspice/CStyleCheck_ACQ4_Supplier_Monitoring.md` |
+| 18 | CSC-SVD-001 | Software Version Description | x.x | `docs/aspice/CStyleCheck_SVD_Software_Version_Description.md` |
+| 19 | CSC-PA2-001 | Capability Records (PA 2.1/2.2) | x.x | `docs/aspice/CStyleCheck_PA2_Capability_Records.md` |
+| 20 | CSC-DEV-001 | AI Authorship Deviation Record | x.x | `docs/aspice/CStyleCheck_DEV001_AI_Authorship_Deviation.md` |
+| 21 | CSC-DEV-002 | Independent Review Deviation Record | x.x | `docs/aspice/CStyleCheck_DEV002_Independent_Review_Deviation.md` |
+
+---
+
+## 3. Review Criteria
+
+Each work product is assessed against the following dimensions:
+
+| Criterion | Description | Check Method |
+|---|---|---|
+| **C1 — Completeness** | All required sections present; no placeholder text (`<fill …>`, TBD, N/A without explanation) | Read each section |
+| **C2 — Consistency** | Version numbers, rule counts, module names, test counts, and CI targets agree across documents | Cross-check PA2, SWE4, README |
+| **C3 — Traceability** | Requirements trace to design; design traces to tests; tests trace to CI evidence | Check traceability matrices |
+| **C4 — Correctness** | Technical content matches the actual codebase (file paths, module names, rule IDs, test names) | Compare against `src/` and `tests/` |
+| **C5 — Clarity** | Text is unambiguous; definitions are consistent; no contradictions within the document | Read for understanding |
+
+---
+
+## 4. Per-Document Checklist
+
+Repeat this table for each document in §2. Mark each criterion: ✅ Pass · ⚠️ Concern · ❌ Fail · N/A.
+
+### Template Row (copy and fill for each document)
+
+| Criterion | Result | Notes |
+|---|---|---|
+| C1 — Completeness | ✅ / ⚠️ / ❌ | |
+| C2 — Consistency | ✅ / ⚠️ / ❌ | |
+| C3 — Traceability | ✅ / ⚠️ / ❌ | |
+| C4 — Correctness | ✅ / ⚠️ / ❌ | |
+| C5 — Clarity | ✅ / ⚠️ / ❌ | |
+| **Overall** | Pass / Conditional / Fail | |
+
+---
+
+## 5. Findings
+
+Record every deviation from the review criteria.
+
+| Finding ID | Document | Criterion | Severity | Description | Disposition |
+|---|---|---|---|---|---|
+| RR-`<nnn>`-001 | CSC-XXX-001 | Cx | Major / Minor / Observation | `<clear description of the issue>` | Open / Waived / Fixed-before-approval |
+
+**Severity definitions:**
+- **Major** — blocks approval; must be corrected before the work product is approved
+- **Minor** — must be resolved within one release cycle; document may be conditionally approved
+- **Observation** — improvement suggestion; no release impact; recorded for backlog
+
+---
+
+## 6. Review Summary
+
+| Item | Value |
+|---|---|
+| **Total work products reviewed** | `<n>` |
+| **Work products with no findings** | `<n>` |
+| **Work products with findings** | `<n>` |
+| **Total findings** | `<n>` |
+| **— Major** | `<n>` |
+| **— Minor** | `<n>` |
+| **— Observation** | `<n>` |
+| **Open actions** | `<n>` |
+| **Review verdict** | Pass / Conditional Pass / Fail |
+
+**Verdict rationale:**
+
+> `<1–3 sentences summarising the overall quality of the work products and the basis for the verdict.>`
+
+---
+
+## 7. Sign-off
+
+| Role | Name | Date | Notes |
+|---|---|---|---|
+| Reviewer | `<name>` | YYYY-MM-DD | |
+| Author / Review Owner | Dermot Murphy | YYYY-MM-DD | *Solo developer — see CSC-DEV-002 for peer-review constraint* |
+
+> **Note (CSC-DEV-002):** CStyleCheck is developed by a solo engineer. The independent peer-review requirement of ASPICE GP 2.2.3 cannot be satisfied by a separate human reviewer in the conventional sense. This review is conducted by the AI tool (Claude) acting in the reviewer role, as formally documented in CSC-DEV-002. The Review Owner signature above constitutes the required management approval of this review record.
+
+---
+
+*Template: CSC-REVIEW-TEMPLATE-001 · Version 1.0 · 2026-05-29*


### PR DESCRIPTION
## Summary

Adds two new ASPICE documents to `docs/aspice/`:

### 1. `CStyleCheck_Review_Template.md` — CSC-REVIEW-TEMPLATE-001 v1.0

Reusable peer review template containing:
- Review identification header (ID, date, reviewer, baseline)
- 21-row work product scope table drawn from CSC-PA2-001
- 5-criterion checklist table: Completeness · Consistency · Traceability · Correctness · Clarity
- Findings table with Major / Minor / Observation severity definitions
- Review summary verdict block
- Sign-off with CSC-DEV-002 acknowledgement (solo-developer constraint)

### 2. `CStyleCheck_Review_Record_v1.2.md` — CSC-REVIEW-001 v1.0

Populated review of all 21 ASPICE work products at the v1.2.1 baseline:

| Metric | Value |
|--------|-------|
| Work products reviewed | 21 |
| Pass (no findings) | 15 |
| Conditional Pass (findings) | 6 |
| Major findings | 0 |
| Minor findings | 5 |
| Observations | 1 |
| Verdict | **Conditional Pass** |

**Findings summary:**

| ID | Document | Severity | Issue |
|----|----------|----------|-------|
| RR-001-001 | SYS2 rule count 48 ≠ 53 | Minor | #163 |
| RR-001-002 | SYS4 execution table has placeholders | Minor | #152 |
| RR-001-003 | SYS5 results table has placeholders | Minor | #152 |
| RR-001-004 | SWE4 coverage metric label inconsistency | Observation | #151 |
| RR-001-005 | MAN5 risk mitigations high-level | Minor | #155 |
| RR-001-006 | SUP1 no formal review template cited | Minor | #169 (this PR) |

## Test plan

- [x] Template reviewed for ASPICE GP 2.2.3 alignment
- [x] Review record cross-checked against PA2 v1.6 work product list
- [x] All finding IDs reference valid open GitHub issues
- [x] CI passes (documentation-only change)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)