### PR TITLE
Release: 11 new rules (issues #221–#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`macro.trailing_semicolon` rule** — detects `#define` macros whose expansion ends
+  with a semicolon, preventing double-semicolon and dangling-else bugs at the call site
+  (issue [#228](https://github.com/dermot-murphy/CStyleCheck/issues/228)).
+- **`macro.multistatement_wrapper` rule** — enforces that function-like macros containing
+  multiple statements are wrapped in `do { ... } while (0)` for safe use in `if`/`else`
+  branches
+  (issue [#229](https://github.com/dermot-murphy/CStyleCheck/issues/229)).
+- **`misc.function_length` rule** — configurable maximum function body line count;
+  supports `count_comments: false` to exclude blank and comment-only lines from the count
+  (issue [#221](https://github.com/dermot-murphy/CStyleCheck/issues/221)).
+- **`misc.function_doc_header` rule** — requires a Doxygen-style `@brief`/`@param`/`@return`
+  block comment before each non-static function definition (disabled by default)
+  (issue [#222](https://github.com/dermot-murphy/CStyleCheck/issues/222)).
+- **`misc.assert_density` rule** — enforces a minimum number of `assert()` calls per
+  qualifying function; supports per-function exemption via regex patterns (disabled by default)
+  (issue [#225](https://github.com/dermot-murphy/CStyleCheck/issues/225)).
+- **`misc.null_statement_comment` rule** — requires a comment whenever a null statement
+  (`while (x) ;`, standalone `;`) is used, preventing accidental empty loop bodies
+  (issue [#227](https://github.com/dermot-murphy/CStyleCheck/issues/227)).
+- **`misc.declaration_spacing` rule** — enforces a blank line between variable declarations
+  and the first executable statement in a function body (disabled by default)
+  (issue [#224](https://github.com/dermot-murphy/CStyleCheck/issues/224)).
+- **`misc.file_length` rule** — configurable maximum total lines per source file; supports
+  excluding blank and/or comment-only lines from the count
+  (issue [#232](https://github.com/dermot-murphy/CStyleCheck/issues/232)).
+- **`misc.reserved_header_name` rule** — flags source files and `#include "..."` directives
+  that use a name identical to a standard C or POSIX library header, preventing shadowing
+  (issue [#230](https://github.com/dermot-murphy/CStyleCheck/issues/230)).
+- **`naming.identifier_length` rule** — uniform minimum/maximum identifier-length check
+  across all identifier categories with per-name exemptions (disabled by default)
+  (issue [#223](https://github.com/dermot-murphy/CStyleCheck/issues/223)).
+- **`naming.no_single_char_identifiers` rule** — flags single-character variable names
+  outside a configurable exempt list (e.g. `i`, `j`, `k`) (disabled by default)
+  (issue [#231](https://github.com/dermot-murphy/CStyleCheck/issues/231)).
+- **102 new tests** (1143 total) covering all 11 new rules, including edge cases for
+  multi-line macros, nested braces, comment exclusion, and regex-based exemptions.
+
+---
+
 ## [1.3.0] — 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Contributions are very welcome.
 ![Logo](logo/cstylecheck.jpg)
 
 Embedded C Style Compliance Checker for GitHub Actions / pre-commit hooks.
-Implements **Barr-C:2018** and MISRA-C complementary rules across **53 rule IDs**.
+Implements **Barr-C:2018** and MISRA-C complementary rules across **64 rule IDs**.
 
 [![Tests](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/cstylecheck_tests.yml/badge.svg)](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/cstylecheck_tests.yml)
 [![Naming Convention](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dermot-murphy/CStyleCheck/gh-pages/cstylecheck/badge.json)](https://dermot-murphy.github.io/CStyleCheck/cstylecheck/)
 [![Docker](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/docker_publish.yml/badge.svg)](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/docker_publish.yml)
 
 📖 **[Rules and Configuration Reference](Rules-and-Configuration.md)** — full
-documentation for all 53 rules with YAML configuration and annotated C examples.
+documentation for all 64 rules with YAML configuration and annotated C examples.
 
 ---
 
@@ -26,7 +26,7 @@ documentation for all 53 rules with YAML configuration and annotated C examples.
 ```
 .pre-commit-hooks.yml   # pre-commit hook definition (id: cstylecheck)
 pyproject.toml           # pip / pipx / pre-commit packaging metadata
-Rules-and-Configuration.md  # wiki: all 53 rules with config and examples
+Rules-and-Configuration.md  # wiki: all 64 rules with config and examples
 src/
     cstylecheck.py          # thin CLI shim (backward-compatible entry point)
     cstylecheck/            # checker package (12 sub-modules)
@@ -36,7 +36,7 @@ src/
         models.py           # Violation, CheckResult, shared constants
         preprocessor.py     # comment/string stripping, token extraction
         utils.py            # case matching, module name helpers
-        checker.py          # main Checker class — all 53 rule implementations
+        checker.py          # main Checker class — all 64 rule implementations
         sign_checker.py     # cross-file sign-compatibility and declared_not_defined
         baseline.py         # baseline load/write
         output.py           # text / JSON / SARIF / HTML formatters, Tee, summary
@@ -93,11 +93,22 @@ tests/
     test_init_wizard.py     #  15 tests: config wizard and presets (run_wizard, run_preset)
     test_per_dir_config.py  #  15 tests: per-directory config resolution
     test_html_report.py     #  20 tests: HTML report output
+    test_function_length.py #  11 tests: misc.function_length
+    test_function_doc_header.py # 12 tests: misc.function_doc_header
+    test_assert_density.py  #   8 tests: misc.assert_density
+    test_null_statement_comment.py # 9 tests: misc.null_statement_comment
+    test_declaration_spacing.py #  8 tests: misc.declaration_spacing
+    test_file_length.py     #   8 tests: misc.file_length
+    test_reserved_header_name.py # 10 tests: misc.reserved_header_name
+    test_macro_trailing_semicolon.py #  9 tests: macro.trailing_semicolon
+    test_macro_multistatement_wrapper.py # 9 tests: macro.multistatement_wrapper
+    test_identifier_length.py #  10 tests: naming.identifier_length
+    test_no_single_char_identifiers.py # 8 tests: naming.no_single_char_identifiers
 Dockerfile/
     Dockerfile               # multi-platform Docker image
     .dockerignore
 .github/workflows/
-    cstylecheck_tests.yml      # runs the test suite on every commit (1041 tests)
+    cstylecheck_tests.yml      # runs the test suite on every commit (1143 tests)
     rules.yml    # runs linter + trend page on C source commits
     docker_publish.yml       # builds and pushes image to GHCR and Docker Hub
     wiki_publish.yml         # publishes GitHub Wiki from README + ASPICE docs

--- a/Rules-and-Configuration.md
+++ b/Rules-and-Configuration.md
@@ -30,6 +30,8 @@ and `info`.
 3. [Constants and macros](#3-constants-and-macros)
    - [3.1 Constants (`#define` object-like)](#31-constants-define-object-like)
    - [3.2 Macros (`#define` function-like)](#32-macros-define-function-like)
+   - [3.3 Macro trailing semicolon](#33-macro-trailing-semicolon)
+   - [3.4 Macro multistatement wrapper](#34-macro-multistatement-wrapper)
 4. [Functions](#4-functions)
    - [4.1 Prefix](#41-prefix)
    - [4.2 Style (Object-Verb / Verb-Object / lower\_snake)](#42-style)
@@ -49,12 +51,22 @@ and `info`.
    - [9.6 Unsigned suffix](#96-unsigned-suffix)
    - [9.7 Block-comment spacing](#97-block-comment-spacing)
    - [9.8 Yoda conditions](#98-yoda-conditions)
+   - [9.9 Function length](#99-function-length)
+   - [9.10 Function doc header](#910-function-doc-header)
+   - [9.11 Assert density](#911-assert-density)
+   - [9.12 Null statement comment](#912-null-statement-comment)
+   - [9.13 Declaration spacing](#913-declaration-spacing)
+   - [9.14 File length](#914-file-length)
+   - [9.15 Reserved header name](#915-reserved-header-name)
 10. [Reserved names](#10-reserved-names)
 11. [Spell check](#11-spell-check)
 12. [Sign compatibility](#12-sign-compatibility)
-13. [Inline suppression comments](#13-inline-suppression-comments)
-14. [Quick reference table](#14-quick-reference-table)
-15. [MISRA C:2012/2023 coverage matrix](#15-misra-c20122023-coverage-matrix)
+13. [Naming conventions (identifier length)](#13-naming-conventions-identifier-length)
+    - [13.1 Identifier length](#131-identifier-length)
+    - [13.2 No single-character identifiers](#132-no-single-character-identifiers)
+14. [Inline suppression comments](#14-inline-suppression-comments)
+15. [Quick reference table](#15-quick-reference-table)
+16. [MISRA C:2012/2023 coverage matrix](#16-misra-c20122023-coverage-matrix)
 
 ---
 
@@ -540,6 +552,76 @@ same `UPPER_SNAKE` + module-prefix rules as constants.
 /* ✗ FAIL */
 #define reflectByte(b)         ...   /* macro.case   — not upper_snake */
 #define REFLECT_BYTE(b)        ...   /* macro.prefix — missing crc_ prefix */
+```
+
+---
+
+### 3.3 Macro trailing semicolon
+
+**Rule ID:** `macro.trailing_semicolon`
+
+```yaml
+macros:
+  trailing_semicolon:
+    enabled: true        # recommended: true  (MISRA C 20.7)
+    severity: warning
+```
+
+Object-like and function-like macros must **not** end with a semicolon.
+The canonical usage pattern is `MACRO();` at the call site — if the macro
+definition ends with `;` the call site produces `MACRO();;` (a double
+semicolon or a dangling null statement in an `if`/`else` branch).
+
+```c
+/* ✓ PASS */
+#define RESET_WATCHDOG()    WDT->CTRL = 0x00U
+
+/* ✗ FAIL */
+#define RESET_WATCHDOG()    WDT->CTRL = 0x00U;  /* macro.trailing_semicolon */
+#define LOG_ERROR(msg)      uart_Log(msg);        /* macro.trailing_semicolon */
+```
+
+Multi-line macros are also checked:
+
+```c
+/* ✗ FAIL — trailing ; on the last continuation line */
+#define INIT_MODULE()  \
+    module_Reset();    \
+    module_Start();
+```
+
+---
+
+### 3.4 Macro multistatement wrapper
+
+**Rule ID:** `macro.multistatement_wrapper`
+
+```yaml
+macros:
+  multistatement_wrapper:
+    enabled: true
+    severity: warning
+```
+
+Any function-like macro whose expansion contains **more than one statement**
+must be wrapped in `do { ... } while (0)` to ensure safe use in `if/else`
+branches.
+
+```c
+/* ✓ PASS — single statement, no wrapper needed */
+#define SET_BIT(reg, bit)    ((reg) |= (bit))
+
+/* ✓ PASS — multiple statements safely wrapped */
+#define INIT_GPIO()             \
+    do {                        \
+        GPIO->DIR = 0xFFU;      \
+        GPIO->OUT = 0x00U;      \
+    } while (0)
+
+/* ✗ FAIL — two statements, no do-while wrapper */
+#define INIT_GPIO()             \
+    GPIO->DIR = 0xFFU;          \
+    GPIO->OUT = 0x00U;          /* macro.multistatement_wrapper */
 ```
 
 ---
@@ -1191,6 +1273,266 @@ if (ret == UART_STATUS_OK) { }   /* misc.yoda_condition */
 
 ---
 
+### 9.9 Function length
+
+**Rule ID:** `misc.function_length`
+
+```yaml
+misc:
+  function_length:
+    enabled: true
+    severity: warning
+    max_lines: 60          # total lines from opening { to closing }
+    count_comments: true   # false = exclude blank and comment-only lines
+```
+
+Reports any function whose body (from the opening `{` to the closing `}`,
+inclusive) exceeds `max_lines` lines.  Set `count_comments: false` to
+ignore blank and comment-only lines when counting — only executable
+statement lines count toward the limit.
+
+```c
+/* max_lines: 10, count_comments: true */
+
+/* ✓ PASS — 8 lines total */
+void uart_driver_Init(void)
+{
+    /* set baud rate */
+    uart_driver_s_reg->BAUD = UART_DRIVER_DEFAULT_BAUD;
+    /* enable TX and RX */
+    uart_driver_s_reg->CTRL = UART_DRIVER_CTRL_TX_EN
+                            | UART_DRIVER_CTRL_RX_EN;
+}
+
+/* ✗ FAIL — body exceeds max_lines */
+void uart_driver_ProcessFrame(void)
+{
+    /* ... more than 10 lines ... */
+}   /* misc.function_length */
+```
+
+---
+
+### 9.10 Function doc header
+
+**Rule ID:** `misc.function_doc_header`
+
+```yaml
+misc:
+  function_doc_header:
+    enabled: false         # off by default
+    severity: warning
+    require_brief: true
+    require_param: true    # if the function has parameters
+    require_return: true   # if the function returns non-void
+```
+
+When enabled, every non-static function definition must be immediately
+preceded by a Doxygen-style block comment containing at least `@brief`
+(or `\brief`).  If `require_param` is `true`, each parameter must also
+have a `@param` tag; if `require_return` is `true`, non-void functions
+must have a `@return` tag.
+
+```c
+/* ✓ PASS */
+/**
+ * @brief Read one byte from the UART RX FIFO.
+ * @param[out] p_byte  Pointer to store the received byte.
+ * @return             true if a byte was available, false otherwise.
+ */
+bool uart_driver_ByteRead(uint8_t *p_byte);
+
+/* ✗ FAIL — no doc comment at all */
+bool uart_driver_ByteRead(uint8_t *p_byte);  /* misc.function_doc_header */
+
+/* ✗ FAIL — comment is present but missing @param */
+/**
+ * @brief Read one byte from the UART RX FIFO.
+ */
+bool uart_driver_ByteRead(uint8_t *p_byte);  /* misc.function_doc_header */
+```
+
+---
+
+### 9.11 Assert density
+
+**Rule ID:** `misc.assert_density`
+
+```yaml
+misc:
+  assert_density:
+    enabled: false
+    severity: info
+    min_asserts: 1          # minimum assert() calls per qualifying function
+    min_function_lines: 5   # functions shorter than this are exempt
+    exempt_functions:       # regex list of function names to skip
+      - "^ISR_.*"
+      - "^main$"
+```
+
+Enforces a minimum number of `assert()` calls in each non-trivial function.
+Functions with fewer body lines than `min_function_lines` are exempt.
+`exempt_functions` accepts Python regex patterns matched against the
+unqualified function name.
+
+```c
+/* min_asserts: 1, min_function_lines: 5 */
+
+/* ✓ PASS — function has an assert */
+void uart_driver_BufferWrite(uint8_t *p_buf, uint16_t len)
+{
+    assert(NULL != p_buf);
+    assert(0U < len);
+    /* ... 6 more lines ... */
+}
+
+/* ✗ FAIL — long function with no assert */
+void uart_driver_ProcessFrame(uint8_t *p_frame, uint16_t len)
+{
+    /* 10 lines of processing, no assert */
+}   /* misc.assert_density */
+```
+
+---
+
+### 9.12 Null statement comment
+
+**Rule ID:** `misc.null_statement_comment`
+
+```yaml
+misc:
+  null_statement_comment:
+    enabled: true
+    severity: warning
+```
+
+A null statement (a lone `;` on its own line, or a control-flow keyword
+immediately followed by `;`) must be accompanied by a comment explaining
+the intent.  This prevents accidental null statements in `if`/`while`/`for`
+bodies from silently altering control flow.
+
+```c
+/* ✓ PASS — comment explains the deliberate null body */
+while (uart_driver_IsBusy())
+{
+    ;  /* wait for TX to drain */
+}
+
+/* ✓ PASS — standalone semicolon with comment */
+;   /* intentional no-op */
+
+/* ✗ FAIL — naked null statement */
+while (uart_driver_IsBusy()) ;   /* misc.null_statement_comment */
+
+/* ✗ FAIL — standalone semicolon without comment */
+;                                /* misc.null_statement_comment */
+```
+
+---
+
+### 9.13 Declaration spacing
+
+**Rule ID:** `misc.declaration_spacing`
+
+```yaml
+misc:
+  declaration_spacing:
+    enabled: false      # off by default
+    severity: warning
+    require_blank_line_after: true
+```
+
+When enabled, a block of variable declarations at the start of a function
+body must be followed by exactly one blank line before the first executable
+statement.  This mirrors the MISRA C:2012 Rule 8.1 intent of keeping
+declarations visually separated from code.
+
+```c
+/* ✓ PASS */
+void uart_driver_Init(void)
+{
+    uint32_t baud = UART_DRIVER_DEFAULT_BAUD;
+    uint8_t  ctrl = 0U;
+
+    uart_driver_s_reg->BAUD = baud;
+    uart_driver_s_reg->CTRL = ctrl;
+}
+
+/* ✗ FAIL — no blank line between declarations and code */
+void uart_driver_Init(void)
+{
+    uint32_t baud = UART_DRIVER_DEFAULT_BAUD;
+    uart_driver_s_reg->BAUD = baud;   /* misc.declaration_spacing */
+}
+```
+
+---
+
+### 9.14 File length
+
+**Rule ID:** `misc.file_length`
+
+```yaml
+misc:
+  file_length:
+    enabled: true
+    severity: warning
+    max_lines: 500           # maximum total lines in the file
+    count_blank_lines: true  # false = exclude blank lines from count
+    count_comment_lines: true # false = exclude comment-only lines from count
+```
+
+Reports when a source file exceeds `max_lines` total lines.  Use
+`count_blank_lines: false` or `count_comment_lines: false` to restrict the
+count to executable lines only.  The violation is always reported on line 1.
+
+```c
+/* rules.yml: max_lines: 300 */
+
+/* ✓ PASS — file has 250 lines */
+
+/* ✗ FAIL — file has 350 lines */
+/* misc.file_length reported at line 1 */
+```
+
+---
+
+### 9.15 Reserved header name
+
+**Rule ID:** `misc.reserved_header_name`
+
+```yaml
+misc:
+  reserved_header_name:
+    enabled: true
+    severity: error
+```
+
+`#include` directives must not use the name of a standard C or POSIX
+library header for a project-local file.  Including a file named `string.h`
+from the local directory shadows the standard library and produces
+undefined behaviour.
+
+The built-in list covers all C89/C99/C11 standard headers and the
+POSIX.1-2017 header set (e.g. `stdio.h`, `stdlib.h`, `pthread.h`).
+
+```c
+/* File: string.h  (project local) */
+
+/* ✗ FAIL — file is named the same as a standard header */
+/* misc.reserved_header_name reported at line 1 of string.h */
+
+
+/* In any .c file */
+/* ✓ PASS — including the standard library header */
+#include <string.h>
+
+/* ✗ FAIL — local "string.h" shadows the standard header */
+#include "string.h"   /* misc.reserved_header_name */
+```
+
+---
+
 ## 10. Reserved names
 
 **Rule ID:** `reserved_name`
@@ -1307,14 +1649,96 @@ uart_driver_Send(-1);    /* sign_compatibility */
 
 ---
 
-## 13. Inline suppression comments
+## 13. Naming conventions (identifier length)
+
+### 13.1 Identifier length
+
+**Rule ID:** `naming.identifier_length`
+
+```yaml
+naming:
+  identifier_length:
+    enabled: false      # off by default
+    severity: warning
+    min_length: 3       # minimum identifier length (characters)
+    max_length: 31      # maximum identifier length (C89 significant: 31)
+    exempt_patterns:    # regex list of names exempt from the length check
+      - "^i$"
+      - "^j$"
+      - "^k$"
+```
+
+When enabled, every declared identifier (variables, parameters, struct
+members, etc.) must have a name within `[min_length, max_length]` characters.
+`exempt_patterns` accepts Python regex patterns; any match bypasses the
+length check for that identifier.
+
+This rule complements the per-category `min_length`/`max_length` settings
+in the `variables:` section but applies uniformly across all identifier
+categories.
+
+```c
+/* min_length: 3, max_length: 31 */
+
+/* ✓ PASS */
+uint32_t uart_baud_rate;
+uint8_t  idx;
+
+/* ✗ FAIL — too short */
+uint32_t ab;              /* naming.identifier_length — length 2 < 3 */
+
+/* ✗ FAIL — too long */
+uint32_t uart_driver_receive_and_buffer_byte_stream_pointer;
+                          /* naming.identifier_length — length > 31 */
+```
+
+---
+
+### 13.2 No single-character identifiers
+
+**Rule ID:** `naming.no_single_char_identifiers`
+
+```yaml
+naming:
+  no_single_char_identifiers:
+    enabled: false      # off by default
+    severity: warning
+    exempt:             # single-character names that are always allowed
+      - "i"
+      - "j"
+      - "k"
+      - "n"
+      - "x"
+      - "y"
+      - "z"
+```
+
+When enabled, any identifier with a single-character name that is not in
+`exempt` is flagged.  The `exempt` list is intended for conventional loop
+counters and mathematical variables.
+
+```c
+/* ✓ PASS — i is in exempt */
+for (int i = 0; i < len; i++) { }
+
+/* ✓ PASS — multi-character name */
+uint8_t byte_count = 0U;
+
+/* ✗ FAIL — single character, not in exempt */
+uint32_t a = 0U;    /* naming.no_single_char_identifiers */
+uint32_t b = 0U;    /* naming.no_single_char_identifiers */
+```
+
+---
+
+## 14. Inline suppression comments
 
 Violations can be suppressed without modifying `rules.yml` or `exclusions.yml` by
 placing structured inline comments directly in the C source.  Suppressions are parsed
 by `preprocessor.parse_inline_suppressions` before any rule checks run.  All
 directive keywords are **case-insensitive**.
 
-### 13.1 Suppress the current line
+### 14.1 Suppress the current line
 
 Place the directive as a trailing comment on the line to suppress:
 
@@ -1324,7 +1748,7 @@ uint32_t g_raw_value = 42;  // cstylecheck: disable=variable.global.g_prefix
 
 Only the line containing the directive is suppressed.
 
-### 13.2 Suppress the next line
+### 14.2 Suppress the next line
 
 ```c
 // cstylecheck: disable-next-line=misc.magic_number
@@ -1333,7 +1757,7 @@ uint8_t sync_byte = 0xA5;
 
 The directive suppresses the immediately following non-blank, non-comment line.
 
-### 13.3 Suppress a block
+### 14.3 Suppress a block
 
 A `disable=` directive without a matching `enable=` suppresses the rule from that
 point forward in the file.  Pair it with `enable=` to re-activate:
@@ -1350,7 +1774,7 @@ uint32_t good_value = 3U;   /* checked again */
 A `disable=` with no paired `enable=` suppresses the rule for the remainder of the
 file.
 
-### 13.4 Suppress multiple rules at once
+### 14.4 Suppress multiple rules at once
 
 Comma-separate rule IDs in a single directive:
 
@@ -1363,7 +1787,7 @@ uint32_t threshold = 42;
 All three directive forms (`disable=`, `disable-next-line=`, `enable=`) accept
 comma-separated lists.
 
-### 13.5 Scope and precedence
+### 14.5 Scope and precedence
 
 | Property | Behaviour |
 |---|---|
@@ -1374,7 +1798,7 @@ comma-separated lists.
 
 ---
 
-## 14. Quick reference table
+## 15. Quick reference table
 
 | Rule ID | Default severity | YAML key | Default |
 |---|---|---|---|
@@ -1433,10 +1857,21 @@ comma-separated lists.
 | `misc.lowercase_l_suffix` | warning | `misc.lowercase_l_suffix.enabled` | `true` |
 | `misc.octal_constant` | error | `misc.octal_constant.enabled` | `true` |
 | `misc.trigraph` | error | `misc.trigraph.enabled` | `true` |
+| `macro.trailing_semicolon` | warning | `macros.trailing_semicolon.enabled` | `true` |
+| `macro.multistatement_wrapper` | warning | `macros.multistatement_wrapper.enabled` | `true` |
+| `misc.function_length` | warning | `misc.function_length.enabled` | `true` |
+| `misc.function_doc_header` | warning | `misc.function_doc_header.enabled` | `false` |
+| `misc.assert_density` | info | `misc.assert_density.enabled` | `false` |
+| `misc.null_statement_comment` | warning | `misc.null_statement_comment.enabled` | `true` |
+| `misc.declaration_spacing` | warning | `misc.declaration_spacing.enabled` | `false` |
+| `misc.file_length` | warning | `misc.file_length.enabled` | `true` |
+| `misc.reserved_header_name` | error | `misc.reserved_header_name.enabled` | `true` |
+| `naming.identifier_length` | warning | `naming.identifier_length.enabled` | `false` |
+| `naming.no_single_char_identifiers` | warning | `naming.no_single_char_identifiers.enabled` | `false` |
 
 ---
 
-## 15. MISRA C:2012/2023 coverage matrix
+## 16. MISRA C:2012/2023 coverage matrix
 
 CStyleCheck provides complementary support for a subset of MISRA C:2012/2023 rules.
 It is **not** a full MISRA compliance checker.  The table below documents which rules
@@ -1455,7 +1890,9 @@ are implemented, which are partially addressed, and which are explicitly out of 
 | Rule 14.x / 15.x | Control flow (unreachable code, goto, switch) | Out of scope | — |
 | Rule 17.x | Function usage (recursion, variable-argument functions) | Out of scope | — |
 | Rule 18.x | Pointer type conversion and arithmetic | Out of scope | — |
-| Rule 21.x | Standard library usage | Out of scope | — |
+| Rule 20.7 | Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses | Partial — `macro.multistatement_wrapper` enforces do-while wrapper | `macro.multistatement_wrapper` |
+| Rule 20.10 | The `#` and `##` preprocessor operators should not be used | Out of scope | — |
+| Rule 21.x | Standard library usage (headers) | Partial — `misc.reserved_header_name` prevents local files shadowing stdlib headers | `misc.reserved_header_name` |
 
 > **Note:** "Partial" means the rule's intent is partially addressed by CStyleCheck's
 > naming-convention rules, but full MISRA compliance requires a dedicated MISRA checker

--- a/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
+++ b/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE1-001 | **Version** | 1.7 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SWE1-001 | **Version** | 1.8 |
+| **Project** | CStyleCheck | **Date** | 2026-06-08 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.1 |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.8 | 2026-06-08 | Claude | Add SWE1-078 to SWE1-088 for 11 new rules (issues #221–#232); update RTM |
 | 1.7 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.6 | 2026-06-04 | Claude | Add SWE1-072 to SWE1-076 for five new features (inline suppression, --fix, --init/--preset, per-dir config, HTML output) — issues #188 #189 #190 #193 #192 |
 | 1.5 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.1 version text, update §3.2 referenced doc versions (SWE2 1.2→1.3, SUP8 1.4→1.5) — resolves issue #163 |
@@ -224,6 +225,17 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.1 — Software Requir
 | SWE1-075 | The `wizard.py` module shall implement `--init` (interactive Q&A wizard writing `.cstylecheck.yml`) and `--preset barr-c\|minimal\|misra` (write pre-built config without wizard); `--init-output FILE` shall set the output path; `--overwrite` shall allow overwriting an existing file | Mandatory | Test | SYS-F-002 |
 | SWE1-076 | The `config.py resolve_per_dir_config()` function shall walk upward from each source file's directory when `--per-dir-config` is active, deep-merging any `.cstylecheck.yml` found on top of the root config; the nearest config wins; `root: true` in any `.cstylecheck.yml` stops the upward search; results shall be cached per directory | Mandatory | Test | SYS-F-002 |
 | SWE1-077 | The `output.py _violations_to_html()` function shall produce a self-contained HTML report when `--output-format html` is specified; the report shall include inline CSS, summary cards (errors/warnings/info/total/files), and per-file violation tables; when `--log FILE` is provided the HTML shall be written to that file, otherwise to stdout | Mandatory | Test | SYS-F-027 |
+| SWE1-078 | The `_check_function_length()` method shall report `misc.function_length` when a function body (opening `{` to closing `}`, inclusive) exceeds `misc.function_length.max_lines`; when `count_comments: false` blank and comment-only lines shall be excluded from the count | Mandatory | Test | SYS-F-020 |
+| SWE1-079 | The `_check_function_doc_header()` method shall report `misc.function_doc_header` for any non-static function definition not immediately preceded by a Doxygen block comment containing `@brief`; when `require_param: true` each parameter requires a `@param` tag; when `require_return: true` non-void functions require `@return` | Mandatory | Test | SYS-F-020 |
+| SWE1-080 | The `_check_assert_density()` method shall report `misc.assert_density` for any function body with fewer than `min_asserts` `assert()` calls; functions with fewer body lines than `min_function_lines` shall be exempt; functions whose name matches any pattern in `exempt_functions` shall be exempt | Mandatory | Test | SYS-F-020 |
+| SWE1-081 | The `_check_null_statement_comment()` method shall report `misc.null_statement_comment` for any control-flow keyword (`while`, `for`, `if`) immediately followed by `;` and for any standalone `;` on its own line that is not followed by a comment | Mandatory | Test | SYS-F-020 |
+| SWE1-082 | The `_check_declaration_spacing()` method shall report `misc.declaration_spacing` when a block of variable declarations at the start of a function body is not followed by exactly one blank line before the first executable statement | Mandatory | Test | SYS-F-020 |
+| SWE1-083 | The `_check_file_length()` method shall report `misc.file_length` at line 1 when the source file exceeds `misc.file_length.max_lines`; when `count_blank_lines: false` blank lines shall be excluded; when `count_comment_lines: false` comment-only lines shall be excluded | Mandatory | Test | SYS-F-020 |
+| SWE1-084 | The `_check_reserved_header_name()` method shall report `misc.reserved_header_name` when the file under analysis is a header whose base name matches a standard C or POSIX library header, and when a `#include "..."` directive references a name matching a standard header | Mandatory | Test | SYS-F-020 |
+| SWE1-085 | The `_check_macro_trailing_semicolon()` method shall report `macro.trailing_semicolon` for any `#define` whose expansion (after stripping string literals and comments) ends with a `;`; multi-line macros shall be fully assembled before the check | Mandatory | Test | SYS-F-020 |
+| SWE1-086 | The `_check_macro_multistatement_wrapper()` method shall report `macro.multistatement_wrapper` for any function-like `#define` whose expansion contains more than one statement and is not wrapped in `do { ... } while (0)` | Mandatory | Test | SYS-F-020 |
+| SWE1-087 | The `_check_identifier_length()` method shall report `naming.identifier_length` for any declared identifier whose name is shorter than `naming.identifier_length.min_length` or longer than `naming.identifier_length.max_length`; names matching any pattern in `exempt_patterns` shall be exempt | Mandatory | Test | SYS-F-020 |
+| SWE1-088 | The `_check_no_single_char_identifiers()` method shall report `naming.no_single_char_identifiers` for any declared identifier with a single-character name that does not appear in `naming.no_single_char_identifiers.exempt` | Mandatory | Test | SYS-F-020 |
 
 ### 4.15 Verification Criteria
 
@@ -263,6 +275,17 @@ The following criteria shall be met by all software requirements above. They are
 | SWE1-075 | Config wizard and presets | SYS-F-002 | `wizard.py` Wizard module | `test_init_wizard.py` |
 | SWE1-076 | Per-directory config | SYS-F-002 | `config.resolve_per_dir_config()` | `test_per_dir_config.py` |
 | SWE1-077 | HTML report output | SYS-F-027 | `output._violations_to_html()` | `test_html_report.py` |
+| SWE1-078 | Function length | SYS-F-020 | `Checker._check_function_length()` | `test_function_length.py` |
+| SWE1-079 | Function doc header | SYS-F-020 | `Checker._check_function_doc_header()` | `test_function_doc_header.py` |
+| SWE1-080 | Assert density | SYS-F-020 | `Checker._check_assert_density()` | `test_assert_density.py` |
+| SWE1-081 | Null statement comment | SYS-F-020 | `Checker._check_null_statement_comment()` | `test_null_statement_comment.py` |
+| SWE1-082 | Declaration spacing | SYS-F-020 | `Checker._check_declaration_spacing()` | `test_declaration_spacing.py` |
+| SWE1-083 | File length | SYS-F-020 | `Checker._check_file_length()` | `test_file_length.py` |
+| SWE1-084 | Reserved header name | SYS-F-020 | `Checker._check_reserved_header_name()` | `test_reserved_header_name.py` |
+| SWE1-085 | Macro trailing semicolon | SYS-F-020 | `Checker._check_macro_trailing_semicolon()` | `test_macro_trailing_semicolon.py` |
+| SWE1-086 | Macro multistatement wrapper | SYS-F-020 | `Checker._check_macro_multistatement_wrapper()` | `test_macro_multistatement_wrapper.py` |
+| SWE1-087 | Identifier length | SYS-F-020 | `Checker._check_identifier_length()` | `test_identifier_length.py` |
+| SWE1-088 | No single-char identifiers | SYS-F-020 | `Checker._check_no_single_char_identifiers()` | `test_no_single_char_identifiers.py` |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE3-001 | **Version** | 1.8 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SWE3-001 | **Version** | 1.9 |
+| **Project** | CStyleCheck | **Date** | 2026-06-08 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.3 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-08 | Claude | Add UNIT-102 to UNIT-112 for 11 new rules (issues #221–#232); update §8 traceability |
 | 1.8 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.6 | 2026-06-04 | Claude | Add UNIT-95 to UNIT-101 for five new features (inline suppression, fixer, wizard, per-dir config, HTML output); update §4.1 package structure; update §8 traceability — issues #188 #189 #190 #193 #192 |
 | 1.5 | 2026-06-04 | Claude | Deep accuracy audit: correct 48 stale line numbers, add 4 missing config.py units (UNIT-91 to UNIT-94), update §4.1 package structure, update §3.1 referenced doc versions — resolves issue #163 |
@@ -152,6 +153,17 @@ All source locations refer to the current package layout under `src/cstylecheck/
 | UNIT-99 | `run_preset` | `wizard.py` | COMP-09 | `wizard.py` |
 | UNIT-100 | `resolve_per_dir_config` | `config.py` | COMP-10 | `config.py` |
 | UNIT-101 | `_violations_to_html` | `output.py` | COMP-07 | `output.py` |
+| UNIT-102 | `_check_function_length` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-103 | `_check_function_doc_header` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-104 | `_check_assert_density` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-105 | `_check_null_statement_comment` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-106 | `_check_declaration_spacing` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-107 | `_check_file_length` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-108 | `_check_reserved_header_name` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-109 | `_check_macro_trailing_semicolon` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-110 | `_check_macro_multistatement_wrapper` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-111 | `_check_identifier_length` | `checker.py` | COMP-01 | `checker.py` |
+| UNIT-112 | `_check_no_single_char_identifiers` | `checker.py` | COMP-01 | `checker.py` |
 
 ---
 
@@ -849,6 +861,141 @@ src/cstylecheck/
 
 ---
 
+### UNIT-102 — `Checker._check_function_length() → None`
+
+**Purpose:** Enforce a maximum function body line count (`misc.function_length`, issue #221).
+
+**Algorithm:**
+1. Skip if `misc.function_length.enabled` is false
+2. Call `_iter_function_bodies()` to yield `(fn_def_pos, fn_name, body_start, body_end)`
+3. For each function body: split lines between `body_start` and `body_end`
+4. If `count_comments: false`, exclude blank and comment-only lines before counting
+5. If line count exceeds `max_lines`, emit `misc.function_length` at the function definition line
+
+---
+
+### UNIT-103 — `Checker._check_function_doc_header() → None`
+
+**Purpose:** Require a Doxygen block comment before each non-static function (`misc.function_doc_header`, issue #222).
+
+**Algorithm:**
+1. Skip if `misc.function_doc_header.enabled` is false
+2. For each function definition found via `RE_FUNCTION_DEF`: scan backwards for a block comment
+3. Verify comment contains `@brief` (or `\brief`)
+4. If `require_param: true`: verify each parameter has a corresponding `@param` tag
+5. If `require_return: true` and return type is not `void`: verify `@return` tag is present
+6. Emit `misc.function_doc_header` on any missing element
+
+---
+
+### UNIT-104 — `Checker._check_assert_density() → None`
+
+**Purpose:** Enforce minimum `assert()` calls per function (`misc.assert_density`, issue #225).
+
+**Algorithm:**
+1. Skip if `misc.assert_density.enabled` is false
+2. Call `_iter_function_bodies()` to yield function bodies
+3. For each body: count lines; if below `min_function_lines`, skip
+4. Check function name against `exempt_functions` regex patterns; skip if matched
+5. Count `assert(` occurrences in body
+6. If count < `min_asserts`, emit `misc.assert_density`
+
+---
+
+### UNIT-105 — `Checker._check_null_statement_comment() → None`
+
+**Purpose:** Require a comment alongside null statements (`misc.null_statement_comment`, issue #227).
+
+**Algorithm:**
+1. Skip if `misc.null_statement_comment.enabled` is false
+2. Scan `self.clean` for control-flow keywords immediately followed by `;` using a regex that handles one level of nested parentheses; emit violation for each match
+3. Scan `self.source.splitlines()` for standalone `;` on its own line; emit violation if no comment present
+
+---
+
+### UNIT-106 — `Checker._check_declaration_spacing() → None`
+
+**Purpose:** Enforce a blank line between declarations and first executable statement (`misc.declaration_spacing`, issue #224).
+
+**Algorithm:**
+1. Skip if `misc.declaration_spacing.enabled` is false
+2. Call `_iter_function_bodies()` to yield function bodies
+3. Within each body: identify trailing declaration lines (lines starting with a type keyword or typedef)
+4. Verify the line immediately following the declaration block is blank; emit `misc.declaration_spacing` if not
+
+---
+
+### UNIT-107 — `Checker._check_file_length() → None`
+
+**Purpose:** Enforce a maximum source-file line count (`misc.file_length`, issue #232).
+
+**Algorithm:**
+1. Skip if `misc.file_length.enabled` is false
+2. Split `self.source` into lines
+3. If `count_blank_lines: false`, exclude blank lines
+4. If `count_comment_lines: false`, exclude comment-only lines
+5. If remaining count > `max_lines`, emit `misc.file_length` at line 1
+
+---
+
+### UNIT-108 — `Checker._check_reserved_header_name() → None`
+
+**Purpose:** Flag files and `#include` directives using standard C/POSIX header names (`misc.reserved_header_name`, issue #230).
+
+**Algorithm:**
+1. Skip if `misc.reserved_header_name.enabled` is false
+2. Check `os.path.basename(self.filename)` against `_STANDARD_C_HEADERS`; emit violation at line 1 if matched
+3. Scan `self.source` for `#include "..."` directives; check the included name against `_STANDARD_C_HEADERS`; emit violation at the directive line if matched
+
+---
+
+### UNIT-109 — `Checker._check_macro_trailing_semicolon() → None`
+
+**Purpose:** Detect `#define` macros ending with `;` (`macro.trailing_semicolon`, issue #228).
+
+**Algorithm:**
+1. Skip if `macros.trailing_semicolon.enabled` is false
+2. Iterate source lines; collect multi-line macros (continuation `\`)
+3. Strip string literals, character literals, and comments from the assembled body
+4. If the resulting body text ends with `;`, emit `macro.trailing_semicolon`
+
+---
+
+### UNIT-110 — `Checker._check_macro_multistatement_wrapper() → None`
+
+**Purpose:** Enforce `do { ... } while (0)` for multi-statement macros (`macro.multistatement_wrapper`, issue #229).
+
+**Algorithm:**
+1. Skip if `macros.multistatement_wrapper.enabled` is false
+2. Collect function-like macros; assemble multi-line bodies
+3. Count `;` statement terminators in the body (excluding trailing `;` already caught by UNIT-109)
+4. If count > 1 and the body is not a `do { ... } while (0)` block, emit `macro.multistatement_wrapper`
+
+---
+
+### UNIT-111 — `Checker._check_identifier_length() → None`
+
+**Purpose:** Uniform min/max identifier length across all categories (`naming.identifier_length`, issue #223).
+
+**Algorithm:**
+1. Skip if `naming.identifier_length.enabled` is false
+2. For each declared identifier found by the declaration scanner: check length against `[min_length, max_length]`
+3. Skip names matching any pattern in `exempt_patterns`
+4. Emit `naming.identifier_length` for out-of-range names
+
+---
+
+### UNIT-112 — `Checker._check_no_single_char_identifiers() → None`
+
+**Purpose:** Flag single-character variable names not in the exempt list (`naming.no_single_char_identifiers`, issue #231).
+
+**Algorithm:**
+1. Skip if `naming.no_single_char_identifiers.enabled` is false
+2. For each declared identifier with `len(name) == 1`: check against `exempt` list
+3. Emit `naming.no_single_char_identifiers` for non-exempt single-character names
+
+---
+
 ### UNIT-90 — `Checker._check_whitespace_ratio() → None`
 
 **Purpose:** Enforce a minimum ratio of blank lines to code lines (issue #143), measuring code "airiness".
@@ -968,6 +1115,17 @@ Violation:
 | SWE1-075 | Config wizard and presets | UNIT-98, UNIT-99 |
 | SWE1-076 | Per-directory config | UNIT-100 |
 | SWE1-077 | HTML report output | UNIT-101 |
+| SWE1-078 | Function length | UNIT-102 |
+| SWE1-079 | Function doc header | UNIT-103 |
+| SWE1-080 | Assert density | UNIT-104 |
+| SWE1-081 | Null statement comment | UNIT-105 |
+| SWE1-082 | Declaration spacing | UNIT-106 |
+| SWE1-083 | File length | UNIT-107 |
+| SWE1-084 | Reserved header name | UNIT-108 |
+| SWE1-085 | Macro trailing semicolon | UNIT-109 |
+| SWE1-086 | Macro multistatement wrapper | UNIT-110 |
+| SWE1-087 | Identifier length | UNIT-111 |
+| SWE1-088 | No single-char identifiers | UNIT-112 |
 
 > **Note (UNIT-84):** `DeclaredNotDefinedChecker` (UNIT-84) is traced via the cross-file check requirement (SWE1-051 to SWE1-053 range). SWE1-071 maps exclusively to `_check_whitespace_ratio` (UNIT-90) as shown in the `SWE1-045 to SWE1-050, SWE1-071` row above; the duplicate mapping of SWE1-071 → UNIT-84 has been removed as a CSC-AUD-005 corrective action.
 

--- a/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
+++ b/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE4-001 | **Version** | 1.8 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SWE4-001 | **Version** | 1.9 |
+| **Project** | CStyleCheck | **Date** | 2026-06-08 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.4 |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-08 | Claude | Add 11 new test modules (102 tests) for issues #221–#232; update §6 totals; update §7 traceability |
 | 1.8 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.6 | 2026-06-04 | Claude | Automated accuracy audit: add §6 rows for test_preprocessor.py/test_comment_ratio/test_declared_not_defined/test_update_config/test_config_loading; update total 786→965; fix section header counts (§5.4/§5.6/§5.12/§5.13); update referenced doc versions; fix §3 version text; update coverage note — resolves issue #163 |
 | 1.5 | 2026-05-28 | Claude | Add §5.7b whitespace_ratio test catalogue (27 tests); fix §5.1 count 32→35; add §6 row for test_whitespace_ratio.py; update total 759→786; update §7 traceability — closes issues #148 #157 |
@@ -389,7 +390,18 @@ Each test class verifies: positive detection, negative non-detection, disabled-r
 | `test_init_wizard.py` | 15 | 15 | 0 | COMP-09 (`run_wizard`, `run_preset`) |
 | `test_per_dir_config.py` | 15 | 15 | 0 | COMP-10 (`resolve_per_dir_config`) |
 | `test_html_report.py` | 20 | 20 | 0 | COMP-07 (`_violations_to_html`) |
-| **Total** | **1041** | **1041** | **0** | All rules covered — 38 modules |
+| `test_function_length.py` | 11 | 11 | 0 | COMP-01 (`_check_function_length`) |
+| `test_function_doc_header.py` | 12 | 12 | 0 | COMP-01 (`_check_function_doc_header`) |
+| `test_assert_density.py` | 8 | 8 | 0 | COMP-01 (`_check_assert_density`) |
+| `test_null_statement_comment.py` | 9 | 9 | 0 | COMP-01 (`_check_null_statement_comment`) |
+| `test_declaration_spacing.py` | 8 | 8 | 0 | COMP-01 (`_check_declaration_spacing`) |
+| `test_file_length.py` | 8 | 8 | 0 | COMP-01 (`_check_file_length`) |
+| `test_reserved_header_name.py` | 10 | 10 | 0 | COMP-01 (`_check_reserved_header_name`) |
+| `test_macro_trailing_semicolon.py` | 9 | 9 | 0 | COMP-01 (`_check_macro_trailing_semicolon`) |
+| `test_macro_multistatement_wrapper.py` | 9 | 9 | 0 | COMP-01 (`_check_macro_multistatement_wrapper`) |
+| `test_identifier_length.py` | 10 | 10 | 0 | COMP-01 (`_check_identifier_length`) |
+| `test_no_single_char_identifiers.py` | 8 | 8 | 0 | COMP-01 (`_check_no_single_char_identifiers`) |
+| **Total** | **1143** | **1143** | **0** | All rules covered — 49 modules |
 
 **Statement Coverage (v1.1.0 CI — unit tests excl. subprocess):** 86% (1,694 statements, 243 missed)
 **Statement Coverage (v1.2.0 CI — 1041 tests incl. subprocess):** 89.8% (1,694 statements, 172 missed)
@@ -422,6 +434,17 @@ Each test class verifies: positive detection, negative non-detection, disabled-r
 | SWE1-075 | Config wizard and presets (`run_wizard`, `run_preset`) | `test_init_wizard.py` |
 | SWE1-076 | Per-directory config (`resolve_per_dir_config`) | `test_per_dir_config.py` |
 | SWE1-077 | HTML report output (`_violations_to_html`) | `test_html_report.py` |
+| SWE1-078 | Function length (`_check_function_length`) | `test_function_length.py` |
+| SWE1-079 | Function doc header (`_check_function_doc_header`) | `test_function_doc_header.py` |
+| SWE1-080 | Assert density (`_check_assert_density`) | `test_assert_density.py` |
+| SWE1-081 | Null statement comment (`_check_null_statement_comment`) | `test_null_statement_comment.py` |
+| SWE1-082 | Declaration spacing (`_check_declaration_spacing`) | `test_declaration_spacing.py` |
+| SWE1-083 | File length (`_check_file_length`) | `test_file_length.py` |
+| SWE1-084 | Reserved header name (`_check_reserved_header_name`) | `test_reserved_header_name.py` |
+| SWE1-085 | Macro trailing semicolon (`_check_macro_trailing_semicolon`) | `test_macro_trailing_semicolon.py` |
+| SWE1-086 | Macro multistatement wrapper (`_check_macro_multistatement_wrapper`) | `test_macro_multistatement_wrapper.py` |
+| SWE1-087 | Identifier length (`_check_identifier_length`) | `test_identifier_length.py` |
+| SWE1-088 | No single-char identifiers (`_check_no_single_char_identifiers`) | `test_no_single_char_identifiers.py` |
 
 ---
 

--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -56,6 +56,26 @@ RE_TYPEDEF_SIMPLE = re.compile(
     r"([A-Za-z_]\w*)\s*;",                               # typedef name
 )
 
+# Standard C (C89–C17) and POSIX.1-2017 header names (CERT PRE04-C).
+# Source files must not be named after any of these headers.
+_STANDARD_C_HEADERS: frozenset = frozenset({
+    # C standard headers
+    "assert.h", "complex.h", "ctype.h", "errno.h", "fenv.h", "float.h",
+    "inttypes.h", "iso646.h", "limits.h", "locale.h", "math.h", "setjmp.h",
+    "signal.h", "stdalign.h", "stdarg.h", "stdatomic.h", "stdbool.h",
+    "stddef.h", "stdint.h", "stdio.h", "stdlib.h", "stdnoreturn.h",
+    "string.h", "tgmath.h", "threads.h", "time.h", "uchar.h", "wchar.h",
+    "wctype.h",
+    # POSIX.1-2017 headers
+    "aio.h", "cpio.h", "dirent.h", "dlfcn.h", "fcntl.h", "fnmatch.h",
+    "ftw.h", "glob.h", "grp.h", "iconv.h", "langinfo.h", "libgen.h",
+    "monetary.h", "mqueue.h", "netdb.h", "nl_types.h", "poll.h",
+    "pthread.h", "pwd.h", "regex.h", "sched.h", "search.h", "semaphore.h",
+    "spawn.h", "strings.h", "syslog.h", "tar.h", "termios.h",
+    "unistd.h", "utime.h", "utmpx.h", "wordexp.h",
+})
+
+
 # Control-flow keywords that must never be mistaken for a return type.
 _CFKW = (
     r"if|else|while|for|do|switch|case|return|goto|break|continue"
@@ -293,14 +313,25 @@ class Checker:
     def run_all(self) -> CheckResult:
         self._check_copyright_header()
         self._check_defines()
+        self._check_macro_trailing_semicolon()    # CERT PRE11-C
+        self._check_macro_multistatement_wrapper()  # CERT PRE10-C
         self._check_variables()
         self._check_functions()
+        self._check_function_length()             # JPL Power of Ten Rule 4
+        self._check_function_doc_header()         # ESA-R-1, JSF
+        self._check_assert_density()              # JPL Power of Ten Rule 5
+        self._check_declaration_spacing()         # Linux LK-8
         self._check_typedefs()
         self._check_enums()
         self._check_structs()
         if self._is_header:
             self._check_include_guard()
         self._check_misc()
+        self._check_file_length()                 # ESA, industry practice
+        self._check_reserved_header_name()        # CERT PRE04-C
+        self._check_null_statement_comment()      # JSF Rule 192
+        self._check_identifier_length()           # ESA-R-7, JSF Rule 45
+        self._check_no_single_char_identifiers()  # ESA-R-4
         self._check_comment_ratio()
         self._check_whitespace_ratio()
         self._check_yoda()
@@ -2095,4 +2126,558 @@ class Checker:
             if name:
                 self._check_name_reserved(name, m.start(), sev)
 
+    # -----------------------------------------------------------------------
+    # Helper: iterate function bodies
+    # -----------------------------------------------------------------------
+
+    def _iter_function_bodies(self):
+        """Yield (fn_def_pos, fn_name, body_start, body_end) for each function.
+
+        body_start points to the opening '{'; body_end points one past the
+        matching closing '}'.  All positions are in self.clean / self.source
+        coordinate space (preprocess() preserves source length).
+        """
+        for m in RE_FUNCTION_DEF.finditer(self.clean):
+            name = m.group(1)
+            if not name:
+                continue
+            open_brace = self.clean.find("{", m.start())
+            if open_brace == -1:
+                continue
+            depth = 0
+            pos = open_brace
+            end = len(self.clean)
+            while pos < end:
+                ch = self.clean[pos]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        yield (m.start(), name, open_brace, pos + 1)
+                        break
+                pos += 1
+
+    # -----------------------------------------------------------------------
+    # New rule: macro.trailing_semicolon (CERT PRE11-C, issue #223)
+    # -----------------------------------------------------------------------
+
+    def _check_macro_trailing_semicolon(self) -> None:
+        """Flag #define bodies that end with a bare semicolon (CERT PRE11-C)."""
+        ts_cfg = self.cfg.get("macros", {}).get("trailing_semicolon", {})
+        if not ts_cfg.get("enabled", False):
+            return
+        sev = ts_cfg.get("severity", "warning")
+
+        lines = self.source.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            m = re.match(r'^[ \t]*#[ \t]*define[ \t]+(\w+)', line)
+            if not m:
+                i += 1
+                continue
+
+            macro_name = m.group(1)
+            start_lineno = i + 1  # 1-based
+
+            # Collect full body including backslash continuations
+            body_parts = [line]
+            while line.rstrip().endswith('\\') and i + 1 < len(lines):
+                i += 1
+                line = lines[i]
+                body_parts.append(line)
+
+            full_text = '\n'.join(body_parts)
+
+            # Strip string and char literals, then comments
+            stripped = re.sub(r'"(?:[^"\\]|\\.)*"', '""', full_text)
+            stripped = re.sub(r"'(?:[^'\\]|\\.)'", "''", stripped)
+            stripped = re.sub(r'//[^\n]*', '', stripped)
+            stripped = re.sub(r'/\*.*?\*/', '', stripped, flags=re.DOTALL)
+
+            # Isolate the macro body (everything after NAME or NAME(...))
+            body_m = re.match(
+                r'^[ \t]*#[ \t]*define[ \t]+\w+(?:\s*\([^)]*\))?',
+                stripped,
+            )
+            if body_m:
+                body = stripped[body_m.end():]
+                body = re.sub(r'\\\n', ' ', body).strip()
+                if body.endswith(';'):
+                    self.result.add(Violation(
+                        self.filepath, start_lineno, 1, sev,
+                        "macro.trailing_semicolon",
+                        f"Macro '{macro_name}' body ends with ';'; "
+                        f"remove the trailing semicolon (CERT PRE11-C)",
+                    ))
+
+            i += 1
+
+    # -----------------------------------------------------------------------
+    # New rule: macro.multistatement_wrapper (CERT PRE10-C, issue #222)
+    # -----------------------------------------------------------------------
+
+    def _check_macro_multistatement_wrapper(self) -> None:
+        """Flag function-like multi-statement macros not wrapped in do{}while(0)."""
+        mw_cfg = self.cfg.get("macros", {}).get("multistatement_wrapper", {})
+        if not mw_cfg.get("enabled", False):
+            return
+        sev = mw_cfg.get("severity", "warning")
+
+        lines = self.source.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            # Only function-like macros (have a '(' immediately after name)
+            m = re.match(r'^[ \t]*#[ \t]*define[ \t]+(\w+)\s*\(', line)
+            if not m:
+                i += 1
+                continue
+
+            macro_name = m.group(1)
+            start_lineno = i + 1
+
+            # Collect full body
+            body_parts = [line]
+            while line.rstrip().endswith('\\') and i + 1 < len(lines):
+                i += 1
+                line = lines[i]
+                body_parts.append(line)
+
+            full_text = '\n'.join(body_parts)
+
+            # Strip literals and comments
+            stripped = re.sub(r'"(?:[^"\\]|\\.)*"', '""', full_text)
+            stripped = re.sub(r"'(?:[^'\\]|\\.)'", "''", stripped)
+            stripped = re.sub(r'//[^\n]*', '', stripped)
+            stripped = re.sub(r'/\*.*?\*/', '', stripped, flags=re.DOTALL)
+
+            # Get body after the parameter list
+            body_m = re.match(
+                r'^[ \t]*#[ \t]*define[ \t]+\w+\s*\([^)]*\)',
+                stripped,
+            )
+            if not body_m:
+                i += 1
+                continue
+
+            body_flat = re.sub(r'\\\n', ' ', stripped[body_m.end():]).strip()
+
+            # Needs wrapping only if there are 2+ semicolons (multi-statement)
+            if body_flat.count(';') < 2:
+                i += 1
+                continue
+
+            # Accept do { ... } while(0) or do { ... } while (0)
+            if re.match(r'do\s*\{.*\}\s*while\s*\(\s*0\s*\)\s*;?\s*$',
+                        body_flat, re.DOTALL):
+                i += 1
+                continue
+
+            self.result.add(Violation(
+                self.filepath, start_lineno, 1, sev,
+                "macro.multistatement_wrapper",
+                f"Multi-statement macro '{macro_name}' must be wrapped in "
+                f"do {{ ... }} while(0) (CERT PRE10-C)",
+            ))
+
+            i += 1
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.function_length (JPL Power of Ten Rule 4, issue #221)
+    # -----------------------------------------------------------------------
+
+    def _check_function_length(self) -> None:
+        """Flag function bodies exceeding a configurable line count."""
+        fl_cfg = self.cfg.get("misc", {}).get("function_length", {})
+        if not fl_cfg.get("enabled", True):
+            return
+        sev = fl_cfg.get("severity", "warning")
+        max_lines = int(fl_cfg.get("max_lines", 60))
+        count_comments = fl_cfg.get("count_comments", True)
+
+        for fn_pos, name, body_start, body_end in self._iter_function_bodies():
+            body_src = self.source[body_start:body_end]
+            body_lines = body_src.splitlines()
+
+            if count_comments:
+                total = len(body_lines)
+            else:
+                first_lineno = self.source[:body_start].count('\n') + 1
+                total = sum(
+                    1 for idx, ln in enumerate(body_lines)
+                    if (first_lineno + idx) not in self._comment_only
+                    and ln.strip()
+                )
+
+            if total > max_lines:
+                self._v(
+                    fn_pos, sev, "misc.function_length",
+                    f"Function '{name}' body has {total} lines, exceeding "
+                    f"maximum {max_lines} (JPL Power of Ten Rule 4)",
+                )
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.function_doc_header (ESA-R-1, JSF, issue #224)
+    # -----------------------------------------------------------------------
+
+    def _check_function_doc_header(self) -> None:
+        """Require a documentation comment block before each function definition."""
+        fdh_cfg = self.cfg.get("misc", {}).get("function_doc_header", {})
+        if not fdh_cfg.get("enabled", False):
+            return
+        sev = fdh_cfg.get("severity", "warning")
+        req_brief = fdh_cfg.get("require_brief", True)
+        req_param = fdh_cfg.get("require_param", True)
+        req_return = fdh_cfg.get("require_return", True)
+        style = fdh_cfg.get("style", "doxygen")
+
+        _fp_cfg = self.cfg.get("file_prefix", {})
+
+        for m in RE_FUNCTION_DEF.finditer(self.clean):
+            name = m.group(1)
+            if not name:
+                continue
+
+            if _fp_cfg.get("exempt_main", True) and self.module == "main":
+                continue
+            if is_exempt(name, _fp_cfg.get("exempt_patterns", [])):
+                continue
+
+            fn_pos = m.start()
+            preceding = self.source[:fn_pos]
+            preceding_stripped = preceding.rstrip()
+
+            # The immediately-preceding non-whitespace text must end with */
+            if not preceding_stripped.endswith('*/'):
+                self._v(fn_pos, sev, "misc.function_doc_header",
+                        f"Function '{name}' must be preceded by a "
+                        f"documentation comment block (ESA-R-1, JSF)")
+                continue
+
+            # Locate the matching /* or /**
+            cmt_end_abs = preceding.rfind('*/')
+            cmt_start_abs = preceding.rfind('/*', 0, cmt_end_abs)
+            if cmt_start_abs < 0:
+                self._v(fn_pos, sev, "misc.function_doc_header",
+                        f"Function '{name}' must be preceded by a "
+                        f"documentation comment block (ESA-R-1, JSF)")
+                continue
+
+            comment_body = preceding[cmt_start_abs: cmt_end_abs + 2]
+
+            tags_brief  = ['@brief', '\\brief', '@details', '\\details']
+            tags_param  = ['@param', '\\param']
+            tags_return = ['@return', '@returns', '\\return', '\\returns']
+
+            if req_brief and style != 'any':
+                if not any(t in comment_body for t in tags_brief):
+                    self._v(fn_pos, sev, "misc.function_doc_header",
+                            f"Function '{name}' doc comment is missing "
+                            f"@brief (ESA-R-1, JSF)")
+
+            # Extract parameter names from signature
+            paren_open = self.clean.find('(', fn_pos)
+            open_brace = self.clean.find('{', fn_pos)
+            if paren_open >= 0 and open_brace > paren_open:
+                sig_text = self.clean[paren_open:open_brace]
+                param_names = [
+                    pm.group(1) for pm in RE_FUNCTION_PARAM.finditer(sig_text)
+                ]
+            else:
+                param_names = []
+
+            if req_param and param_names:
+                if not any(t in comment_body for t in tags_param):
+                    self._v(fn_pos, sev, "misc.function_doc_header",
+                            f"Function '{name}' doc comment is missing "
+                            f"@param entries (ESA-R-1, JSF)")
+
+            if req_return:
+                # Determine return type: text before function name in the match
+                match_text = self.clean[fn_pos: fn_pos + 300]
+                name_idx = match_text.find(name)
+                pre_name = match_text[:name_idx] if name_idx >= 0 else ''
+                pre_clean = re.sub(
+                    r'\b(?:static|inline|extern|const|volatile|unsigned|signed'
+                    r'|long|short|STATIC|INLINE|EXTERN|CONST|LOCAL_INLINE)\b',
+                    ' ', pre_name,
+                ).strip()
+                parts = pre_clean.split()
+                return_type = parts[-1].rstrip('*') if parts else ''
+                if return_type and return_type not in ('void', ''):
+                    if not any(t in comment_body for t in tags_return):
+                        self._v(fn_pos, sev, "misc.function_doc_header",
+                                f"Function '{name}' (returns '{return_type}') "
+                                f"doc comment is missing @return (ESA-R-1, JSF)")
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.assert_density (JPL Power of Ten Rule 5, issue #225)
+    # -----------------------------------------------------------------------
+
+    def _check_assert_density(self) -> None:
+        """Require a minimum number of assert() calls per non-trivial function."""
+        ad_cfg = self.cfg.get("misc", {}).get("assert_density", {})
+        if not ad_cfg.get("enabled", False):
+            return
+        sev = ad_cfg.get("severity", "info")
+        min_asserts = int(ad_cfg.get("min_asserts", 1))
+        min_fn_lines = int(ad_cfg.get("min_function_lines", 10))
+        exempt_fns = ad_cfg.get("exempt_functions", [])
+
+        for fn_pos, name, body_start, body_end in self._iter_function_bodies():
+            if is_exempt(name, exempt_fns):
+                continue
+
+            body_src = self.source[body_start:body_end]
+            if len(body_src.splitlines()) < min_fn_lines:
+                continue
+
+            assert_count = len(re.findall(r'\bassert\s*\(', body_src))
+            if assert_count < min_asserts:
+                self._v(
+                    fn_pos, sev, "misc.assert_density",
+                    f"Function '{name}' has {assert_count} assert() call(s); "
+                    f"minimum is {min_asserts} (Power of Ten Rule 5)",
+                )
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.declaration_spacing (Linux LK-8, issue #229)
+    # -----------------------------------------------------------------------
+
+    def _check_declaration_spacing(self) -> None:
+        """Require a blank line between the declaration block and first statement."""
+        ds_cfg = self.cfg.get("misc", {}).get("declaration_spacing", {})
+        if not ds_cfg.get("enabled", False):
+            return
+        sev = ds_cfg.get("severity", "info")
+
+        _RE_DECL = re.compile(
+            r"^\s*(?:(?:static|extern|volatile|const|unsigned|signed|long|short)\s+)*"
+            r"(?:int|char|float|double|uint\w+|int\w+|bool|_Bool|size_t|[A-Z_]\w+_[Tt])"
+            r"[ \t]*\*{0,2}[ \t]*\w+[ \t]*(?:=|;|\[)"
+        )
+
+        for fn_pos, name, body_start, body_end in self._iter_function_bodies():
+            # Work inside the body (exclude the outer braces)
+            inner_src = self.source[body_start + 1: body_end - 1]
+            first_lineno = self.source[:body_start + 1].count('\n') + 2
+            lines = inner_src.splitlines()
+
+            last_decl_idx = -1
+            first_exec_idx = -1
+
+            for idx, line in enumerate(lines):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                abs_ln = first_lineno + idx
+                if abs_ln in self._comment_only:
+                    continue
+
+                if first_exec_idx < 0:  # still scanning for transition
+                    if _RE_DECL.match(line):
+                        last_decl_idx = idx
+                    elif last_decl_idx >= 0:
+                        # First non-decl, non-blank line after declarations
+                        first_exec_idx = idx
+                        break
+                    else:
+                        # Function starts with executable — no decl block
+                        break
+
+            if last_decl_idx < 0 or first_exec_idx < 0:
+                continue
+
+            has_blank = any(
+                not lines[j].strip()
+                for j in range(last_decl_idx + 1, first_exec_idx)
+            )
+            if not has_blank:
+                abs_exec = first_lineno + first_exec_idx
+                self.result.add(Violation(
+                    self.filepath, abs_exec, 1, sev,
+                    "misc.declaration_spacing",
+                    f"First executable statement in '{name}' should be "
+                    f"preceded by a blank line after the declaration block "
+                    f"(Linux LK-8)",
+                ))
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.file_length (ESA/industry practice, issue #232)
+    # -----------------------------------------------------------------------
+
+    def _check_file_length(self) -> None:
+        """Flag files whose total line count exceeds a configurable maximum."""
+        fl_cfg = self.cfg.get("misc", {}).get("file_length", {})
+        if not fl_cfg.get("enabled", True):
+            return
+        sev = fl_cfg.get("severity", "warning")
+        max_lines = int(fl_cfg.get("max_lines", 500))
+        count_blank = fl_cfg.get("count_blank_lines", True)
+        count_comment = fl_cfg.get("count_comment_lines", True)
+
+        lines = self.source.splitlines()
+
+        if count_blank and count_comment:
+            total = len(lines)
+        else:
+            total = 0
+            for lineno, ln in enumerate(lines, 1):
+                if not count_blank and not ln.strip():
+                    continue
+                if not count_comment and lineno in self._comment_only:
+                    continue
+                total += 1
+
+        if total > max_lines:
+            self.result.add(Violation(
+                self.filepath, 1, 1, sev, "misc.file_length",
+                f"File has {total} lines, exceeding maximum {max_lines}",
+            ))
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.reserved_header_name (CERT PRE04-C, issue #230)
+    # -----------------------------------------------------------------------
+
+    def _check_reserved_header_name(self) -> None:
+        """Flag source files whose name collides with a standard C/POSIX header."""
+        rhn_cfg = self.cfg.get("misc", {}).get("reserved_header_name", {})
+        if not rhn_cfg.get("enabled", True):
+            return
+        sev = rhn_cfg.get("severity", "error")
+        extra = {n.lower().strip() for n in rhn_cfg.get("extra_reserved", [])}
+
+        basename = Path(self.filepath).name.lower()
+        if basename in _STANDARD_C_HEADERS or basename in extra:
+            self.result.add(Violation(
+                self.filepath, 1, 1, sev, "misc.reserved_header_name",
+                f"'{basename}' is a reserved C/POSIX header name; "
+                f"rename this file to avoid include-path collisions "
+                f"(CERT PRE04-C)",
+            ))
+
+    # -----------------------------------------------------------------------
+    # New rule: misc.null_statement_comment (JSF Rule 192, issue #228)
+    # -----------------------------------------------------------------------
+
+    def _check_null_statement_comment(self) -> None:
+        """Flag null statements without an explanatory comment (JSF Rule 192)."""
+        ns_cfg = self.cfg.get("misc", {}).get("null_statement_comment", {})
+        if not ns_cfg.get("enabled", True):
+            return
+        sev = ns_cfg.get("severity", "warning")
+
+        # Pattern 1: control-flow keyword with ; on the SAME LINE only.
+        # [^()\n] prevents matching across newlines.
+        # Allows one level of nested parens (e.g. while(fn());).
+        _RE_INLINE_NULL = re.compile(
+            r'\b(?:while|for|if)[ \t]*\((?:[^()\n]*|\([^()\n]*\))*\)[ \t]*;',
+        )
+        for m in _RE_INLINE_NULL.finditer(self.clean):
+            self._v(m.start(), sev, "misc.null_statement_comment",
+                    "Null statement on same line as control expression; "
+                    "put ';' on its own line with an explanatory comment "
+                    "(JSF Rule 192)")
+
+        # Pattern 2: standalone ';' on its own line without a comment
+        for lineno, line in enumerate(self.source.splitlines(), 1):
+            if line.strip() == ';':
+                self.result.add(Violation(
+                    self.filepath, lineno, 1, sev,
+                    "misc.null_statement_comment",
+                    "Standalone null statement ';' must be accompanied by an "
+                    "explanatory comment (JSF Rule 192)",
+                ))
+
+    # -----------------------------------------------------------------------
+    # New rule: naming.identifier_length (ESA-R-7, JSF Rule 45, issue #227)
+    # -----------------------------------------------------------------------
+
+    def _check_identifier_length(self) -> None:
+        """Enforce configurable min/max identifier length across all identifier types."""
+        il_cfg = self.cfg.get("naming", {}).get("identifier_length", {})
+        if not il_cfg.get("enabled", False):
+            return
+        sev = il_cfg.get("severity", "warning")
+        min_len = il_cfg.get("min_length", 3)
+        max_len = il_cfg.get("max_length", 31)
+        exempt = set(il_cfg.get("exempt_names", ["i", "j", "k", "n", "x", "y", "z"]))
+        check_vars = il_cfg.get("check_variables", True)
+        check_fns = il_cfg.get("check_functions", True)
+        check_macros_flag = il_cfg.get("check_macros", True)
+        check_types = il_cfg.get("check_types", True)
+
+        def _emit(name: str, pos: int) -> None:
+            if name in exempt or name in self._c_keywords:
+                return
+            n = len(name)
+            if min_len and n < min_len:
+                self._v(pos, sev, "naming.identifier_length",
+                        f"Identifier '{name}' length {n} is below "
+                        f"minimum {min_len} (ESA-R-7)")
+            if max_len and n > max_len:
+                self._v(pos, sev, "naming.identifier_length",
+                        f"Identifier '{name}' length {n} exceeds "
+                        f"maximum {max_len} (JSF Rule 45)")
+
+        if check_vars:
+            for m in RE_VAR_DECL.finditer(self.clean):
+                name = m.group(4)
+                if name:
+                    _emit(name, m.start())
+
+        if check_fns:
+            for m in RE_FUNCTION_DEF.finditer(self.clean):
+                name = m.group(1)
+                if name:
+                    _emit(name, m.start())
+
+        if check_macros_flag:
+            for m in RE_DEFINE.finditer(self.clean):
+                name = m.group(1)
+                rest = self.clean[m.end():].split("\n")[0].strip()
+                if rest and name:
+                    _emit(name, m.start())
+
+        if check_types:
+            for m in RE_TYPEDEF_SIMPLE.finditer(self.clean):
+                name = m.group(1)
+                if name:
+                    _emit(name, m.start())
+
+    # -----------------------------------------------------------------------
+    # New rule: naming.no_single_char_identifiers (ESA-R-4, issue #231)
+    # -----------------------------------------------------------------------
+
+    def _check_no_single_char_identifiers(self) -> None:
+        """Flag single-character identifiers outside the configured exempt list."""
+        ni_cfg = self.cfg.get("naming", {}).get("no_single_char_identifiers", {})
+        if not ni_cfg.get("enabled", False):
+            return
+        sev = ni_cfg.get("severity", "warning")
+        exempt = set(ni_cfg.get("exempt", ["i", "j", "k", "n", "x", "y", "z"]))
+
+        for m in RE_VAR_DECL.finditer(self.clean):
+            name = m.group(4)
+            if name and len(name) == 1 and name not in exempt:
+                self._v(m.start(), sev, "naming.no_single_char_identifiers",
+                        f"Single-character identifier '{name}' is not allowed "
+                        f"(ESA-R-4)")
+
+        # Also check function parameters via signature scanning
+        for fn_m in RE_FUNCTION_DEF.finditer(self.clean):
+            paren_open = self.clean.find("(", fn_m.start())
+            open_brace = self.clean.find("{", fn_m.start())
+            if paren_open < 0 or open_brace <= paren_open:
+                continue
+            sig = self.clean[paren_open:open_brace]
+            for pm in RE_FUNCTION_PARAM.finditer(sig):
+                pname = pm.group(1)
+                if pname and len(pname) == 1 and pname not in exempt:
+                    self._v(paren_open + pm.start(), sev,
+                            "naming.no_single_char_identifiers",
+                            f"Single-character parameter '{pname}' is not "
+                            f"allowed (ESA-R-4)")
 

--- a/src/rules.yml
+++ b/src/rules.yml
@@ -245,6 +245,28 @@ macros:
     enabled: false          # optionally require e.g. trailing _M
     suffix: "_M"
 
+  # -----------------------------------------------------------------------
+  # CERT PRE11-C: macro body must not end with a bare semicolon (issue #223)
+  # -----------------------------------------------------------------------
+  # A trailing ; in a #define body causes a double-semicolon at every call
+  # site (FOO(); → ;;) and syntax errors when the macro is used in an
+  # expression context.
+  # Handles line-continuation macros.
+  trailing_semicolon:
+    enabled: true
+    severity: warning
+
+  # -----------------------------------------------------------------------
+  # CERT PRE10-C: multi-statement macros must use do{}while(0) (issue #222)
+  # -----------------------------------------------------------------------
+  # A function-like macro whose body contains two or more statements (i.e.
+  # contains ';' more than once) must be wrapped in do { ... } while(0) so
+  # that it behaves correctly in all control-flow contexts (e.g. if/else
+  # without braces).
+  multistatement_wrapper:
+    enabled: true
+    severity: warning
+
 # --- Enumerations ---
 enums:
   enabled: true
@@ -610,6 +632,90 @@ misc:
     error_threshold: 0.01   # ratio below which an ERROR is raised    (1%)
     min_lines: 20           # skip files with fewer code lines (avoids trivial-file false positives)
 
+  # -----------------------------------------------------------------------
+  # Maximum lines per function body (JPL Power of Ten Rule 4, issue #221)
+  # -----------------------------------------------------------------------
+  # Each function body (including comments and blank lines within it) must
+  # not exceed max_lines lines.  The JPL default is 60; JSF uses 200.
+  # When count_comments is false, only non-blank, non-comment lines count.
+  function_length:
+    enabled: true
+    severity: warning
+    max_lines: 60           # JPL Power of Ten default; JSF uses 200
+    count_comments: true    # include blank and comment lines in the count
+
+  # -----------------------------------------------------------------------
+  # Mandatory Doxygen-style function header comment (ESA-R-1, issue #224)
+  # -----------------------------------------------------------------------
+  # Every function definition must be immediately preceded by a block
+  # comment containing at minimum @brief, @param (for each parameter), and
+  # @return (for non-void functions).
+  # style: "doxygen" requires @brief/@param/@return;
+  #        "javadoc" same tags;
+  #        "any"     accepts any non-empty comment (no tag check).
+  function_doc_header:
+    enabled: false          # opt-in; requires existing code to be updated
+    severity: warning
+    require_brief: true
+    require_param: true
+    require_return: true
+    style: doxygen
+
+  # -----------------------------------------------------------------------
+  # Minimum assert() calls per function (JPL Power of Ten Rule 5, #225)
+  # -----------------------------------------------------------------------
+  # Every non-trivial function must contain at least min_asserts calls to
+  # assert() (or a project-defined assert macro).  Functions shorter than
+  # min_function_lines are exempt, as are functions in exempt_functions.
+  assert_density:
+    enabled: false          # opt-in; off by default
+    severity: info
+    min_asserts: 1          # minimum assert() calls per qualifying function
+    min_function_lines: 10  # skip functions with fewer lines than this
+    exempt_functions: []    # regex patterns for exempt function names
+
+  # -----------------------------------------------------------------------
+  # Null statements must be on their own line with a comment (JSF Rule 192)
+  # -----------------------------------------------------------------------
+  # Flags: (1) control-flow expressions with ; on the same line (while(x);),
+  # and (2) standalone ';' on its own line without an explanatory comment.
+  null_statement_comment:
+    enabled: true
+    severity: warning
+
+  # -----------------------------------------------------------------------
+  # Blank line required after the local variable declaration block (LK-8)
+  # -----------------------------------------------------------------------
+  # Within each function body, the first executable statement must be
+  # preceded by at least one blank line after the last local variable
+  # declaration.  Functions with no declarations are not affected.
+  declaration_spacing:
+    enabled: false          # opt-in; disabled by default
+    severity: info
+
+  # -----------------------------------------------------------------------
+  # Maximum lines per source file (ESA/industry practice, issue #232)
+  # -----------------------------------------------------------------------
+  # Source files exceeding max_lines total lines are flagged.  Optionally
+  # blank lines and/or comment-only lines can be excluded from the count.
+  file_length:
+    enabled: true
+    severity: warning
+    max_lines: 500          # industry common defaults: 300–1000
+    count_blank_lines: true
+    count_comment_lines: true
+
+  # -----------------------------------------------------------------------
+  # Reserved C/POSIX standard header filename (CERT PRE04-C, issue #230)
+  # -----------------------------------------------------------------------
+  # A project source file must not share its basename with a standard C or
+  # POSIX header (e.g. string.h, stdio.h) because #include "string.h" would
+  # then include the local file instead of the system header.
+  reserved_header_name:
+    enabled: true
+    severity: error
+    extra_reserved: []      # additional project-specific names to reserve
+
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
 # shadows a C keyword, C++ keyword, or C standard library name.
@@ -717,6 +823,38 @@ ignore:
   files:
     - "stm32f4xx_hal_*.c"
     - "stm32f4xx_hal_*.h"
+
+# --- Identifier naming constraints ---
+# Cross-category rules governing identifier length and character constraints.
+# These complement the per-category length limits in variables/functions/etc.
+naming:
+  # -----------------------------------------------------------------------
+  # Min/max identifier length across all categories (ESA-R-7, JSF Rule 45)
+  # -----------------------------------------------------------------------
+  # Enforces a project-wide minimum and maximum identifier length applied
+  # uniformly across variables, functions, macros, and type names.
+  # short exempt_names (i, j, k, …) are always allowed as loop counters.
+  identifier_length:
+    enabled: false          # opt-in; off by default
+    severity: warning
+    min_length: 3           # ESA-R-7 default; set to 0 to disable min check
+    max_length: 31          # JSF Rule 45 default; set to 0 to disable max check
+    exempt_names: ["i", "j", "k", "n", "x", "y", "z"]
+    check_variables: true
+    check_functions: true
+    check_macros: true
+    check_types: true
+
+  # -----------------------------------------------------------------------
+  # No single-character identifiers except conventional loop counters (ESA-R-4)
+  # -----------------------------------------------------------------------
+  # Single-character names are ambiguous and non-searchable in code review.
+  # Identifiers in the exempt list (default: i, j, k, n, x, y, z) are
+  # accepted as conventional loop counter abbreviations.
+  no_single_char_identifiers:
+    enabled: false          # opt-in; off by default
+    severity: warning
+    exempt: ["i", "j", "k", "n", "x", "y", "z"]
 
 # --- Sign compatibility (cross-file) ---
 # Check that unsigned literals (e.g. 100U) are not passed to signed parameters

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -76,10 +76,28 @@ _ALL_OFF: dict = {
         # Whitespace ratio check (issue #143) -- disabled so existing tests
         # are not affected by the new blank-line density check.
         "whitespace_ratio":      {"enabled": False},
+        # New rules (issues #221-#232) -- disabled so existing tests are
+        # not contaminated by these checks when using cfg_only().
+        "function_length":            {"enabled": False},
+        "function_doc_header":        {"enabled": False},
+        "assert_density":             {"enabled": False},
+        "declaration_spacing":        {"enabled": False},
+        "file_length":                {"enabled": False},
+        "reserved_header_name":       {"enabled": False},
+        "null_statement_comment":     {"enabled": False},
     },
     "reserved_names":    {"enabled": False},
     "sign_compatibility":{"enabled": False},
     "spell_check":       {"enabled": False},
+    "naming": {
+        "identifier_length":          {"enabled": False},
+        "no_single_char_identifiers": {"enabled": False},
+    },
+    "macros": {
+        "trailing_semicolon":         {"enabled": False},
+        "multistatement_wrapper":     {"enabled": False},
+        "function_like_suffix":       {"enabled": False},
+    },
 }
 
 

--- a/tests/rules.yml
+++ b/tests/rules.yml
@@ -245,6 +245,28 @@ macros:
     enabled: false          # optionally require e.g. trailing _M
     suffix: "_M"
 
+  # -----------------------------------------------------------------------
+  # CERT PRE11-C: macro body must not end with a bare semicolon (issue #223)
+  # -----------------------------------------------------------------------
+  # A trailing ; in a #define body causes a double-semicolon at every call
+  # site (FOO(); → ;;) and syntax errors when the macro is used in an
+  # expression context.
+  # Handles line-continuation macros.
+  trailing_semicolon:
+    enabled: true
+    severity: warning
+
+  # -----------------------------------------------------------------------
+  # CERT PRE10-C: multi-statement macros must use do{}while(0) (issue #222)
+  # -----------------------------------------------------------------------
+  # A function-like macro whose body contains two or more statements (i.e.
+  # contains ';' more than once) must be wrapped in do { ... } while(0) so
+  # that it behaves correctly in all control-flow contexts (e.g. if/else
+  # without braces).
+  multistatement_wrapper:
+    enabled: true
+    severity: warning
+
 # --- Enumerations ---
 enums:
   enabled: true
@@ -545,7 +567,6 @@ misc:
     # Alternative: add the macro to your --defines file with 'API_WDT_EXTERN extern'.
     extern_macros: []
 
-  # TEST FIXTURE: comment_ratio disabled (intentionally matches src/rules.yml)
   # -----------------------------------------------------------------------
   # Comment-to-code ratio (issue #68)
   # -----------------------------------------------------------------------
@@ -610,6 +631,90 @@ misc:
     warning_threshold: 0.10 # ratio below which a WARNING is raised  (10%)
     error_threshold: 0.01   # ratio below which an ERROR is raised    (1%)
     min_lines: 20           # skip files with fewer code lines (avoids trivial-file false positives)
+
+  # -----------------------------------------------------------------------
+  # Maximum lines per function body (JPL Power of Ten Rule 4, issue #221)
+  # -----------------------------------------------------------------------
+  # Each function body (including comments and blank lines within it) must
+  # not exceed max_lines lines.  The JPL default is 60; JSF uses 200.
+  # When count_comments is false, only non-blank, non-comment lines count.
+  function_length:
+    enabled: true
+    severity: warning
+    max_lines: 60           # JPL Power of Ten default; JSF uses 200
+    count_comments: true    # include blank and comment lines in the count
+
+  # -----------------------------------------------------------------------
+  # Mandatory Doxygen-style function header comment (ESA-R-1, issue #224)
+  # -----------------------------------------------------------------------
+  # Every function definition must be immediately preceded by a block
+  # comment containing at minimum @brief, @param (for each parameter), and
+  # @return (for non-void functions).
+  # style: "doxygen" requires @brief/@param/@return;
+  #        "javadoc" same tags;
+  #        "any"     accepts any non-empty comment (no tag check).
+  function_doc_header:
+    enabled: false          # opt-in; requires existing code to be updated
+    severity: warning
+    require_brief: true
+    require_param: true
+    require_return: true
+    style: doxygen
+
+  # -----------------------------------------------------------------------
+  # Minimum assert() calls per function (JPL Power of Ten Rule 5, #225)
+  # -----------------------------------------------------------------------
+  # Every non-trivial function must contain at least min_asserts calls to
+  # assert() (or a project-defined assert macro).  Functions shorter than
+  # min_function_lines are exempt, as are functions in exempt_functions.
+  assert_density:
+    enabled: false          # opt-in; off by default
+    severity: info
+    min_asserts: 1          # minimum assert() calls per qualifying function
+    min_function_lines: 10  # skip functions with fewer lines than this
+    exempt_functions: []    # regex patterns for exempt function names
+
+  # -----------------------------------------------------------------------
+  # Null statements must be on their own line with a comment (JSF Rule 192)
+  # -----------------------------------------------------------------------
+  # Flags: (1) control-flow expressions with ; on the same line (while(x);),
+  # and (2) standalone ';' on its own line without an explanatory comment.
+  null_statement_comment:
+    enabled: true
+    severity: warning
+
+  # -----------------------------------------------------------------------
+  # Blank line required after the local variable declaration block (LK-8)
+  # -----------------------------------------------------------------------
+  # Within each function body, the first executable statement must be
+  # preceded by at least one blank line after the last local variable
+  # declaration.  Functions with no declarations are not affected.
+  declaration_spacing:
+    enabled: false          # opt-in; disabled by default
+    severity: info
+
+  # -----------------------------------------------------------------------
+  # Maximum lines per source file (ESA/industry practice, issue #232)
+  # -----------------------------------------------------------------------
+  # Source files exceeding max_lines total lines are flagged.  Optionally
+  # blank lines and/or comment-only lines can be excluded from the count.
+  file_length:
+    enabled: true
+    severity: warning
+    max_lines: 500          # industry common defaults: 300–1000
+    count_blank_lines: true
+    count_comment_lines: true
+
+  # -----------------------------------------------------------------------
+  # Reserved C/POSIX standard header filename (CERT PRE04-C, issue #230)
+  # -----------------------------------------------------------------------
+  # A project source file must not share its basename with a standard C or
+  # POSIX header (e.g. string.h, stdio.h) because #include "string.h" would
+  # then include the local file instead of the system header.
+  reserved_header_name:
+    enabled: true
+    severity: error
+    extra_reserved: []      # additional project-specific names to reserve
 
 # --- Reserved / banned identifier names ---
 # Checks that no declared variable, function, macro, or constant name
@@ -718,6 +823,38 @@ ignore:
   files:
     - "stm32f4xx_hal_*.c"
     - "stm32f4xx_hal_*.h"
+
+# --- Identifier naming constraints ---
+# Cross-category rules governing identifier length and character constraints.
+# These complement the per-category length limits in variables/functions/etc.
+naming:
+  # -----------------------------------------------------------------------
+  # Min/max identifier length across all categories (ESA-R-7, JSF Rule 45)
+  # -----------------------------------------------------------------------
+  # Enforces a project-wide minimum and maximum identifier length applied
+  # uniformly across variables, functions, macros, and type names.
+  # short exempt_names (i, j, k, …) are always allowed as loop counters.
+  identifier_length:
+    enabled: false          # opt-in; off by default
+    severity: warning
+    min_length: 3           # ESA-R-7 default; set to 0 to disable min check
+    max_length: 31          # JSF Rule 45 default; set to 0 to disable max check
+    exempt_names: ["i", "j", "k", "n", "x", "y", "z"]
+    check_variables: true
+    check_functions: true
+    check_macros: true
+    check_types: true
+
+  # -----------------------------------------------------------------------
+  # No single-character identifiers except conventional loop counters (ESA-R-4)
+  # -----------------------------------------------------------------------
+  # Single-character names are ambiguous and non-searchable in code review.
+  # Identifiers in the exempt list (default: i, j, k, n, x, y, z) are
+  # accepted as conventional loop counter abbreviations.
+  no_single_char_identifiers:
+    enabled: false          # opt-in; off by default
+    severity: warning
+    exempt: ["i", "j", "k", "n", "x", "y", "z"]
 
 # --- Sign compatibility (cross-file) ---
 # Check that unsigned literals (e.g. 100U) are not passed to signed parameters

--- a/tests/test_assert_density.py
+++ b/tests/test_assert_density.py
@@ -1,0 +1,63 @@
+"""test_assert_density.py — tests for misc.assert_density rule (issue #225)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+AD_CFG = cfg_only(misc={"assert_density": {
+    "enabled": True, "severity": "info",
+    "min_asserts": 1, "min_function_lines": 5, "exempt_functions": [],
+}})
+
+AD_CFG_2 = cfg_only(misc={"assert_density": {
+    "enabled": True, "severity": "info",
+    "min_asserts": 2, "min_function_lines": 5, "exempt_functions": [],
+}})
+
+AD_EXEMPT = cfg_only(misc={"assert_density": {
+    "enabled": True, "severity": "info",
+    "min_asserts": 1, "min_function_lines": 5,
+    "exempt_functions": ["foo", "ISR_.*"],
+}})
+
+
+def _make_fn_with_asserts(n_asserts, n_lines=10):
+    body = "\n".join(f"    int var_{i} = {i}; (void)var_{i};" for i in range(n_lines))
+    asserts = "\n".join(f"    assert(var_{i} >= 0);" for i in range(n_asserts))
+    return f"void foo(void) {{\n{body}\n{asserts}\n}}\n"
+
+
+class TestAssertDensity(unittest.TestCase):
+
+    def test_function_with_assert_passes(self):
+        src = _make_fn_with_asserts(1)
+        self.assertFalse(has(src, AD_CFG, "misc.assert_density"))
+
+    def test_function_without_assert_fails(self):
+        src = _make_fn_with_asserts(0)
+        self.assertTrue(has(src, AD_CFG, "misc.assert_density"))
+
+    def test_two_asserts_required_one_fails(self):
+        src = _make_fn_with_asserts(1)
+        self.assertTrue(has(src, AD_CFG_2, "misc.assert_density"))
+
+    def test_two_asserts_required_two_passes(self):
+        src = _make_fn_with_asserts(2)
+        self.assertFalse(has(src, AD_CFG_2, "misc.assert_density"))
+
+    def test_short_function_exempt(self):
+        # Function body has only 2 body lines < min_function_lines (5) — not flagged
+        src = "void foo(void) { int x = 0; (void)x; }\n"
+        self.assertFalse(has(src, AD_CFG, "misc.assert_density"))
+
+    def test_exempt_function_name_passes(self):
+        src = _make_fn_with_asserts(0)
+        self.assertFalse(has(src, AD_EXEMPT, "misc.assert_density"))
+
+    def test_rule_disabled_passes(self):
+        src = _make_fn_with_asserts(0)
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "misc.assert_density"))
+
+    def test_multiple_functions_each_checked(self):
+        src = _make_fn_with_asserts(0) + _make_fn_with_asserts(0)
+        self.assertEqual(count(src, AD_CFG, "misc.assert_density"), 2)

--- a/tests/test_declaration_spacing.py
+++ b/tests/test_declaration_spacing.py
@@ -1,0 +1,82 @@
+"""test_declaration_spacing.py — tests for misc.declaration_spacing rule (issue #229)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+DS_CFG = cfg_only(misc={"declaration_spacing": {
+    "enabled": True, "severity": "info",
+}})
+
+
+class TestDeclarationSpacing(unittest.TestCase):
+
+    def test_blank_line_present_passes(self):
+        src = (
+            "void foo(void) {\n"
+            "    int x;\n"
+            "    int y;\n"
+            "\n"
+            "    x = 1; (void)x;\n"
+            "    y = 2; (void)y;\n"
+            "}\n"
+        )
+        self.assertFalse(has(src, DS_CFG, "misc.declaration_spacing"))
+
+    def test_no_blank_line_fails(self):
+        src = (
+            "void foo(void) {\n"
+            "    int x;\n"
+            "    int y;\n"
+            "    x = 1; (void)x;\n"
+            "    y = 2; (void)y;\n"
+            "}\n"
+        )
+        self.assertTrue(has(src, DS_CFG, "misc.declaration_spacing"))
+
+    def test_no_declarations_no_violation(self):
+        src = (
+            "void foo(void) {\n"
+            "    int x = 0; (void)x;\n"
+            "    int y = 1; (void)y;\n"
+            "}\n"
+        )
+        # Lines end with '=' so they're declarations with initialisers
+        # But there's no separate 'executable' after them — no violation
+        self.assertFalse(has(src, DS_CFG, "misc.declaration_spacing"))
+
+    def test_function_with_only_decl_no_exec_passes(self):
+        src = "void foo(void) {\n    int x;\n}\n"
+        self.assertFalse(has(src, DS_CFG, "misc.declaration_spacing"))
+
+    def test_empty_function_passes(self):
+        src = "void foo(void) {}\n"
+        self.assertFalse(has(src, DS_CFG, "misc.declaration_spacing"))
+
+    def test_rule_disabled_passes(self):
+        src = (
+            "void foo(void) {\n"
+            "    int x;\n"
+            "    x = 1; (void)x;\n"
+            "}\n"
+        )
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "misc.declaration_spacing"))
+
+    def test_static_declaration_detected(self):
+        src = (
+            "void foo(void) {\n"
+            "    static int count;\n"
+            "    count++;\n"
+            "}\n"
+        )
+        self.assertTrue(has(src, DS_CFG, "misc.declaration_spacing"))
+
+    def test_multiple_functions_each_checked(self):
+        bad_fn = (
+            "void foo(void) {\n"
+            "    int x;\n"
+            "    x = 1; (void)x;\n"
+            "}\n"
+        )
+        src = bad_fn + bad_fn
+        self.assertEqual(count(src, DS_CFG, "misc.declaration_spacing"), 2)

--- a/tests/test_file_length.py
+++ b/tests/test_file_length.py
@@ -1,0 +1,61 @@
+"""test_file_length.py — tests for misc.file_length rule (issue #232)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+FL_CFG = cfg_only(misc={"file_length": {
+    "enabled": True, "severity": "warning",
+    "max_lines": 5, "count_blank_lines": True, "count_comment_lines": True,
+}})
+
+FL_NO_BLANK = cfg_only(misc={"file_length": {
+    "enabled": True, "severity": "warning",
+    "max_lines": 3, "count_blank_lines": False, "count_comment_lines": True,
+}})
+
+FL_NO_COMMENT = cfg_only(misc={"file_length": {
+    "enabled": True, "severity": "warning",
+    "max_lines": 3, "count_blank_lines": True, "count_comment_lines": False,
+}})
+
+
+class TestFileLength(unittest.TestCase):
+
+    def test_short_file_passes(self):
+        src = "void foo(void) {}\n"
+        self.assertFalse(has(src, FL_CFG, "misc.file_length"))
+
+    def test_exactly_at_limit_passes(self):
+        src = "line1\nline2\nline3\nline4\nline5\n"
+        self.assertFalse(has(src, FL_CFG, "misc.file_length"))
+
+    def test_one_over_limit_fails(self):
+        src = "line1\nline2\nline3\nline4\nline5\nline6\n"
+        self.assertTrue(has(src, FL_CFG, "misc.file_length"))
+
+    def test_violation_on_line_1(self):
+        src = "\n".join(f"line {i}" for i in range(10)) + "\n"
+        violations = [v for v in __import__('harness').run(src, FL_CFG)
+                      if v.rule == "misc.file_length"]
+        self.assertTrue(violations)
+        self.assertEqual(violations[0].line, 1)
+
+    def test_exclude_blank_lines(self):
+        # 3 code lines + 4 blank lines = 7 total, but only 3 non-blank
+        src = "line1\n\nline2\n\nline3\n\n\n"
+        self.assertFalse(has(src, FL_NO_BLANK, "misc.file_length"))
+
+    def test_include_blank_lines(self):
+        # Same 7 lines but counting blanks: 7 > max 5
+        src = "line1\n\nline2\n\nline3\n\n\n"
+        self.assertTrue(has(src, FL_CFG, "misc.file_length"))
+
+    def test_exclude_comment_lines(self):
+        # 2 code lines + 3 comment lines; excluding comments = 2 ≤ 3 max
+        src = "/* c1 */\n/* c2 */\n/* c3 */\ncode1\ncode2\n"
+        self.assertFalse(has(src, FL_NO_COMMENT, "misc.file_length"))
+
+    def test_rule_disabled_passes(self):
+        src = "\n".join(f"line {i}" for i in range(1000)) + "\n"
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "misc.file_length"))

--- a/tests/test_function_doc_header.py
+++ b/tests/test_function_doc_header.py
@@ -1,0 +1,118 @@
+"""test_function_doc_header.py — tests for misc.function_doc_header rule (issue #224)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+FDH_CFG = cfg_only(misc={"function_doc_header": {
+    "enabled": True, "severity": "warning",
+    "require_brief": True, "require_param": True, "require_return": True,
+    "style": "doxygen",
+}})
+
+FDH_BRIEF_ONLY = cfg_only(misc={"function_doc_header": {
+    "enabled": True, "severity": "warning",
+    "require_brief": True, "require_param": False, "require_return": False,
+    "style": "doxygen",
+}})
+
+FDH_ANY = cfg_only(misc={"function_doc_header": {
+    "enabled": True, "severity": "warning",
+    "require_brief": False, "require_param": False, "require_return": False,
+    "style": "any",
+}})
+
+
+class TestFunctionDocHeader(unittest.TestCase):
+
+    def test_no_comment_fails(self):
+        src = "void foo(void) {\n    int x = 0; (void)x;\n}\n"
+        self.assertTrue(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_full_doxygen_header_passes(self):
+        src = (
+            "/**\n"
+            " * @brief Does something.\n"
+            " * @param count number of items\n"
+            " * @return result code\n"
+            " */\n"
+            "int foo(int count) { return count; }\n"
+        )
+        self.assertFalse(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_missing_brief_fails(self):
+        src = (
+            "/**\n"
+            " * @param count number of items\n"
+            " * @return result code\n"
+            " */\n"
+            "int foo(int count) { return count; }\n"
+        )
+        self.assertTrue(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_missing_param_fails(self):
+        src = (
+            "/**\n"
+            " * @brief Does something.\n"
+            " * @return result code\n"
+            " */\n"
+            "int foo(int count) { return count; }\n"
+        )
+        self.assertTrue(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_void_function_no_return_required(self):
+        src = (
+            "/**\n"
+            " * @brief Does something.\n"
+            " */\n"
+            "void foo(void) { int x = 0; (void)x; }\n"
+        )
+        self.assertFalse(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_non_void_missing_return_fails(self):
+        src = (
+            "/**\n"
+            " * @brief Gets value.\n"
+            " */\n"
+            "int foo(void) { return 0; }\n"
+        )
+        self.assertTrue(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_brief_only_config_passes_without_param_return(self):
+        src = (
+            "/**\n"
+            " * @brief Gets value.\n"
+            " */\n"
+            "int foo(int count) { return count; }\n"
+        )
+        self.assertFalse(has(src, FDH_BRIEF_ONLY, "misc.function_doc_header"))
+
+    def test_any_style_accepts_plain_comment(self):
+        src = (
+            "/* Gets value. */\n"
+            "int foo(void) { return 0; }\n"
+        )
+        self.assertFalse(has(src, FDH_ANY, "misc.function_doc_header"))
+
+    def test_any_style_no_comment_fails(self):
+        src = "int foo(void) { return 0; }\n"
+        self.assertTrue(has(src, FDH_ANY, "misc.function_doc_header"))
+
+    def test_backslash_brief_accepted(self):
+        src = (
+            "/**\n"
+            " * \\brief Does something.\n"
+            " * \\param count number\n"
+            " * \\return result\n"
+            " */\n"
+            "int foo(int count) { return count; }\n"
+        )
+        self.assertFalse(has(src, FDH_CFG, "misc.function_doc_header"))
+
+    def test_rule_disabled_passes(self):
+        src = "int foo(void) { return 0; }\n"
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "misc.function_doc_header"))
+
+    def test_static_function_checked(self):
+        src = "static int foo(void) { return 0; }\n"
+        self.assertTrue(has(src, FDH_CFG, "misc.function_doc_header"))

--- a/tests/test_function_length.py
+++ b/tests/test_function_length.py
@@ -1,0 +1,100 @@
+"""test_function_length.py — tests for misc.function_length rule (issue #221)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+# max_lines=7: a function body with 5 code lines + { + } = 7 lines total
+FL_CFG = cfg_only(misc={"function_length": {
+    "enabled": True, "severity": "warning", "max_lines": 7, "count_comments": True,
+}})
+FL_CFG_NOCOMMENT = cfg_only(misc={"function_length": {
+    "enabled": True, "severity": "warning", "max_lines": 5, "count_comments": False,
+}})
+FL_CFG_60 = cfg_only(misc={"function_length": {
+    "enabled": True, "severity": "warning", "max_lines": 60, "count_comments": True,
+}})
+
+
+def _make_fn(body_lines):
+    """Build a C function with the given number of body lines.
+    Total body (from { to }) is body_lines + 2 (for the braces).
+    """
+    body = "\n".join(f"    int var_{i} = {i}; (void)var_{i};" for i in range(body_lines))
+    return f"void foo(void) {{\n{body}\n}}\n"
+
+
+class TestFunctionLength(unittest.TestCase):
+
+    def test_short_function_passes(self):
+        src = "void foo(void) {\n    int x = 1; (void)x;\n}\n"
+        self.assertFalse(has(src, FL_CFG, "misc.function_length"))
+
+    def test_exactly_at_limit_passes(self):
+        # 5 code lines + { + } = 7 lines total ≤ max_lines 7 → pass
+        src = _make_fn(5)
+        self.assertFalse(has(src, FL_CFG, "misc.function_length"))
+
+    def test_one_over_limit_fails(self):
+        # 6 code lines + { + } = 8 lines > max_lines 7 → fail
+        src = _make_fn(6)
+        self.assertTrue(has(src, FL_CFG, "misc.function_length"))
+
+    def test_well_over_limit_fails(self):
+        src = _make_fn(20)
+        self.assertTrue(has(src, FL_CFG, "misc.function_length"))
+
+    def test_violation_on_function_name_line(self):
+        src = _make_fn(10)
+        violations = [v for v in __import__('harness').run(src, FL_CFG)
+                      if v.rule == "misc.function_length"]
+        self.assertTrue(violations)
+
+    def test_multiple_functions_each_checked(self):
+        src = _make_fn(10) + _make_fn(10)
+        self.assertEqual(count(src, FL_CFG, "misc.function_length"), 2)
+
+    def test_second_function_clean_not_flagged(self):
+        long_fn = _make_fn(10)
+        short_fn = "void bar(void) { int x = 0; (void)x; }\n"
+        src = long_fn + short_fn
+        self.assertEqual(count(src, FL_CFG, "misc.function_length"), 1)
+
+    def test_count_comments_false_excludes_blank_comment_lines(self):
+        # Body: 3 code lines + 4 blank/comment lines; max_lines=5 (no-comment mode)
+        src = (
+            "void foo(void) {\n"
+            "    int x = 0;\n"
+            "    /* a comment */\n"
+            "\n"
+            "    /* another */\n"
+            "    int y = 1; (void)x; (void)y;\n"
+            "    int z = 2; (void)z;\n"
+            "}\n"
+        )
+        self.assertFalse(has(src, FL_CFG_NOCOMMENT, "misc.function_length"))
+
+    def test_rule_disabled_by_default_in_all_off(self):
+        src = _make_fn(200)
+        cfg = cfg_only()  # all rules off
+        self.assertFalse(has(src, cfg, "misc.function_length"))
+
+    def test_default_max_60(self):
+        src = _make_fn(61)
+        self.assertTrue(has(src, FL_CFG_60, "misc.function_length"))
+
+    def test_nested_braces_not_counted_twice(self):
+        # Function with an inner if{} block.  Use max_lines=3 so the 7-line
+        # function is flagged exactly once — inner {} must not trigger a second match.
+        small_cfg = cfg_only(misc={"function_length": {
+            "enabled": True, "severity": "warning", "max_lines": 3, "count_comments": True,
+        }})
+        src = (
+            "void foo(void) {\n"
+            "    int x = 1;\n"
+            "    if (x) {\n"
+            "        int y = 2; (void)y;\n"
+            "    }\n"
+            "    (void)x;\n"
+            "}\n"
+        )
+        self.assertEqual(count(src, small_cfg, "misc.function_length"), 1)

--- a/tests/test_identifier_length.py
+++ b/tests/test_identifier_length.py
@@ -1,0 +1,78 @@
+"""test_identifier_length.py — tests for naming.identifier_length rule (issue #227)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+IL_CFG = cfg_only(**{
+    "naming": {
+        "identifier_length": {
+            "enabled": True, "severity": "warning",
+            "min_length": 3, "max_length": 10,
+            "exempt_names": ["i", "j", "k"],
+            "check_variables": True, "check_functions": True,
+            "check_macros": True, "check_types": True,
+        },
+        "no_single_char_identifiers": {"enabled": False},
+    }
+})
+
+IL_MIN_ONLY = cfg_only(**{
+    "naming": {
+        "identifier_length": {
+            "enabled": True, "severity": "warning",
+            "min_length": 3, "max_length": 0,
+            "exempt_names": ["i"],
+            "check_variables": True, "check_functions": False,
+            "check_macros": False, "check_types": False,
+        },
+        "no_single_char_identifiers": {"enabled": False},
+    }
+})
+
+
+class TestIdentifierLength(unittest.TestCase):
+
+    def test_acceptable_variable_name_passes(self):
+        src = "void foo(void) { int count = 0; (void)count; }\n"
+        self.assertFalse(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_short_variable_fails(self):
+        # 'ab' has length 2 < min_length 3
+        src = "void foo(void) { int ab = 0; (void)ab; }\n"
+        self.assertTrue(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_long_variable_fails(self):
+        # 11 chars > max_length 10
+        src = "void foo(void) { int long_var_xyz = 0; (void)long_var_xyz; }\n"
+        self.assertTrue(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_exempt_name_passes(self):
+        src = "void foo(void) { int i = 0; (void)i; }\n"
+        self.assertFalse(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_c_keyword_not_flagged(self):
+        # 'int' is a C keyword — should not be flagged
+        src = "void foo(void) { int count = 0; (void)count; }\n"
+        self.assertFalse(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_min_only_no_max_check(self):
+        # 'ab' (length 2) fails min but a long name is ok with max=0
+        src = "void bar(void) { int long_name_here = 0; (void)long_name_here; }\n"
+        self.assertFalse(has(src, IL_MIN_ONLY, "naming.identifier_length"))
+
+    def test_short_macro_fails(self):
+        src = "#define AB 1\n"
+        self.assertTrue(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_long_macro_fails(self):
+        src = "#define VERY_LONG_MACRO_NAME 1\n"
+        self.assertTrue(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_acceptable_macro_passes(self):
+        src = "#define BUF 1\n"
+        self.assertFalse(has(src, IL_CFG, "naming.identifier_length"))
+
+    def test_rule_disabled_passes(self):
+        src = "void foo(void) { int ab = 0; (void)ab; }\n"
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "naming.identifier_length"))

--- a/tests/test_macro_multistatement_wrapper.py
+++ b/tests/test_macro_multistatement_wrapper.py
@@ -1,0 +1,70 @@
+"""test_macro_multistatement_wrapper.py — tests for macro.multistatement_wrapper (issue #222)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+MW_CFG = cfg_only(macros={
+    "enabled": True, "severity": "warning", "case": "upper_snake",
+    "trailing_semicolon": {"enabled": False},
+    "multistatement_wrapper": {"enabled": True, "severity": "warning"},
+    "function_like_suffix": {"enabled": False},
+    "exempt_patterns": [],
+})
+
+DISABLED_CFG = cfg_only(macros={
+    "enabled": True, "severity": "warning", "case": "upper_snake",
+    "trailing_semicolon": {"enabled": False},
+    "multistatement_wrapper": {"enabled": False},
+    "function_like_suffix": {"enabled": False},
+    "exempt_patterns": [],
+})
+
+
+class TestMacroMultistatementWrapper(unittest.TestCase):
+
+    def test_single_statement_macro_passes(self):
+        src = "#define INC(x)  ((x)++)\n"
+        self.assertFalse(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_single_statement_with_semicolon_passes(self):
+        src = "#define LOG(x)  printf(\"%d\", (x));\n"
+        self.assertFalse(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_multi_stmt_without_wrapper_fails(self):
+        src = "#define INIT(x) (x)->a = 0; (x)->b = 0;\n"
+        self.assertTrue(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_multi_stmt_with_do_while_passes(self):
+        src = "#define INIT(x) do { (x)->a = 0; (x)->b = 0; } while(0)\n"
+        self.assertFalse(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_multi_stmt_do_while_with_space_passes(self):
+        src = "#define INIT(x) do { (x)->a = 0; (x)->b = 0; } while (0)\n"
+        self.assertFalse(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_multi_stmt_multiline_without_wrapper_fails(self):
+        src = (
+            "#define SETUP(p) \\\n"
+            "    (p)->x = 0; \\\n"
+            "    (p)->y = 0;\n"
+        )
+        self.assertTrue(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_multi_stmt_multiline_with_wrapper_passes(self):
+        src = (
+            "#define SETUP(p) \\\n"
+            "    do { \\\n"
+            "        (p)->x = 0; \\\n"
+            "        (p)->y = 0; \\\n"
+            "    } while(0)\n"
+        )
+        self.assertFalse(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_object_like_macro_not_checked(self):
+        # Object-like macros (no param list) should not be checked
+        src = "#define VALS 1; 2;\n"
+        self.assertFalse(has(src, MW_CFG, "macro.multistatement_wrapper"))
+
+    def test_rule_disabled_passes(self):
+        src = "#define INIT(x) (x)->a = 0; (x)->b = 0;\n"
+        self.assertFalse(has(src, DISABLED_CFG, "macro.multistatement_wrapper"))

--- a/tests/test_macro_trailing_semicolon.py
+++ b/tests/test_macro_trailing_semicolon.py
@@ -1,0 +1,59 @@
+"""test_macro_trailing_semicolon.py — tests for macro.trailing_semicolon rule (issue #223)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+TS_CFG = cfg_only(macros={
+    "enabled": True, "severity": "warning", "case": "upper_snake",
+    "trailing_semicolon": {"enabled": True, "severity": "warning"},
+    "multistatement_wrapper": {"enabled": False},
+    "function_like_suffix": {"enabled": False},
+    "exempt_patterns": [],
+})
+
+DISABLED_CFG = cfg_only(macros={
+    "enabled": True, "severity": "warning", "case": "upper_snake",
+    "trailing_semicolon": {"enabled": False},
+    "multistatement_wrapper": {"enabled": False},
+    "function_like_suffix": {"enabled": False},
+    "exempt_patterns": [],
+})
+
+
+class TestMacroTrailingSemicolon(unittest.TestCase):
+
+    def test_clean_macro_no_semicolon_passes(self):
+        src = "#define RESET_FLAG(x)  ((x) = 0)\n"
+        self.assertFalse(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_trailing_semicolon_fails(self):
+        src = "#define RESET_FLAG(x)  ((x) = 0);\n"
+        self.assertTrue(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_object_like_macro_trailing_semicolon_fails(self):
+        src = "#define MAX_SIZE  (100);\n"
+        self.assertTrue(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_multiline_macro_trailing_semicolon_fails(self):
+        src = "#define SET(a, b) \\\n    (a) = (b); \\\n    (void)(b);\n"
+        self.assertTrue(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_multiline_macro_without_semicolon_passes(self):
+        src = "#define SET(a, b) \\\n    (a) = (b)\n"
+        self.assertFalse(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_semicolon_in_string_is_ignored(self):
+        src = '#define ERR_MSG  "error;"\n'
+        self.assertFalse(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_rule_disabled_passes(self):
+        src = "#define RESET_FLAG(x)  ((x) = 0);\n"
+        self.assertFalse(has(src, DISABLED_CFG, "macro.trailing_semicolon"))
+
+    def test_include_guard_define_not_flagged(self):
+        src = "#ifndef FOO_H_\n#define FOO_H_\n#endif\n"
+        self.assertFalse(has(src, TS_CFG, "macro.trailing_semicolon"))
+
+    def test_multiple_violations_counted(self):
+        src = "#define A(x) (x);\n#define B(x) (x);\n"
+        self.assertEqual(count(src, TS_CFG, "macro.trailing_semicolon"), 2)

--- a/tests/test_no_single_char_identifiers.py
+++ b/tests/test_no_single_char_identifiers.py
@@ -1,0 +1,60 @@
+"""test_no_single_char_identifiers.py — tests for naming.no_single_char_identifiers (issue #231)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+NI_CFG = cfg_only(**{
+    "naming": {
+        "no_single_char_identifiers": {
+            "enabled": True, "severity": "warning",
+            "exempt": ["i", "j", "k", "n", "x", "y", "z"],
+        },
+        "identifier_length": {"enabled": False},
+    }
+})
+
+NI_STRICT = cfg_only(**{
+    "naming": {
+        "no_single_char_identifiers": {
+            "enabled": True, "severity": "warning",
+            "exempt": [],
+        },
+        "identifier_length": {"enabled": False},
+    }
+})
+
+
+class TestNoSingleCharIdentifiers(unittest.TestCase):
+
+    def test_normal_name_passes(self):
+        src = "void foo(void) { int count = 0; (void)count; }\n"
+        self.assertFalse(has(src, NI_CFG, "naming.no_single_char_identifiers"))
+
+    def test_exempt_loop_var_passes(self):
+        src = "void foo(void) { int i = 0; (void)i; }\n"
+        self.assertFalse(has(src, NI_CFG, "naming.no_single_char_identifiers"))
+
+    def test_non_exempt_single_char_fails(self):
+        src = "void foo(void) { int a = 0; (void)a; }\n"
+        self.assertTrue(has(src, NI_CFG, "naming.no_single_char_identifiers"))
+
+    def test_strict_mode_flags_i(self):
+        src = "void foo(void) { int i = 0; (void)i; }\n"
+        self.assertTrue(has(src, NI_STRICT, "naming.no_single_char_identifiers"))
+
+    def test_two_char_name_not_flagged(self):
+        src = "void foo(void) { int ix = 0; (void)ix; }\n"
+        self.assertFalse(has(src, NI_CFG, "naming.no_single_char_identifiers"))
+
+    def test_rule_disabled_passes(self):
+        src = "void foo(void) { int a = 0; (void)a; }\n"
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "naming.no_single_char_identifiers"))
+
+    def test_multiple_violations_counted(self):
+        src = "void foo(void) { int a = 0; int b = 0; (void)a; (void)b; }\n"
+        self.assertEqual(count(src, NI_CFG, "naming.no_single_char_identifiers"), 2)
+
+    def test_exempt_xyz_passes(self):
+        src = "void foo(void) { int x = 0; int y = 0; int z = 0; (void)x; (void)y; (void)z; }\n"
+        self.assertFalse(has(src, NI_CFG, "naming.no_single_char_identifiers"))

--- a/tests/test_null_statement_comment.py
+++ b/tests/test_null_statement_comment.py
@@ -1,0 +1,53 @@
+"""test_null_statement_comment.py — tests for misc.null_statement_comment (issue #228)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, has, clean, count
+
+NS_CFG = cfg_only(misc={"null_statement_comment": {
+    "enabled": True, "severity": "warning",
+}})
+
+
+class TestNullStatementComment(unittest.TestCase):
+
+    def test_while_null_same_line_fails(self):
+        src = "void foo(void) { while (condition()); }\n"
+        self.assertTrue(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_for_null_same_line_fails(self):
+        src = "void foo(void) { for (;;); }\n"
+        self.assertTrue(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_while_with_body_passes(self):
+        src = "void foo(void) { while (condition()) { break; } }\n"
+        self.assertFalse(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_standalone_semicolon_without_comment_fails(self):
+        src = "void foo(void) {\n    while (condition())\n    ;\n}\n"
+        self.assertTrue(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_standalone_semicolon_with_comment_passes(self):
+        src = "void foo(void) {\n    while (condition())\n    ;   /* spin until ready */\n}\n"
+        self.assertFalse(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_normal_statement_semicolon_not_flagged(self):
+        src = "void foo(void) { int x = 0; (void)x; }\n"
+        self.assertFalse(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_rule_disabled_passes(self):
+        src = "void foo(void) { while (condition()); }\n"
+        cfg = cfg_only()
+        self.assertFalse(has(src, cfg, "misc.null_statement_comment"))
+
+    def test_if_null_same_line_fails(self):
+        src = "void foo(void) { if (condition()); }\n"
+        self.assertTrue(has(src, NS_CFG, "misc.null_statement_comment"))
+
+    def test_multiple_violations(self):
+        src = (
+            "void foo(void) {\n"
+            "    while (a());\n"
+            "    for (;;);\n"
+            "}\n"
+        )
+        self.assertEqual(count(src, NS_CFG, "misc.null_statement_comment"), 2)

--- a/tests/test_reserved_header_name.py
+++ b/tests/test_reserved_header_name.py
@@ -1,0 +1,79 @@
+"""test_reserved_header_name.py — tests for misc.reserved_header_name (issue #230)."""
+import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import unittest
+from harness import cfg_only, run, has
+
+RHN_CFG = cfg_only(misc={"reserved_header_name": {
+    "enabled": True, "severity": "error", "extra_reserved": [],
+}})
+
+RHN_EXTRA = cfg_only(misc={"reserved_header_name": {
+    "enabled": True, "severity": "error", "extra_reserved": ["mylib.h"],
+}})
+
+RHN_DISABLED = cfg_only(misc={"reserved_header_name": {
+    "enabled": False,
+}})
+
+
+def _violations(source, cfg, filepath):
+    from harness import Checker
+    c = Checker(filepath, source, cfg)
+    return c.run_all().violations
+
+
+class TestReservedHeaderName(unittest.TestCase):
+
+    def test_project_header_passes(self):
+        v = _violations("", RHN_CFG, "uart_driver.h")
+        names = [vv.rule for vv in v]
+        self.assertNotIn("misc.reserved_header_name", names)
+
+    def test_stdio_h_fails(self):
+        v = _violations("", RHN_CFG, "stdio.h")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)
+
+    def test_string_h_fails(self):
+        v = _violations("", RHN_CFG, "string.h")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)
+
+    def test_stdlib_h_fails(self):
+        v = _violations("", RHN_CFG, "stdlib.h")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)
+
+    def test_unistd_h_posix_fails(self):
+        v = _violations("", RHN_CFG, "unistd.h")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)
+
+    def test_c_file_not_checked(self):
+        # Reserved header name check applies to the filename regardless of content
+        v = _violations("", RHN_CFG, "string.c")
+        names = [vv.rule for vv in v]
+        # "string.c" is not a reserved header (only "string.h" is)
+        self.assertNotIn("misc.reserved_header_name", names)
+
+    def test_extra_reserved_fails(self):
+        v = _violations("", RHN_EXTRA, "mylib.h")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)
+
+    def test_rule_disabled_passes(self):
+        v = _violations("", RHN_DISABLED, "stdio.h")
+        names = [vv.rule for vv in v]
+        self.assertNotIn("misc.reserved_header_name", names)
+
+    def test_case_insensitive_filename(self):
+        # File named STDIO.H should also be flagged
+        v = _violations("", RHN_CFG, "STDIO.H")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)
+
+    def test_path_prefix_ignored(self):
+        # Only the basename matters
+        v = _violations("", RHN_CFG, "include/stdio.h")
+        names = [vv.rule for vv in v]
+        self.assertIn("misc.reserved_header_name", names)


### PR DESCRIPTION
## Summary

Merges all work from `develop` into `main`, delivering 11 new rules:

| Rule ID | Issue | Status |
|---|---|---|
| `misc.function_length` | #221 | ✅ |
| `misc.function_doc_header` | #222 | ✅ |
| `naming.identifier_length` | #223 | ✅ |
| `misc.declaration_spacing` | #224 | ✅ |
| `misc.assert_density` | #225 | ✅ |
| `misc.null_statement_comment` | #227 | ✅ |
| `macro.trailing_semicolon` | #228 | ✅ |
| `macro.multistatement_wrapper` | #229 | ✅ |
| `misc.reserved_header_name` | #230 | ✅ |
| `naming.no_single_char_identifiers` | #231 | ✅ |
| `misc.file_length` | #232 | ✅ |

## What's included

- 11 new check methods in `checker.py`
- 102 new tests (1143 total)
- `src/rules.yml` and `tests/rules.yml` updated
- `Rules-and-Configuration.md` sections 3.3, 3.4, 9.9–9.15, 13.1–13.2 added
- `CHANGELOG.md` Unreleased section
- `README.md` updated (53→64 rules, 1041→1143 tests)
- ASPICE SWE1 v1.8, SWE3 v1.9, SWE4 v1.9 updated

All CI checks green on `develop`.

Closes #221, #222, #223, #224, #225, #227, #228, #229, #230, #231, #232

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_