### PR TITLE
Fix 10 bugs, add preprocessor unit tests, and suggest new features

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -634,14 +634,8 @@ class Checker:
             if in_sig:
                 scope  = "parameter"
                 sc     = sc_param
-                # variable.parameter.p_prefix via in_sig path
-                if _pp_param_en:
-                    _p_stripped = self._strip_any_prefix(name)
-                    if not _p_stripped.startswith(_pp_param_pfx):
-                        self._v(m.start(), _pp_param_sev,
-                                "variable.parameter.p_prefix",
-                                f"Parameter '{name}' must start with "
-                                f"'{_pp_param_pfx}' (parameter prefix)")
+                # variable.parameter.p_prefix already emitted by _collect_sig
+                # for every parameter in a signature range — no duplicate here.
             elif depth == 0 and is_static:
                 scope  = "static"
                 sc     = sc_static
@@ -736,7 +730,7 @@ class Checker:
                                 f"Double-pointer variable '{name}' local part "
                                 f"should start with '{pp_pfx}' (BARR-C 7.1.l)")
             elif stars == "*":
-                if ptr_cfg.get("enabled"):
+                if ptr_cfg.get("enabled", True):
                     p_pfx = ptr_cfg.get("prefix", "p_")
                     p_sev = ptr_cfg.get("severity", "warning")
                     if scope == "parameter":
@@ -1032,15 +1026,16 @@ class Checker:
             member_pfx = to_case(raw_base, member_case)
 
             # --- member checks ---
+            body_offset = m.start(1)
             for mm in RE_ENUM_MEMBER.finditer(body_str):
                 mname = mm.group(1)
                 if not matches_case(mname, member_case):
-                    self._v(m.start(), type_sev, "enum.member_case",
+                    self._v(body_offset + mm.start(), type_sev, "enum.member_case",
                             f"Enum member '{mname}' must be {member_case}")
                 if (member_pfx_cfg.get("enabled")
                         and not mname.upper().startswith(
                             member_pfx.upper() + "_")):
-                    self._v(m.start(),
+                    self._v(body_offset + mm.start(),
                             member_pfx_cfg.get("severity", "warning"),
                             "enum.member_prefix",
                             f"Enum member '{mname}' should start with "
@@ -1164,9 +1159,12 @@ class Checker:
         #   '\nvoid'     → ['\n', 'void']         → 0 blanks ✗
         #   '\n\n\ncode' → ['\n','\n','\n','code']→ 2 blanks ✗
         after_lines  = after.splitlines(keepends=True)
-        # [0] is the tail of the */ line itself; skip it.
+        # Skip [0] only when it is the tail fragment of the */ line.
+        # When m.end() lands exactly on a '\n' there is no tail — [0] is
+        # already the first post-header line and must not be discarded.
+        skip = 0 if (m.end() > 0 and source[m.end() - 1] == "\n") else 1
         blank_count  = 0
-        for al in after_lines[1:]:
+        for al in after_lines[skip:]:
             if al.strip():
                 break
             blank_count += 1
@@ -1901,7 +1899,7 @@ class Checker:
         if re.fullmatch(r"'[^']*'", t):                    return True  # char
         if t in {"true", "false", "TRUE", "FALSE",
                  "NULL", "nullptr"}:                       return True  # bool/null
-        if re.fullmatch(r"[A-Z_][A-Z0-9_]+", t):          return True  # ALL_CAPS ≥ 2 chars
+        if re.fullmatch(r"[A-Z][A-Z0-9_]*", t):            return True  # ALL_CAPS ≥ 1 char
         return False
 
     @staticmethod
@@ -2016,9 +2014,8 @@ class Checker:
         sev = tg_cfg.get("severity", "error")
 
         # Check raw source so trigraphs inside comments are also caught.
-        line_map = build_line_map(self.source)
         for m in self._RE_TRIGRAPH.finditer(self.source):
-            line, col = offset_to_line_col(line_map, m.start())
+            line, col = offset_to_line_col(self._line_map, m.start())
             self.result.add(Violation(
                 self.filepath, line, col, sev, "misc.trigraph",
                 f"Trigraph '{m.group(0)}' is forbidden "

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -417,170 +417,167 @@ def main() -> int:
             sys.exit(f"Cannot open log file '{args.log}': {e}")
 
     tee = Tee(log_fh)
+    try:
+        # Discover files lazily — emit progress immediately rather than
+        # blocking until the entire glob tree is walked.
+        files: list = []
+        for _fp in discover_files(
+            args.files,
+            args.include,
+            args.exclude,
+            cfg.get("ignore", {}),
+        ):
+            files.append(_fp)
+            if getattr(args, "verbose", False) and sys.stderr.isatty():
+                _msg = f"Discovering: {_fp}"
+                print(f"{_msg:<79}", end="\r",
+                      file=sys.stderr, flush=True)
 
-    # Discover files
-    # Discover files lazily — emit progress immediately rather than
-    # blocking until the entire glob tree is walked.
-    files: list = []
-    for _fp in discover_files(
-        args.files,
-        args.include,
-        args.exclude,
-        cfg.get("ignore", {}),
-    ):
-        files.append(_fp)
-        if getattr(args, "verbose", False) and sys.stderr.isatty():
-            _msg = f"Discovering: {_fp}"
-            print(f"{_msg:<79}", end="\r",
-                  file=sys.stderr, flush=True)
+        if not files:
+            print("No C files to check.", file=sys.stderr)
+            return 0
 
-    if not files:
-        print("No C files to check.", file=sys.stderr)
-        tee.close()
-        return 0
-
-    if getattr(args, "verbose", False):
-        _n = len(files)
-        _msg = f"Found {_n} file(s) - starting analysis..."
-        print(f"{_msg:<79}", file=sys.stderr, flush=True)
-
-    output_format  = getattr(args, "output_format", "text")
-    all_violations: list = []
-    # Cache source text keyed by filepath to avoid reading each file twice
-    # (once for Checker, once for SignChecker).
-    source_cache: dict = {}
-
-    for filepath in files:
         if getattr(args, "verbose", False):
-            _msg = f"Scanning: {filepath}"
-            if sys.stderr.isatty():
-                print(f"{_msg:<79}", end="\r", file=sys.stderr, flush=True)
-            else:
-                print(_msg, file=sys.stderr, flush=True)
-        try:
-            source = Path(filepath).read_text(encoding="utf-8", errors="replace")
-            source_cache[filepath] = source
-        except OSError as e:
-            tee.print(f"ERROR: Cannot read {filepath}: {e}")
-            continue
+            _n = len(files)
+            _msg = f"Found {_n} file(s) - starting analysis..."
+            print(f"{_msg:<79}", file=sys.stderr, flush=True)
 
-        # Build accepted prefix list for this file (canonical + aliases)
-        mod   = module_name(filepath)
-        sep   = _cfg(cfg, "file_prefix", "separator", default="_")
-        case  = _cfg(cfg, "file_prefix", "case", default="lower")
-        canon = (mod.upper() if case == "upper" else mod.lower()) + sep
-        alias_pfxs = [canon] + [
-            a.lower() + sep for a in alias_map.get(mod.lower(), [])
-        ]
+        output_format  = getattr(args, "output_format", "text")
+        all_violations: list = []
+        # Cache source text keyed by filepath to avoid reading each file twice
+        # (once for Checker, once for SignChecker).
+        source_cache: dict = {}
 
-        # Collect disabled rules for this specific file
-        _file_disabled, _ident_disabled = _disabled_rules_for_file(filepath, exclusions_map)
-
-        checker = Checker(
-            filepath, source, cfg,
-            spell_words=spell_words,
-            alias_prefixes=alias_pfxs,
-            disabled_rules=_file_disabled,
-            ident_disabled_rules=_ident_disabled,
-            defines=defines,
-            extra_banned=extra_banned,
-            copyright_header=copyright_header,
-            c_keywords=keywords_set,
-            c_stdlib_names=stdlib_set,
-        )
-        result  = checker.run_all()
-        all_violations.extend(result.violations)
-
-        if output_format == "text":
-            for v in sorted(result.violations, key=lambda x: (x.line, x.col)):
-                if args.github_actions:
-                    tee.print(v.github_annotation())
-                else:
-                    tee.print(v)
-
-    if getattr(args, "verbose", False) and sys.stderr.isatty():
-        print(" " * 80, end="\r",
-              file=sys.stderr)  # erase last progress line
-    # Cross-file sign-compatibility check (needs all files ingested first).
-    # Uses the source cache so no file is read from disk a second time.
-    sign_cfg = cfg.get("sign_compatibility", {})
-    if sign_cfg.get("enabled", True):
-        sc = SignChecker(cfg)
         for filepath in files:
-            src = source_cache.get(filepath)
-            if src is not None:
-                sc.ingest(filepath, src)
-        sign_violations = sc.check()
-        all_violations.extend(sign_violations)
-        if output_format == "text":
-            for v in sorted(sign_violations, key=lambda x: (x.filepath, x.line, x.col)):
-                if args.github_actions:
-                    tee.print(v.github_annotation())
+            if getattr(args, "verbose", False):
+                _msg = f"Scanning: {filepath}"
+                if sys.stderr.isatty():
+                    print(f"{_msg:<79}", end="\r", file=sys.stderr, flush=True)
                 else:
-                    tee.print(v)
+                    print(_msg, file=sys.stderr, flush=True)
+            try:
+                source = Path(filepath).read_text(encoding="utf-8", errors="replace")
+                source_cache[filepath] = source
+            except OSError as e:
+                tee.print(f"ERROR: Cannot read {filepath}: {e}")
+                continue
 
-    # Cross-file declared-but-not-defined check (needs all files ingested first).
-    dnd_cfg = cfg.get("misc", {}).get("declared_not_defined", {})
-    if dnd_cfg.get("enabled", False):
-        dndc = DeclaredNotDefinedChecker(cfg, defines=defines)
-        for filepath in files:
-            src = source_cache.get(filepath)
-            if src is not None:
-                dndc.ingest(filepath, src)
-        dnd_violations = dndc.check()
-        all_violations.extend(dnd_violations)
-        if output_format == "text":
-            for v in sorted(dnd_violations, key=lambda x: (x.filepath, x.line, x.col)):
-                if args.github_actions:
-                    tee.print(v.github_annotation())
-                else:
-                    tee.print(v)
+            # Build accepted prefix list for this file (canonical + aliases)
+            mod   = module_name(filepath)
+            sep   = _cfg(cfg, "file_prefix", "separator", default="_")
+            case  = _cfg(cfg, "file_prefix", "case", default="lower")
+            canon = (mod.upper() if case == "upper" else mod.lower()) + sep
+            alias_pfxs = [canon] + [
+                a.lower() + sep for a in alias_map.get(mod.lower(), [])
+            ]
 
-    # --write-baseline: dump all violations and exit 0 (no further checks).
-    if getattr(args, "write_baseline", None):
-        write_baseline(all_violations, args.write_baseline)
-        tee.print(f"Baseline written to '{args.write_baseline}' "
-                  f"({len(all_violations)} violation(s)).")
+            # Collect disabled rules for this specific file
+            _file_disabled, _ident_disabled = _disabled_rules_for_file(filepath, exclusions_map)
+
+            checker = Checker(
+                filepath, source, cfg,
+                spell_words=spell_words,
+                alias_prefixes=alias_pfxs,
+                disabled_rules=_file_disabled,
+                ident_disabled_rules=_ident_disabled,
+                defines=defines,
+                extra_banned=extra_banned,
+                copyright_header=copyright_header,
+                c_keywords=keywords_set,
+                c_stdlib_names=stdlib_set,
+            )
+            result  = checker.run_all()
+            all_violations.extend(result.violations)
+
+            if output_format == "text":
+                for v in sorted(result.violations, key=lambda x: (x.line, x.col)):
+                    if args.github_actions:
+                        tee.print(v.github_annotation())
+                    else:
+                        tee.print(v)
+
+        if getattr(args, "verbose", False) and sys.stderr.isatty():
+            print(" " * 80, end="\r",
+                  file=sys.stderr)  # erase last progress line
+        # Cross-file sign-compatibility check (needs all files ingested first).
+        # Uses the source cache so no file is read from disk a second time.
+        sign_cfg = cfg.get("sign_compatibility", {})
+        if sign_cfg.get("enabled", True):
+            sc = SignChecker(cfg)
+            for filepath in files:
+                src = source_cache.get(filepath)
+                if src is not None:
+                    sc.ingest(filepath, src)
+            sign_violations = sc.check()
+            all_violations.extend(sign_violations)
+            if output_format == "text":
+                for v in sorted(sign_violations, key=lambda x: (x.filepath, x.line, x.col)):
+                    if args.github_actions:
+                        tee.print(v.github_annotation())
+                    else:
+                        tee.print(v)
+
+        # Cross-file declared-but-not-defined check (needs all files ingested first).
+        dnd_cfg = cfg.get("misc", {}).get("declared_not_defined", {})
+        if dnd_cfg.get("enabled", False):
+            dndc = DeclaredNotDefinedChecker(cfg, defines=defines)
+            for filepath in files:
+                src = source_cache.get(filepath)
+                if src is not None:
+                    dndc.ingest(filepath, src)
+            dnd_violations = dndc.check()
+            all_violations.extend(dnd_violations)
+            if output_format == "text":
+                for v in sorted(dnd_violations, key=lambda x: (x.filepath, x.line, x.col)):
+                    if args.github_actions:
+                        tee.print(v.github_annotation())
+                    else:
+                        tee.print(v)
+
+        # --write-baseline: dump all violations and exit 0 (no further checks).
+        if getattr(args, "write_baseline", None):
+            write_baseline(all_violations, args.write_baseline)
+            tee.print(f"Baseline written to '{args.write_baseline}' "
+                      f"({len(all_violations)} violation(s)).")
+            return 0
+
+        # --baseline-file: suppress violations that match the saved baseline.
+        if getattr(args, "baseline_file", None):
+            baseline = load_baseline(args.baseline_file)
+            before   = len(all_violations)
+            all_violations = [
+                v for v in all_violations
+                if _baseline_key(v) not in baseline
+            ]
+            suppressed = before - len(all_violations)
+            if suppressed and output_format == "text":
+                tee.print(f"(Baseline suppressed {suppressed} known violation(s))")
+
+        # --warnings-as-errors: promote every warning and info to error.
+        # We do this AFTER collecting and printing all violations so that the
+        # original severity is visible in the output, but the summary and exit
+        # code reflect the promoted level.
+        if getattr(args, "warnings_as_errors", False):
+            for v in all_violations:
+                if v.severity in ("warning", "info"):
+                    v.severity = "error"
+
+        # --output-format json / sarif: emit structured output to stdout or --log.
+        if output_format == "json":
+            json_text = _violations_to_json(all_violations, len(files))
+            tee.print(json_text)
+        elif output_format == "sarif":
+            sarif_text = _violations_to_sarif(all_violations, _VERSION)
+            tee.print(sarif_text)
+
+        if args.summary and output_format == "text":
+            print_summary(all_violations, len(files), tee)
+
+        if args.exit_zero:
+            return 0
+        return 1 if any(v.severity == "error" for v in all_violations) else 0
+    finally:
         tee.close()
-        return 0
-
-    # --baseline-file: suppress violations that match the saved baseline.
-    if getattr(args, "baseline_file", None):
-        baseline = load_baseline(args.baseline_file)
-        before   = len(all_violations)
-        all_violations = [
-            v for v in all_violations
-            if _baseline_key(v) not in baseline
-        ]
-        suppressed = before - len(all_violations)
-        if suppressed and output_format == "text":
-            tee.print(f"(Baseline suppressed {suppressed} known violation(s))")
-
-    # --warnings-as-errors: promote every warning and info to error.
-    # We do this AFTER collecting and printing all violations so that the
-    # original severity is visible in the output, but the summary and exit
-    # code reflect the promoted level.
-    if getattr(args, "warnings_as_errors", False):
-        for v in all_violations:
-            if v.severity in ("warning", "info"):
-                v.severity = "error"
-
-    # --output-format json / sarif: emit structured output to stdout or --log.
-    if output_format == "json":
-        json_text = _violations_to_json(all_violations, len(files))
-        tee.print(json_text)
-    elif output_format == "sarif":
-        sarif_text = _violations_to_sarif(all_violations, _VERSION)
-        tee.print(sarif_text)
-
-    if args.summary and output_format == "text":
-        print_summary(all_violations, len(files), tee)
-
-    tee.close()
-
-    if args.exit_zero:
-        return 0
-    return 1 if any(v.severity == "error" for v in all_violations) else 0
 
 
 if __name__ == "__main__":

--- a/src/cstylecheck/preprocessor.py
+++ b/src/cstylecheck/preprocessor.py
@@ -97,9 +97,12 @@ def _build_brace_depths(clean: str) -> list:
     for ch in clean:
         if ch == "{":
             depth += 1
+            depths.append(depth)
         elif ch == "}":
+            depths.append(depth)
             depth = max(0, depth - 1)
-        depths.append(depth)
+        else:
+            depths.append(depth)
     return depths
 
 

--- a/src/cstylecheck/sign_checker.py
+++ b/src/cstylecheck/sign_checker.py
@@ -59,7 +59,7 @@ _RE_ONE_PARAM = re.compile(
 )
 
 _RE_CALL       = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
-_RE_UINT_LIT   = re.compile(r"^\s*(?:0[xX][0-9A-Fa-f]+|[0-9]+)[uU][lL]?\s*$")
+_RE_UINT_LIT   = re.compile(r"^\s*(?:0[xX][0-9A-Fa-f]+|[0-9]+)[uU][lL]{0,2}\s*$")
 _RE_NEG_LIT    = re.compile(r"^\s*-\s*[0-9]+\s*$")
 _RE_PLAIN_INT  = re.compile(r"^\s*(?:0[xX][0-9A-Fa-f]+|[0-9]+)[lL]?\s*$")
 _RE_CHAR_LIT   = re.compile(r"^\s*'[^']*'\s*$")
@@ -234,7 +234,7 @@ class SignChecker:
             r"(?:(?:extern|static|inline|const|volatile)[ \t]+)*"
             r"(?:(?:unsigned|signed)[ \t]+)?"
             r"(?:(?:long[ \t]+long|long|short)[ \t]+)?"
-            r"\w+[ \t]*\*?[ \t]*"
+            r"\w+[ \t]*\**[ \t]*"
             r"([A-Za-z_]\w*)"
             r"[ \t]*\(([^)]*)\)"
             r"[ \t]*;",

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -364,17 +364,22 @@ class TestBuildBraceDepths(unittest.TestCase):
         self.assertEqual(depths[0], 1)
 
     def test_depth_after_close_brace(self):
-        src = "{}"
+        # The '}' character records the depth of the scope it closes (pre-decrement).
+        # Depth at positions AFTER '}' correctly reflects the outer scope.
+        src = "{} "
         depths = _build_brace_depths(src)
-        self.assertEqual(depths[0], 1)
-        self.assertEqual(depths[1], 0)
+        self.assertEqual(depths[0], 1)  # '{' — inner scope
+        self.assertEqual(depths[1], 1)  # '}' — still inner (closes the scope)
+        self.assertEqual(depths[2], 0)  # space after '}' — outer scope
 
     def test_nested_braces(self):
-        src = "{{}"
+        # '}' records the depth of the scope it closes (pre-decrement).
+        src = "{{} "
         depths = _build_brace_depths(src)
-        self.assertEqual(depths[0], 1)
-        self.assertEqual(depths[1], 2)
-        self.assertEqual(depths[2], 1)
+        self.assertEqual(depths[0], 1)  # outer '{'
+        self.assertEqual(depths[1], 2)  # inner '{'
+        self.assertEqual(depths[2], 2)  # '}' closes depth-2 scope
+        self.assertEqual(depths[3], 1)  # space — back to outer scope
 
     def test_depth_never_negative(self):
         src = "}} int x;"
@@ -389,12 +394,14 @@ class TestBuildBraceDepths(unittest.TestCase):
     def test_function_body(self):
         src = "void f(void) {\n    int x;\n}\n"
         depths = _build_brace_depths(src)
-        open_idx = src.index("{")
+        open_idx  = src.index("{")
         close_idx = src.index("}")
-        # Character at { position should be depth 1
+        # '{' records the depth of the scope it opens (post-increment → 1)
         self.assertEqual(depths[open_idx], 1)
-        # Character at } position should be depth 0
-        self.assertEqual(depths[close_idx], 0)
+        # '}' records the depth of the scope it closes (pre-decrement → 1)
+        self.assertEqual(depths[close_idx], 1)
+        # characters after '}' are back at outer scope (0)
+        self.assertEqual(depths[close_idx + 1], 0)
 
     def test_empty_source(self):
         self.assertEqual(_build_brace_depths(""), [])

--- a/tests/test_yoda_condition.py
+++ b/tests/test_yoda_condition.py
@@ -104,9 +104,9 @@ class TestYodaNotChecked(unittest.TestCase):
     def test_ge_not_checked(self):
         self.assertFalse(has("void f(void){ if (val >= MIN_VAL) {} }", YODA_CFG, RULE))
 
-    def test_single_uppercase_not_a_macro(self):
-        """A single uppercase letter is not treated as an ALL_CAPS constant."""
-        self.assertFalse(has("void f(void){ if (x == A) {} }", YODA_CFG, RULE))
+    def test_single_uppercase_is_a_macro(self):
+        """A single uppercase letter is treated as an ALL_CAPS constant (e.g. #define N 10)."""
+        self.assertTrue(has("void f(void){ if (x == A) {} }", YODA_CFG, RULE))
 
 
 class TestYodaExemptContexts(unittest.TestCase):


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR covers three areas of work driven by a full code-review and coverage-analysis session:

1. **New tests** — 76 direct unit tests for `preprocessor.py` (previously zero coverage)
2. **10 bug fixes** — correctness, silent-skip, and resource-leak bugs found during review
3. **7 feature issues filed** — #188–#194 (inline suppression, `--fix`, `--init`, watch mode, HTML report, per-dir config, LSP)

---

## 1. Test coverage — `tests/test_preprocessor.py` (76 tests)

`preprocessor.py` is foundational — every rule check runs on its output — but had no direct tests. Added full coverage for all 8 functions:

| Class | Function |
|---|---|
| `TestStripComments` | `strip_comments` |
| `TestStripStrings` | `strip_strings` |
| `TestPreprocess` | `preprocess` |
| `TestCommentOnlyLines` | `_comment_only_lines` |
| `TestExtractComments` | `extract_comments` |
| `TestBuildBraceDepths` | `_build_brace_depths` |
| `TestBuildLineMap` | `build_line_map` |
| `TestOffsetToLineCol` | `offset_to_line_col` |

---

## 2. Bug fixes

| Issue | File | Fix |
|---|---|---|
| [#178](https://github.com/dermot-murphy/CStyleCheck/issues/178) | `checker.py` | Enum member violations reported at typedef line — fixed to use `body_offset + mm.start()` |
| [#179](https://github.com/dermot-murphy/CStyleCheck/issues/179) | `checker.py` | `pointer_prefix` silently skipped when `enabled` key absent — added missing default `True` |
| [#180](https://github.com/dermot-murphy/CStyleCheck/issues/180) | `sign_checker.py` | `ULL`/`ull` suffixes not matched — `[uU][lL]?` → `[uU][lL]{0,2}` |
| [#181](https://github.com/dermot-murphy/CStyleCheck/issues/181) | `sign_checker.py` | Double-pointer return types skipped — `\*?` → `\**` in declaration pattern |
| [#182](https://github.com/dermot-murphy/CStyleCheck/issues/182) | `checker.py` | Single-letter ALL-CAPS macros (`N`, `A`) missed in yoda check — `[A-Z_][A-Z0-9_]+` → `[A-Z][A-Z0-9_]*` |
| [#183](https://github.com/dermot-murphy/CStyleCheck/issues/183) | `checker.py` | False-positive "no blank line after copyright" when header ends on newline boundary |
| [#184](https://github.com/dermot-murphy/CStyleCheck/issues/184) | `checker.py` | `variable.parameter.p_prefix` emitted twice for same parameter — removed duplicate from `in_sig` branch |
| [#185](https://github.com/dermot-murphy/CStyleCheck/issues/185) | `preprocessor.py` | `_build_brace_depths` asymmetry at `}` boundaries — `}` now records pre-decrement depth |
| [#186](https://github.com/dermot-murphy/CStyleCheck/issues/186) | `cli.py` | Log file handle leaked on unexpected exception — wrapped `main()` body in `try/finally: tee.close()` |
| [#187](https://github.com/dermot-murphy/CStyleCheck/issues/187) | `checker.py` | `_check_trigraphs` called `build_line_map()` redundantly — now uses `self._line_map` |

Also fixed `.gitignore` to suppress `__pycache__/` at all nesting levels.

---

## Test plan

- [ ] `python -m pytest tests/ -q` — all 965 tests pass
- [ ] Manually verify enum member violations point to the correct line in a multi-member enum
- [ ] Verify `pointer_prefix` rule fires when `enabled` key is omitted from config
- [ ] Verify `0xFFFFFFFFULL` is correctly classified as `SIGN_UNSIGNED` by the sign checker
- [ ] Verify `if (x == N)` is flagged as a yoda condition

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_