### PR TITLE
feat(#192): HTML report output via --output-format html

### DIFF
--- a/src/cstylecheck/__init__.py
+++ b/src/cstylecheck/__init__.py
@@ -139,6 +139,7 @@ from .output import (                    # noqa: F401, E402
     Tee,
     _violations_to_json,
     _violations_to_sarif,
+    _violations_to_html,
     print_summary,
 )
 

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -30,7 +30,7 @@ from .utils import module_name, _cfg
 from .checker import Checker
 from .sign_checker import SignChecker, DeclaredNotDefinedChecker
 from .baseline import load_baseline, write_baseline, _baseline_key
-from .output import Tee, _violations_to_json, _violations_to_sarif, print_summary
+from .output import Tee, _violations_to_json, _violations_to_sarif, _violations_to_html, print_summary
 from .wizard import run_wizard, run_preset, PRESETS
 from . import _TOOL_NAME, _VERSION, _VERSION_STRING
 
@@ -229,10 +229,11 @@ def _build_parser() -> argparse.ArgumentParser:
                    help="YAML config file (default: rules.yml)")
     p.add_argument("--github-actions", action="store_true",
                    help="Emit ::error/::warning GitHub Actions annotations")
-    p.add_argument("--output-format", choices=["text", "json", "sarif"],
+    p.add_argument("--output-format", choices=["text", "json", "sarif", "html"],
                    default="text",
-                   help="Output format: text (default), json, or sarif. "
-                        "json and sarif write to --log if given, else stdout. "
+                   help="Output format: text (default), json, sarif, or html. "
+                        "json, sarif, and html write to --log if given, "
+                        "else stdout. "
                         "Implies --exit-zero is unaffected.")
     p.add_argument("--summary", action="store_true",
                    help="Print summary table after all files are checked")
@@ -661,13 +662,16 @@ def main() -> int:
                 if v.severity in ("warning", "info"):
                     v.severity = "error"
 
-        # --output-format json / sarif: emit structured output to stdout or --log.
+        # --output-format json / sarif / html: emit structured output.
         if output_format == "json":
             json_text = _violations_to_json(all_violations, len(files))
             tee.print(json_text)
         elif output_format == "sarif":
             sarif_text = _violations_to_sarif(all_violations, _VERSION)
             tee.print(sarif_text)
+        elif output_format == "html":
+            html_text = _violations_to_html(all_violations, len(files), _VERSION)
+            tee.print(html_text)
 
         if args.summary and output_format == "text":
             print_summary(all_violations, len(files), tee)

--- a/src/cstylecheck/output.py
+++ b/src/cstylecheck/output.py
@@ -119,6 +119,143 @@ def _violations_to_sarif(violations: list, tool_version: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# HTML output  (self-contained, no external dependencies)
+# ---------------------------------------------------------------------------
+
+_HTML_CSS = """
+body{font-family:system-ui,sans-serif;margin:0;background:#f5f5f5;color:#222}
+header{background:#1a1a2e;color:#fff;padding:1rem 2rem}
+header h1{margin:0;font-size:1.4rem;letter-spacing:.04em}
+header p{margin:.3rem 0 0;font-size:.85rem;opacity:.8}
+.summary{display:flex;gap:1rem;padding:1rem 2rem;background:#fff;
+  border-bottom:1px solid #ddd;flex-wrap:wrap}
+.card{border-radius:6px;padding:.6rem 1.2rem;min-width:100px;text-align:center;
+  font-weight:bold;font-size:1.1rem}
+.card span{display:block;font-size:.72rem;font-weight:normal;margin-top:.2rem}
+.card.error{background:#fde8e8;color:#c0392b}
+.card.warning{background:#fff3cd;color:#856404}
+.card.info{background:#d1ecf1;color:#0c5460}
+.card.total{background:#e2e3e5;color:#383d41}
+.card.files{background:#d4edda;color:#155724}
+main{padding:1.5rem 2rem}
+.file-section{background:#fff;border-radius:8px;margin-bottom:1.2rem;
+  box-shadow:0 1px 3px rgba(0,0,0,.1);overflow:hidden}
+.file-header{background:#2d3436;color:#fff;padding:.6rem 1rem;
+  font-family:monospace;font-size:.9rem;display:flex;
+  justify-content:space-between;align-items:center}
+.file-header .badge{background:#636e72;border-radius:12px;
+  padding:.1rem .6rem;font-size:.78rem}
+table{width:100%;border-collapse:collapse;font-size:.88rem}
+th{background:#ecf0f1;text-align:left;padding:.45rem .7rem;
+  font-size:.78rem;text-transform:uppercase;letter-spacing:.04em;
+  color:#636e72;border-bottom:2px solid #ddd}
+td{padding:.4rem .7rem;border-bottom:1px solid #f0f0f0;vertical-align:top}
+tr:last-child td{border-bottom:none}
+tr.error td{background:#fff5f5}
+tr.warning td{background:#fffdf0}
+tr.info td{background:#f0faff}
+.sev{border-radius:4px;padding:.1rem .45rem;font-size:.76rem;
+  font-weight:bold;white-space:nowrap}
+.sev.error{background:#fde8e8;color:#c0392b}
+.sev.warning{background:#fff3cd;color:#856404}
+.sev.info{background:#d1ecf1;color:#0c5460}
+.rule{font-family:monospace;font-size:.82rem;color:#2980b9}
+.loc{font-family:monospace;font-size:.82rem;white-space:nowrap}
+.clean{padding:.8rem 1rem;color:#27ae60;font-size:.88rem}
+footer{text-align:center;padding:1rem;font-size:.78rem;color:#888}
+"""
+
+
+def _h(text: str) -> str:
+    """HTML-escape *text*."""
+    import html
+    return html.escape(str(text))
+
+
+def _violations_to_html(violations: list, files_checked: int,
+                         version: str) -> str:
+    """Generate a self-contained HTML report from *violations*."""
+    import datetime
+    from collections import defaultdict
+
+    errors   = sum(1 for v in violations if v.severity == "error")
+    warnings = sum(1 for v in violations if v.severity == "warning")
+    infos    = sum(1 for v in violations if v.severity == "info")
+
+    # Group violations by filepath, preserving order
+    by_file: dict = defaultdict(list)
+    for v in violations:
+        by_file[v.filepath].append(v)
+
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    from . import _VERSION_STRING
+
+    lines = [
+        "<!DOCTYPE html>",
+        '<html lang="en">',
+        "<head>",
+        '<meta charset="UTF-8">',
+        '<meta name="viewport" content="width=device-width,initial-scale=1">',
+        f"<title>CStyleCheck Report — {now}</title>",
+        f"<style>{_HTML_CSS}</style>",
+        "</head>",
+        "<body>",
+        "<header>",
+        "<h1>CStyleCheck Report</h1>",
+        f"<p>Generated {now} &nbsp;|&nbsp; {_h(_VERSION_STRING)}</p>",
+        "</header>",
+        '<div class="summary">',
+        f'<div class="card files">{files_checked}<span>files checked</span></div>',
+        f'<div class="card error">{errors}<span>errors</span></div>',
+        f'<div class="card warning">{warnings}<span>warnings</span></div>',
+        f'<div class="card info">{infos}<span>info</span></div>',
+        f'<div class="card total">{len(violations)}<span>total</span></div>',
+        "</div>",
+        "<main>",
+    ]
+
+    if not violations:
+        lines.append('<p style="color:#27ae60;font-size:1.1rem">'
+                     "&#10003; No violations found.</p>")
+    else:
+        for filepath, file_viols in by_file.items():
+            count = len(file_viols)
+            lines += [
+                '<div class="file-section">',
+                '<div class="file-header">',
+                f'<span>{_h(filepath)}</span>',
+                f'<span class="badge">{count} violation{"s" if count != 1 else ""}</span>',
+                "</div>",
+                "<table>",
+                "<thead><tr>"
+                "<th>Line</th><th>Col</th><th>Severity</th>"
+                "<th>Rule</th><th>Message</th>"
+                "</tr></thead>",
+                "<tbody>",
+            ]
+            for v in sorted(file_viols, key=lambda x: (x.line, x.col)):
+                sev = _h(v.severity)
+                lines.append(
+                    f'<tr class="{sev}">'
+                    f'<td class="loc">{v.line}</td>'
+                    f'<td class="loc">{v.col}</td>'
+                    f'<td><span class="sev {sev}">{sev}</span></td>'
+                    f'<td><span class="rule">{_h(v.rule)}</span></td>'
+                    f'<td>{_h(v.message)}</td>'
+                    "</tr>"
+                )
+            lines += ["</tbody>", "</table>", "</div>"]
+
+    lines += [
+        "</main>",
+        f'<footer>Generated by {_h(_VERSION_STRING)}</footer>',
+        "</body>",
+        "</html>",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -40,6 +40,7 @@ PRESETS                     = _mod.PRESETS
 resolve_per_dir_config      = _mod.resolve_per_dir_config
 _walk_per_dir_configs       = _mod._walk_per_dir_configs
 _PER_DIR_CONFIG_NAME        = _mod._PER_DIR_CONFIG_NAME
+_violations_to_html         = _mod._violations_to_html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,199 @@
+"""
+Tests for HTML report output (issue #192).
+
+Tests cover:
+  - _violations_to_html: structure, content, escaping, empty input
+  - CLI --output-format html integration
+"""
+import os
+import sys
+import io
+
+sys.path.insert(0, os.path.dirname(__file__))
+from harness import _violations_to_html, Violation, cfg_only  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_violation(filepath="test.c", line=10, col=5,
+                    severity="error", rule="misc.line_length",
+                    message="Line too long") -> Violation:
+    return Violation(filepath, line, col, severity, rule, message)
+
+
+# ---------------------------------------------------------------------------
+# Structure tests
+# ---------------------------------------------------------------------------
+
+class TestHtmlStructure:
+    def test_returns_string(self):
+        html = _violations_to_html([], 0, "1.0")
+        assert isinstance(html, str)
+
+    def test_valid_html_doctype(self):
+        html = _violations_to_html([], 0, "1.0")
+        assert html.startswith("<!DOCTYPE html>")
+
+    def test_contains_html_tag(self):
+        html = _violations_to_html([], 0, "1.0")
+        assert "<html" in html
+        assert "</html>" in html
+
+    def test_contains_style_block(self):
+        html = _violations_to_html([], 0, "1.0")
+        assert "<style>" in html
+
+    def test_empty_shows_no_violations_message(self):
+        html = _violations_to_html([], 5, "1.0")
+        assert "No violations found" in html
+
+    def test_files_checked_in_summary(self):
+        html = _violations_to_html([], 42, "1.0")
+        assert "42" in html
+
+    def test_version_in_output(self):
+        html = _violations_to_html([], 0, "2.3.4")
+        assert "2.3.4" in html or "CStyleCheck" in html
+
+
+# ---------------------------------------------------------------------------
+# Violation content tests
+# ---------------------------------------------------------------------------
+
+class TestHtmlViolationContent:
+    def test_filepath_in_output(self):
+        v = _make_violation(filepath="src/foo.c")
+        html = _violations_to_html([v], 1, "1.0")
+        assert "src/foo.c" in html
+
+    def test_line_number_in_output(self):
+        v = _make_violation(line=42)
+        html = _violations_to_html([v], 1, "1.0")
+        assert "42" in html
+
+    def test_col_in_output(self):
+        v = _make_violation(col=7)
+        html = _violations_to_html([v], 1, "1.0")
+        assert "7" in html
+
+    def test_severity_in_output(self):
+        v = _make_violation(severity="warning")
+        html = _violations_to_html([v], 1, "1.0")
+        assert "warning" in html
+
+    def test_rule_in_output(self):
+        v = _make_violation(rule="variables.case")
+        html = _violations_to_html([v], 1, "1.0")
+        assert "variables.case" in html
+
+    def test_message_in_output(self):
+        v = _make_violation(message="Identifier should be lower_snake_case")
+        html = _violations_to_html([v], 1, "1.0")
+        assert "lower_snake_case" in html
+
+    def test_error_count_in_summary(self):
+        violations = [
+            _make_violation(severity="error"),
+            _make_violation(severity="error"),
+            _make_violation(severity="warning"),
+        ]
+        html = _violations_to_html(violations, 1, "1.0")
+        # 2 errors, 1 warning, 0 info in the summary cards
+        assert "2" in html
+        assert "1" in html
+
+    def test_multiple_files_each_shown(self):
+        v1 = _make_violation(filepath="src/alpha.c")
+        v2 = _make_violation(filepath="src/beta.c")
+        html = _violations_to_html([v1, v2], 2, "1.0")
+        assert "alpha.c" in html
+        assert "beta.c" in html
+
+
+# ---------------------------------------------------------------------------
+# HTML escaping tests
+# ---------------------------------------------------------------------------
+
+class TestHtmlEscaping:
+    def test_filepath_lt_gt_escaped(self):
+        v = _make_violation(filepath="src/<module>.c")
+        html = _violations_to_html([v], 1, "1.0")
+        assert "<module>" not in html   # raw angle brackets must not appear
+        assert "&lt;module&gt;" in html
+
+    def test_message_ampersand_escaped(self):
+        v = _make_violation(message="use a && b instead")
+        html = _violations_to_html([v], 1, "1.0")
+        assert "&amp;&amp;" in html
+
+    def test_message_quotes_escaped(self):
+        v = _make_violation(message='variable "foo" is not snake_case')
+        html = _violations_to_html([v], 1, "1.0")
+        assert "&quot;" in html or "&#x27;" in html or '"' not in html.split("foo")[0]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration test
+# ---------------------------------------------------------------------------
+
+class TestHtmlReportCLI:
+    def test_html_flag_produces_html_output(self, tmp_path, monkeypatch, capsys):
+        import cstylecheck as _mod
+        import yaml as _yaml
+
+        root_cfg = cfg_only(
+            misc={"line_length": {"enabled": True, "severity": "error", "max": 10}},
+        )
+        rules_yml = tmp_path / "rules.yml"
+        rules_yml.write_text(_yaml.dump(root_cfg), encoding="utf-8")
+
+        src_file = tmp_path / "test_module.c"
+        src_file.write_text("x" * 20 + "\n", encoding="utf-8")
+
+        orig_argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "cstylecheck",
+                str(src_file),
+                "--config", str(rules_yml),
+                "--output-format", "html",
+                "--exit-zero",
+            ]
+            monkeypatch.chdir(tmp_path)
+            _mod.main()
+        finally:
+            sys.argv = orig_argv
+
+        captured = capsys.readouterr()
+        assert "<!DOCTYPE html>" in captured.out
+        assert "<style>" in captured.out
+
+    def test_html_flag_no_violations_shows_clean(self, tmp_path, monkeypatch, capsys):
+        import cstylecheck as _mod
+        import yaml as _yaml
+
+        root_cfg = cfg_only()  # all rules off
+        rules_yml = tmp_path / "rules.yml"
+        rules_yml.write_text(_yaml.dump(root_cfg), encoding="utf-8")
+
+        src_file = tmp_path / "test_module.c"
+        src_file.write_text("int x = 1;\n", encoding="utf-8")
+
+        orig_argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "cstylecheck",
+                str(src_file),
+                "--config", str(rules_yml),
+                "--output-format", "html",
+            ]
+            monkeypatch.chdir(tmp_path)
+            rc = _mod.main()
+        finally:
+            sys.argv = orig_argv
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "No violations found" in captured.out


### PR DESCRIPTION
## Summary

- Adds `html` as a new `--output-format` choice alongside `text`, `json`, and `sarif`
- Self-contained HTML report with inline CSS — no external dependencies (no Jinja2)
- Report includes: timestamp header, summary cards (errors/warnings/info/total/files), per-file violation tables with severity-coded rows
- All user-supplied content (file paths, rule IDs, messages) is HTML-escaped via `html.escape()` to prevent XSS
- Output destination follows the same rule as `json`/`sarif`: writes to `--log` if provided, else stdout

## Test plan

- [ ] `TestHtmlStructure` — returns string, valid DOCTYPE, html tag, style block, no-violations message, file count, version in output
- [ ] `TestHtmlViolationContent` — filepath, line, col, severity, rule, message, error count in summary, multiple files
- [ ] `TestHtmlEscaping` — `<>` in filepath escaped, `&&` in message escaped, `"` in message escaped
- [ ] `TestHtmlReportCLI` — `--output-format html` produces `<!DOCTYPE html>` + `<style>` in stdout; clean run shows "No violations found"

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_