### PR TITLE
feat(fix): --fix mode for safe mechanical corrections (#189)

### DIFF
--- a/src/cstylecheck/__init__.py
+++ b/src/cstylecheck/__init__.py
@@ -139,6 +139,13 @@ from .output import (                    # noqa: F401, E402
     print_summary,
 )
 
+from .fixer import (                     # noqa: F401, E402
+    apply_fixes,
+    unified_diff,
+    FIXABLE_RULES,
+    SAFE_RULES,
+)
+
 from .cli import (                       # noqa: F401, E402
     discover_files,
     _path_matches_exclude,

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -24,6 +24,7 @@ from .config import (
     update_config,
     C_KEYWORDS, C_STDLIB_NAMES,
 )
+from .fixer import apply_fixes, unified_diff, FIXABLE_RULES, SAFE_RULES
 from .utils import module_name, _cfg
 from .checker import Checker
 from .sign_checker import SignChecker, DeclaredNotDefinedChecker
@@ -309,6 +310,22 @@ def _build_parser() -> argparse.ArgumentParser:
                         "default values.  Exits 0 on success.  "
                         "NOTE: YAML comments are not preserved — keep the "
                         "original file in version control before running.")
+
+    fix_group = p.add_argument_group("auto-fix")
+    fix_group.add_argument(
+        "--fix", action="store_true",
+        help="Automatically apply safe, mechanical fixes to source files in-place. "
+             f"Fixable rules: {', '.join(sorted(FIXABLE_RULES))}. "
+             "Use --dry-run to preview changes without writing files.")
+    fix_group.add_argument(
+        "--dry-run", action="store_true",
+        help="With --fix: print a unified diff of what would change without "
+             "modifying any files.")
+    fix_group.add_argument(
+        "--safe-only", action="store_true",
+        help=f"With --fix: apply only zero-risk fixes "
+             f"({', '.join(sorted(SAFE_RULES))}). "
+             "Implied by default; all current fixes are safe.")
     return p
 
 
@@ -533,6 +550,38 @@ def main() -> int:
                         tee.print(v.github_annotation())
                     else:
                         tee.print(v)
+
+        # --fix / --dry-run: apply mechanical fixes to source files.
+        if getattr(args, "fix", False):
+            safe_only = getattr(args, "safe_only", False)
+            dry_run   = getattr(args, "dry_run", False)
+            total_fixed = 0
+            for filepath in files:
+                original = source_cache.get(filepath)
+                if original is None:
+                    continue
+                file_violations = [
+                    v for v in all_violations if v.filepath == filepath
+                ]
+                fixed, count = apply_fixes(original, file_violations,
+                                           safe_only=safe_only)
+                if fixed == original:
+                    continue
+                if dry_run:
+                    diff_text = unified_diff(original, fixed, filepath)
+                    if diff_text:
+                        tee.print(diff_text)
+                else:
+                    try:
+                        Path(filepath).write_text(fixed, encoding="utf-8")
+                        tee.print(f"Fixed {count} issue(s) in {filepath}")
+                    except OSError as exc:
+                        tee.print(f"ERROR: Cannot write {filepath}: {exc}")
+                total_fixed += count
+            if total_fixed and not dry_run:
+                tee.print(f"Total: {total_fixed} fix(es) applied.")
+            elif dry_run and not total_fixed:
+                tee.print("No fixable violations found.")
 
         # --write-baseline: dump all violations and exit 0 (no further checks).
         if getattr(args, "write_baseline", None):

--- a/src/cstylecheck/fixer.py
+++ b/src/cstylecheck/fixer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import difflib
 import re
-from typing import Callable
+from typing import Optional
 
 from .models import Violation
 
@@ -39,7 +39,7 @@ def _line_col_to_offset(source: str, line: int, col: int) -> int:
     return offset + col - 1
 
 
-def _fix_unsigned_suffix(source: str, v: Violation) -> tuple[int, str, str]:
+def _fix_unsigned_suffix(source: str, v: Violation) -> Optional[tuple]:
     """Return (offset, old_text, new_text) for unsigned suffix fix."""
     m = _RE_EXTRACT_QUOTED.search(v.message)
     if not m:
@@ -63,7 +63,7 @@ def _fix_unsigned_suffix(source: str, v: Violation) -> tuple[int, str, str]:
     return (offset, old_text, new_text)
 
 
-def _fix_lowercase_l_suffix(source: str, v: Violation) -> tuple[int, str, str]:
+def _fix_lowercase_l_suffix(source: str, v: Violation) -> Optional[tuple]:
     """Return (offset, old_text, new_text) for lowercase-l suffix fix."""
     m = _RE_EXTRACT_QUOTED.search(v.message)
     if not m:
@@ -90,7 +90,7 @@ def _fix_lowercase_l_suffix(source: str, v: Violation) -> tuple[int, str, str]:
 
 # Maps rule_id → (fix_fn, is_safe)
 # is_safe=True means applied by both --fix and --fix --safe-only
-_FIXERS: dict[str, tuple[Callable, bool]] = {
+_FIXERS: dict = {
     "misc.unsigned_suffix":    (_fix_unsigned_suffix,    True),
     "misc.lowercase_l_suffix": (_fix_lowercase_l_suffix, True),
 }

--- a/src/cstylecheck/fixer.py
+++ b/src/cstylecheck/fixer.py
@@ -1,0 +1,160 @@
+"""
+fixer.py — Auto-fix engine for CStyleCheck.
+
+Applies safe, mechanical source-text corrections for rules that have a
+single unambiguous fix.  Works on raw source strings to preserve comments
+and formatting; only modifies the specific bytes that constitute the
+offending literal.
+
+Safe fixes (--safe-only and --fix):
+    misc.unsigned_suffix    — append 'U' to bare integer constant
+    misc.lowercase_l_suffix — replace lowercase 'l' with 'L' in suffix
+
+All fixes are applied in reverse-offset order so earlier fixes do not
+shift the positions of later ones.
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from typing import Callable
+
+from .models import Violation
+
+
+# ---------------------------------------------------------------------------
+# Individual fix functions
+# Each receives (source: str, v: Violation) and returns the corrected source.
+# They may return the original source unchanged if the fix cannot be applied.
+# ---------------------------------------------------------------------------
+
+_RE_INT_LITERAL = re.compile(r"\b(\d+)([uUlL]*)\b")
+_RE_EXTRACT_QUOTED = re.compile(r"'([^']+)'")
+
+
+def _line_col_to_offset(source: str, line: int, col: int) -> int:
+    """Convert 1-based (line, col) to 0-based character offset."""
+    lines = source.splitlines(keepends=True)
+    offset = sum(len(lines[i]) for i in range(line - 1))
+    return offset + col - 1
+
+
+def _fix_unsigned_suffix(source: str, v: Violation) -> tuple[int, str, str]:
+    """Return (offset, old_text, new_text) for unsigned suffix fix."""
+    m = _RE_EXTRACT_QUOTED.search(v.message)
+    if not m:
+        return None
+    literal = m.group(1)
+    offset = _line_col_to_offset(source, v.line, v.col)
+    # Verify the literal is actually at this offset
+    snippet = source[offset: offset + len(literal) + 4]
+    lm = re.match(r"(\d+)([uUlLfF]*)", snippet)
+    if not lm:
+        return None
+    digits = lm.group(1)
+    suffix = lm.group(2)
+    old_text = digits + suffix
+    new_text = digits + suffix.upper() + ("U" if "u" not in suffix.lower() else "")
+    # Simplify: just append U if not already present
+    if "u" not in suffix.lower():
+        new_text = digits + suffix + "U"
+    else:
+        new_text = digits + suffix.upper()
+    return (offset, old_text, new_text)
+
+
+def _fix_lowercase_l_suffix(source: str, v: Violation) -> tuple[int, str, str]:
+    """Return (offset, old_text, new_text) for lowercase-l suffix fix."""
+    m = _RE_EXTRACT_QUOTED.search(v.message)
+    if not m:
+        return None
+    literal = m.group(1)
+    offset = _line_col_to_offset(source, v.line, v.col)
+    snippet = source[offset: offset + len(literal) + 4]
+    lm = re.match(r"(\d+)([uUlLfF]+)", snippet)
+    if not lm:
+        return None
+    digits = lm.group(1)
+    suffix = lm.group(2)
+    new_suffix = suffix.replace("l", "L")
+    if new_suffix == suffix:
+        return None
+    old_text = digits + suffix
+    new_text = digits + new_suffix
+    return (offset, old_text, new_text)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+# Maps rule_id → (fix_fn, is_safe)
+# is_safe=True means applied by both --fix and --fix --safe-only
+_FIXERS: dict[str, tuple[Callable, bool]] = {
+    "misc.unsigned_suffix":    (_fix_unsigned_suffix,    True),
+    "misc.lowercase_l_suffix": (_fix_lowercase_l_suffix, True),
+}
+
+FIXABLE_RULES: frozenset = frozenset(_FIXERS)
+SAFE_RULES: frozenset = frozenset(r for r, (_, safe) in _FIXERS.items() if safe)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def apply_fixes(
+    source: str,
+    violations: list,
+    safe_only: bool = False,
+) -> tuple[str, int]:
+    """Apply fixes for all fixable violations to *source*.
+
+    Returns ``(new_source, fix_count)``.  Fixes are applied in
+    reverse-offset order so earlier positions are not shifted.
+    """
+    allowed = SAFE_RULES if safe_only else FIXABLE_RULES
+    edits: list[tuple[int, str, str]] = []
+
+    for v in violations:
+        if v.rule not in allowed:
+            continue
+        fix_fn, _ = _FIXERS[v.rule]
+        edit = fix_fn(source, v)
+        if edit is not None:
+            edits.append(edit)
+
+    if not edits:
+        return source, 0
+
+    # Deduplicate by offset (same offset may appear from multiple violations)
+    seen_offsets: set = set()
+    unique_edits = []
+    for offset, old_text, new_text in edits:
+        if offset not in seen_offsets:
+            seen_offsets.add(offset)
+            unique_edits.append((offset, old_text, new_text))
+
+    # Sort descending by offset so later edits don't affect earlier positions
+    unique_edits.sort(key=lambda e: e[0], reverse=True)
+
+    result = source
+    applied = 0
+    for offset, old_text, new_text in unique_edits:
+        if result[offset: offset + len(old_text)] == old_text:
+            result = result[:offset] + new_text + result[offset + len(old_text):]
+            applied += 1
+
+    return result, applied
+
+
+def unified_diff(original: str, fixed: str, filepath: str) -> str:
+    """Return a unified diff string between *original* and *fixed*."""
+    orig_lines = original.splitlines(keepends=True)
+    fixed_lines = fixed.splitlines(keepends=True)
+    diff = difflib.unified_diff(
+        orig_lines, fixed_lines,
+        fromfile=f"a/{filepath}",
+        tofile=f"b/{filepath}",
+    )
+    return "".join(diff)

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -32,6 +32,8 @@ _load_dict_file             = _mod._load_dict_file
 SignChecker                 = _mod.SignChecker
 DeclaredNotDefinedChecker   = _mod.DeclaredNotDefinedChecker
 parse_inline_suppressions   = _mod.parse_inline_suppressions
+apply_fixes                 = _mod.apply_fixes
+unified_diff                = _mod.unified_diff
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fix_mode.py
+++ b/tests/test_fix_mode.py
@@ -1,0 +1,141 @@
+"""test_fix_mode.py — Tests for --fix mode (issue #189).
+
+Covers apply_fixes(), unified_diff(), and end-to-end CLI --fix / --dry-run.
+"""
+import sys
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from harness import apply_fixes, unified_diff, cfg_only, run  # noqa: E402
+
+_HERE   = Path(__file__).resolve().parent
+_SRC    = _HERE.parent / "src"
+_CHECKER = str(_SRC / "cstylecheck.py")
+_YAML   = str(_HERE / "rules.yml") if (_HERE / "rules.yml").exists() \
+          else str(_SRC / "rules.yml")
+
+
+def _cli(*args, content=None, filename="test.c"):
+    """Write *content* to a temp file, run the CLI, return (rc, output)."""
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / filename
+        if content:
+            p.write_text(content)
+        cmd = [sys.executable, _CHECKER, "--config", _YAML, *args]
+        if content:
+            cmd.append(str(p))
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        fixed_text = p.read_text() if content else None
+    return r.returncode, r.stdout + r.stderr, fixed_text
+
+
+_US_CFG = cfg_only(misc={
+    "unsigned_suffix": {
+        "enabled": True, "severity": "info",
+        "require_on_unsigned_constants": True,
+    },
+})
+
+_LL_CFG = cfg_only(misc={
+    "lowercase_l_suffix": {"enabled": True, "severity": "error"},
+})
+
+
+# ---------------------------------------------------------------------------
+class TestApplyFixes(unittest.TestCase):
+
+    def test_unsigned_suffix_appends_U(self):
+        src = "uint8_t uart_Init(void) { uint8_t uart_x = 42; return uart_x; }\n"
+        violations = run(src, _US_CFG, filepath="uart.c")
+        us_violations = [v for v in violations if v.rule == "misc.unsigned_suffix"]
+        self.assertGreater(len(us_violations), 0)
+        fixed, count = apply_fixes(src, us_violations)
+        self.assertIn("42U", fixed)
+        self.assertNotIn(" 42;", fixed)
+        self.assertEqual(count, len(us_violations))
+
+    def test_lowercase_l_suffix_uppercased(self):
+        src = "long uart_Init(void) { long uart_x = 100l; return uart_x; }\n"
+        violations = run(src, _LL_CFG, filepath="uart.c")
+        ll_violations = [v for v in violations if v.rule == "misc.lowercase_l_suffix"]
+        self.assertGreater(len(ll_violations), 0)
+        fixed, count = apply_fixes(src, ll_violations)
+        self.assertIn("100L", fixed)
+        self.assertNotIn("100l", fixed)
+        self.assertEqual(count, len(ll_violations))
+
+    def test_no_fixable_violations_returns_unchanged(self):
+        src = "uint8_t uart_Init(void) { return 0U; }\n"
+        fixed, count = apply_fixes(src, [])
+        self.assertEqual(fixed, src)
+        self.assertEqual(count, 0)
+
+    def test_safe_only_applies_only_safe_fixes(self):
+        src = "uint8_t uart_Init(void) { uint8_t uart_x = 42; return uart_x; }\n"
+        violations = run(src, _US_CFG, filepath="uart.c")
+        fixed, count = apply_fixes(src, violations, safe_only=True)
+        # unsigned_suffix is a safe fix — should still be applied
+        self.assertIn("42U", fixed)
+
+    def test_multiple_literals_all_fixed(self):
+        src = "uint8_t uart_Init(void) { uint8_t uart_x = 10; uint8_t uart_y = 20; return uart_x; }\n"
+        violations = run(src, _US_CFG, filepath="uart.c")
+        us_violations = [v for v in violations if v.rule == "misc.unsigned_suffix"]
+        fixed, count = apply_fixes(src, us_violations)
+        self.assertIn("10U", fixed)
+        self.assertIn("20U", fixed)
+
+
+# ---------------------------------------------------------------------------
+class TestUnifiedDiff(unittest.TestCase):
+
+    def test_diff_shows_change(self):
+        original = "int x = 42;\n"
+        fixed    = "int x = 42U;\n"
+        diff = unified_diff(original, fixed, "test.c")
+        self.assertIn("-int x = 42;", diff)
+        self.assertIn("+int x = 42U;", diff)
+
+    def test_no_change_produces_empty_diff(self):
+        src = "int x = 42U;\n"
+        diff = unified_diff(src, src, "test.c")
+        self.assertEqual(diff, "")
+
+
+# ---------------------------------------------------------------------------
+class TestCLIFixMode(unittest.TestCase):
+
+    def test_fix_rewrites_file(self):
+        src = "long uart_Init(void) { long uart_x = 100l; return uart_x; }\n"
+        rc, out, fixed_text = _cli("--fix", content=src)
+        self.assertIn("100L", fixed_text)
+        self.assertNotIn("100l", fixed_text)
+
+    def test_dry_run_does_not_rewrite(self):
+        src = "long uart_Init(void) { long uart_x = 100l; return uart_x; }\n"
+        rc, out, fixed_text = _cli("--fix", "--dry-run", content=src)
+        # File should be UNCHANGED
+        self.assertIn("100l", fixed_text)
+        # But the diff should be in output
+        self.assertIn("-", out)
+
+    def test_dry_run_shows_diff(self):
+        src = "long uart_Init(void) { long uart_x = 100l; return uart_x; }\n"
+        rc, out, _ = _cli("--fix", "--dry-run", content=src)
+        self.assertIn("100L", out)
+
+    def test_fix_no_violations_reports_none(self):
+        src = "long uart_Init(void) { long uart_x = 100L; return uart_x; }\n"
+        rc, out, fixed_text = _cli("--fix", "--dry-run", content=src)
+        # lowercase_l is fine here; nothing to fix
+        self.assertNotIn("---", out)
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #189

## Summary

- Adds `--fix` to rewrite source files in-place
- Adds `--dry-run` to preview changes as a unified diff without writing
- Adds `--safe-only` to restrict to zero-risk fixes only (all current fixes are safe)
- New `fixer.py` module with `apply_fixes()` / `unified_diff()` / rule registry
- 11 new tests; 976 total pass

## Fixable rules

| Rule | Fix |
|---|---|
| `misc.unsigned_suffix` | `42` → `42U` on unsigned-typed assignments |
| `misc.lowercase_l_suffix` | `100l` → `100L` |

## Usage

```sh
cstylecheck --fix src/              # fix in-place
cstylecheck --fix --dry-run src/    # preview diff
cstylecheck --fix --safe-only src/  # safe fixes only (same as above currently)
```

## Test plan

- [ ] CI passes
- [ ] `--fix` rewrites `100l` → `100L` in a test file
- [ ] `--fix --dry-run` shows diff but does not modify file
- [ ] Files with no fixable violations are left unchanged

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_