### PR TITLE
feat(#193): per-directory config overrides via --per-dir-config

### DIFF
--- a/src/cstylecheck/__init__.py
+++ b/src/cstylecheck/__init__.py
@@ -96,6 +96,9 @@ from .config import (                    # noqa: F401, E402
     _DEFAULT_KEYWORDS_FILE,
     _DEFAULT_STDLIB_FILE,
     _DEFAULT_SPELL_DICT,
+    _PER_DIR_CONFIG_NAME,
+    _walk_per_dir_configs,
+    resolve_per_dir_config,
 )
 
 from .checker import (                   # noqa: F401, E402

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -23,6 +23,7 @@ from .config import (
     _build_spell_dict, _load_dict_file, _expand_options_file,
     update_config,
     C_KEYWORDS, C_STDLIB_NAMES,
+    resolve_per_dir_config,
 )
 from .fixer import apply_fixes, unified_diff, FIXABLE_RULES, SAFE_RULES
 from .utils import module_name, _cfg
@@ -345,6 +346,14 @@ def _build_parser() -> argparse.ArgumentParser:
     init_group.add_argument(
         "--overwrite", action="store_true",
         help="Overwrite existing config file when using --init or --preset.")
+    p.add_argument("--per-dir-config", action="store_true",
+                   help="Enable per-directory config overrides. For each source "
+                        "file, CStyleCheck walks up the directory tree looking "
+                        "for '.cstylecheck.yml' files and deep-merges any found "
+                        "overrides on top of the root config. Add 'root: true' "
+                        "to any '.cstylecheck.yml' to stop the search at that "
+                        "directory. The nearest config (closest to the file) "
+                        "takes highest priority.")
     return p
 
 
@@ -496,6 +505,8 @@ def main() -> int:
         # Cache source text keyed by filepath to avoid reading each file twice
         # (once for Checker, once for SignChecker).
         source_cache: dict = {}
+        # Per-directory config cache: {dir_path -> effective_cfg}
+        _per_dir_cache: dict = {}
 
         for filepath in files:
             if getattr(args, "verbose", False):
@@ -511,10 +522,17 @@ def main() -> int:
                 tee.print(f"ERROR: Cannot read {filepath}: {e}")
                 continue
 
+            # Resolve effective config (root cfg optionally overridden per-dir)
+            file_cfg = (
+                resolve_per_dir_config(filepath, cfg, _per_dir_cache)
+                if getattr(args, "per_dir_config", False)
+                else cfg
+            )
+
             # Build accepted prefix list for this file (canonical + aliases)
             mod   = module_name(filepath)
-            sep   = _cfg(cfg, "file_prefix", "separator", default="_")
-            case  = _cfg(cfg, "file_prefix", "case", default="lower")
+            sep   = _cfg(file_cfg, "file_prefix", "separator", default="_")
+            case  = _cfg(file_cfg, "file_prefix", "case", default="lower")
             canon = (mod.upper() if case == "upper" else mod.lower()) + sep
             alias_pfxs = [canon] + [
                 a.lower() + sep for a in alias_map.get(mod.lower(), [])
@@ -524,7 +542,7 @@ def main() -> int:
             _file_disabled, _ident_disabled = _disabled_rules_for_file(filepath, exclusions_map)
 
             checker = Checker(
-                filepath, source, cfg,
+                filepath, source, file_cfg,
                 spell_words=spell_words,
                 alias_prefixes=alias_pfxs,
                 disabled_rules=_file_disabled,

--- a/src/cstylecheck/config.py
+++ b/src/cstylecheck/config.py
@@ -645,3 +645,69 @@ def _build_spell_dict(cfg_exempt: list, extra_words: set,
     combined.update(w.lower() for w in cfg_exempt)
     combined.update(w.lower() for w in extra_words)
     return combined
+
+
+# ---------------------------------------------------------------------------
+# Per-directory config override discovery  (--per-dir-config)
+# ---------------------------------------------------------------------------
+
+_PER_DIR_CONFIG_NAME = ".cstylecheck.yml"
+
+
+def _walk_per_dir_configs(dirpath: Path) -> list:
+    """
+    Walk upward from *dirpath* collecting ``.cstylecheck.yml`` dicts.
+
+    Stops at the filesystem root or when a config containing ``root: true``
+    is found.  Returns the list ordered **outermost-to-innermost** so callers
+    can merge them in priority order (innermost wins).
+    """
+    chain: list = []
+    current = dirpath.resolve()
+    while True:
+        candidate = current / _PER_DIR_CONFIG_NAME
+        if candidate.exists():
+            try:
+                data = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+            except (OSError, yaml.YAMLError):
+                data = None
+            if isinstance(data, dict):
+                chain.append(data)
+                if data.get("root"):
+                    break
+        parent = current.parent
+        if parent == current:  # reached filesystem root
+            break
+        current = parent
+    chain.reverse()  # outermost first → lower priority merged first
+    return chain
+
+
+def resolve_per_dir_config(filepath: str, root_cfg: dict, cache: dict) -> dict:
+    """
+    Return the effective config for *filepath* by deep-merging per-directory
+    ``.cstylecheck.yml`` overrides on top of *root_cfg*.
+
+    Walks up from the file's directory, collecting all ``.cstylecheck.yml``
+    files until the filesystem root or until a config with ``root: true`` is
+    encountered.  Overrides are merged outermost-to-innermost so the config
+    nearest to the file has the highest priority.
+
+    Results are cached by the file's resolved directory so each directory is
+    only processed once per run.
+    """
+    file_dir = str(Path(filepath).resolve().parent)
+    if file_dir in cache:
+        return cache[file_dir]
+
+    chain = _walk_per_dir_configs(Path(filepath).resolve().parent)
+    if not chain:
+        result = root_cfg
+    else:
+        result = root_cfg
+        for override in chain:
+            clean_override = {k: v for k, v in override.items() if k != "root"}
+            result = _deep_merge(result, clean_override)
+
+    cache[file_dir] = result
+    return result

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -37,6 +37,9 @@ unified_diff                = _mod.unified_diff
 run_wizard                  = _mod.run_wizard
 run_preset                  = _mod.run_preset
 PRESETS                     = _mod.PRESETS
+resolve_per_dir_config      = _mod.resolve_per_dir_config
+_walk_per_dir_configs       = _mod._walk_per_dir_configs
+_PER_DIR_CONFIG_NAME        = _mod._PER_DIR_CONFIG_NAME
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_per_dir_config.py
+++ b/tests/test_per_dir_config.py
@@ -1,0 +1,280 @@
+"""
+Tests for per-directory config override discovery (issue #193).
+
+Tests cover:
+  - resolve_per_dir_config: no override, single override, chain, root: true
+  - _walk_per_dir_configs: ordering and root: true stop
+  - Cache reuse
+  - CLI --per-dir-config integration
+"""
+import os
+import sys
+import copy
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from harness import (  # noqa: E402
+    resolve_per_dir_config,
+    _walk_per_dir_configs,
+    _PER_DIR_CONFIG_NAME,
+    cfg_only,
+    run,
+    rules,
+)
+
+import yaml  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_yaml(directory: Path, data: dict) -> None:
+    """Write a .cstylecheck.yml into *directory*."""
+    (directory / _PER_DIR_CONFIG_NAME).write_text(
+        yaml.dump(data), encoding="utf-8"
+    )
+
+
+# Minimal root config used across tests
+_ROOT_CFG = cfg_only(
+    misc={
+        "line_length": {"enabled": True, "severity": "error", "max": 80},
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# _walk_per_dir_configs
+# ---------------------------------------------------------------------------
+
+class TestWalkPerDirConfigs:
+    def test_no_configs_returns_empty(self, tmp_path):
+        result = _walk_per_dir_configs(tmp_path)
+        assert result == []
+
+    def test_single_config_in_dir(self, tmp_path):
+        _write_yaml(tmp_path, {"misc": {"line_length": {"max": 100}}})
+        result = _walk_per_dir_configs(tmp_path)
+        assert len(result) == 1
+        assert result[0]["misc"]["line_length"]["max"] == 100
+
+    def test_two_levels_outermost_first(self, tmp_path):
+        outer = tmp_path
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        _write_yaml(outer, {"misc": {"line_length": {"max": 100}}})
+        _write_yaml(inner, {"misc": {"line_length": {"max": 120}}})
+        result = _walk_per_dir_configs(inner)
+        assert len(result) == 2
+        # outermost first
+        assert result[0]["misc"]["line_length"]["max"] == 100
+        assert result[1]["misc"]["line_length"]["max"] == 120
+
+    def test_root_true_stops_walk(self, tmp_path):
+        outer = tmp_path
+        middle = tmp_path / "mid"
+        inner = middle / "inner"
+        inner.mkdir(parents=True)
+        # outer config — should NOT be included because middle has root: true
+        _write_yaml(outer, {"misc": {"line_length": {"max": 80}}})
+        # middle config with root: true — stops here
+        _write_yaml(middle, {"root": True, "misc": {"line_length": {"max": 100}}})
+        # inner config — closest to file
+        _write_yaml(inner, {"misc": {"line_length": {"max": 120}}})
+        result = _walk_per_dir_configs(inner)
+        # Should include middle (with root: true) and inner, but NOT outer
+        assert len(result) == 2
+        maxs = [r["misc"]["line_length"]["max"] for r in result]
+        assert 80 not in maxs
+        assert 100 in maxs
+        assert 120 in maxs
+
+    def test_unreadable_config_is_skipped(self, tmp_path):
+        outer = tmp_path
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        _write_yaml(outer, {"misc": {"line_length": {"max": 100}}})
+        # Write invalid YAML
+        (inner / _PER_DIR_CONFIG_NAME).write_text(
+            ": invalid: yaml: [unclosed", encoding="utf-8"
+        )
+        result = _walk_per_dir_configs(inner)
+        # Only outer config is valid
+        assert len(result) == 1
+        assert result[0]["misc"]["line_length"]["max"] == 100
+
+
+# ---------------------------------------------------------------------------
+# resolve_per_dir_config
+# ---------------------------------------------------------------------------
+
+class TestResolvePerDirConfig:
+    def test_no_override_returns_root_cfg(self, tmp_path):
+        fake_file = tmp_path / "src" / "foo.c"
+        fake_file.parent.mkdir(parents=True)
+        fake_file.touch()
+        cache: dict = {}
+        result = resolve_per_dir_config(str(fake_file), _ROOT_CFG, cache)
+        assert result is _ROOT_CFG
+
+    def test_single_override_is_merged(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        _write_yaml(src_dir, {"misc": {"line_length": {"max": 120}}})
+        fake_file = src_dir / "foo.c"
+        fake_file.touch()
+        cache: dict = {}
+        result = resolve_per_dir_config(str(fake_file), _ROOT_CFG, cache)
+        # Override should raise the max
+        assert result["misc"]["line_length"]["max"] == 120
+        # Other keys from root should still be present
+        assert result["misc"]["line_length"]["enabled"] is True
+
+    def test_override_does_not_mutate_root_cfg(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        _write_yaml(src_dir, {"misc": {"line_length": {"max": 200}}})
+        fake_file = src_dir / "foo.c"
+        fake_file.touch()
+        root_copy = copy.deepcopy(_ROOT_CFG)
+        cache: dict = {}
+        resolve_per_dir_config(str(fake_file), _ROOT_CFG, cache)
+        assert _ROOT_CFG == root_copy
+
+    def test_root_key_not_in_merged_result(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        _write_yaml(src_dir, {"root": True, "misc": {"line_length": {"max": 100}}})
+        fake_file = src_dir / "foo.c"
+        fake_file.touch()
+        cache: dict = {}
+        result = resolve_per_dir_config(str(fake_file), _ROOT_CFG, cache)
+        assert "root" not in result
+
+    def test_cache_hit_returns_same_object(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        _write_yaml(src_dir, {"misc": {"line_length": {"max": 100}}})
+        file1 = src_dir / "foo.c"
+        file2 = src_dir / "bar.c"
+        file1.touch()
+        file2.touch()
+        cache: dict = {}
+        result1 = resolve_per_dir_config(str(file1), _ROOT_CFG, cache)
+        result2 = resolve_per_dir_config(str(file2), _ROOT_CFG, cache)
+        assert result1 is result2  # exact same object from cache
+
+    def test_chain_innermost_wins(self, tmp_path):
+        outer = tmp_path
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        _write_yaml(outer, {"misc": {"line_length": {"max": 100}}})
+        _write_yaml(inner, {"misc": {"line_length": {"max": 150}}})
+        fake_file = inner / "foo.c"
+        fake_file.touch()
+        cache: dict = {}
+        result = resolve_per_dir_config(str(fake_file), _ROOT_CFG, cache)
+        # Inner (150) should win over outer (100)
+        assert result["misc"]["line_length"]["max"] == 150
+
+    def test_chain_outer_applies_when_no_inner_key(self, tmp_path):
+        outer = tmp_path
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        # Outer adds a completely new section (functions override)
+        _write_yaml(outer, {"functions": {"enabled": False}})
+        # Inner only overrides line_length
+        _write_yaml(inner, {"misc": {"line_length": {"max": 120}}})
+        fake_file = inner / "foo.c"
+        fake_file.touch()
+        root = cfg_only(
+            misc={"line_length": {"enabled": True, "severity": "error", "max": 80}},
+            functions={"enabled": True, "severity": "error", "case": "lower_snake"},
+        )
+        cache: dict = {}
+        result = resolve_per_dir_config(str(fake_file), root, cache)
+        # Outer disabled functions, inner didn't touch it
+        assert result["functions"]["enabled"] is False
+        # Inner raised line_length
+        assert result["misc"]["line_length"]["max"] == 120
+
+    def test_empty_cache_populated_after_call(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        fake_file = src_dir / "foo.c"
+        fake_file.touch()
+        cache: dict = {}
+        resolve_per_dir_config(str(fake_file), _ROOT_CFG, cache)
+        assert len(cache) == 1
+
+    def test_separate_dirs_each_cached(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        _write_yaml(dir_a, {"misc": {"line_length": {"max": 100}}})
+        _write_yaml(dir_b, {"misc": {"line_length": {"max": 120}}})
+        fa = dir_a / "foo.c"
+        fb = dir_b / "bar.c"
+        fa.touch()
+        fb.touch()
+        cache: dict = {}
+        res_a = resolve_per_dir_config(str(fa), _ROOT_CFG, cache)
+        res_b = resolve_per_dir_config(str(fb), _ROOT_CFG, cache)
+        assert res_a["misc"]["line_length"]["max"] == 100
+        assert res_b["misc"]["line_length"]["max"] == 120
+        assert len(cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — --per-dir-config flag
+# ---------------------------------------------------------------------------
+
+class TestPerDirConfigCLI:
+    """Integration test via CLI main()."""
+
+    def test_flag_applies_override(self, tmp_path, monkeypatch):
+        import cstylecheck as _mod
+
+        # Write a minimal rules.yml (root config) — all rules off
+        root_cfg_data = cfg_only(
+            misc={"line_length": {"enabled": True, "severity": "error", "max": 40}},
+        )
+        import yaml as _yaml
+        rules_yml = tmp_path / "rules.yml"
+        rules_yml.write_text(_yaml.dump(root_cfg_data), encoding="utf-8")
+
+        # Write per-dir override relaxing line_length to 200
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        _write_yaml(src_dir, {"misc": {"line_length": {"max": 200}}})
+
+        # Write a short source file (50 chars per line — OK for 200, bad for 40)
+        src_file = src_dir / "test_module.c"
+        src_file.write_text("x" * 50 + "\n", encoding="utf-8")
+
+        orig_argv = sys.argv[:]
+        try:
+            # Without --per-dir-config: should flag line_length violation
+            sys.argv = [
+                "cstylecheck",
+                str(src_file),
+                "--config", str(rules_yml),
+            ]
+            monkeypatch.chdir(tmp_path)
+            rc = _mod.main()
+            assert rc == 1  # 50-char line violates max=40
+
+            # With --per-dir-config: max relaxed to 200, no violation
+            sys.argv = [
+                "cstylecheck",
+                str(src_file),
+                "--config", str(rules_yml),
+                "--per-dir-config",
+            ]
+            rc = _mod.main()
+            assert rc == 0  # 50-char line is fine at max=200
+        finally:
+            sys.argv = orig_argv


### PR DESCRIPTION
## Summary

- Adds `.cstylecheck.yml` nearest-ancestor config lookup enabled via `--per-dir-config` flag
- Walks up from each source file's directory collecting `.cstylecheck.yml` files; deep-merges them outermost-to-innermost so the nearest config takes highest priority
- `root: true` in any `.cstylecheck.yml` stops the upward search at that directory
- Results are cached per resolved directory path so each directory is processed once per run
- Discovery logic (`_walk_per_dir_configs`, `resolve_per_dir_config`) lives in `config.py` alongside `load_config`

## Test plan

- [ ] `TestWalkPerDirConfigs` — no configs, single config, two-level ordering, `root: true` stop, unreadable YAML skipped
- [ ] `TestResolvePerDirConfig` — no override returns root, single override merged, root config not mutated, `root` key stripped, cache hit reuses same object, chain innermost wins, chain outer applies when no inner key, cache populated, separate dirs independently cached
- [ ] `TestPerDirConfigCLI` — `--per-dir-config` flag applies per-dir override (line_length relaxed from 40→200, file passes instead of fails)

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_