### PR TITLE
chore: restore blank line in cli.py — final sync of develop with main

### DIFF
--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -540,6 +540,7 @@ def main() -> int:
                 a.lower() + sep for a in alias_map.get(mod.lower(), [])
             ]
 
+
             # Collect disabled rules for this specific file
             _file_disabled, _ident_disabled = _disabled_rules_for_file(filepath, exclusions_map)
 


### PR DESCRIPTION
## Summary

Restores one blank line in `src/cstylecheck/cli.py` (line 542) that was dropped during conflict resolution in PR #207. After this merge, `develop` and `main` will have byte-for-byte identical file content — `git diff origin/main origin/develop` will produce no output.

Single-line cosmetic change only. All 1041 tests pass.

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_