### PR TITLE
Fix ASPICE audit findings: stale version refs and counts in SVD, SWE2, SWE4 (issue #238)

### DIFF
--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.7 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.8 |
+| **Project** | CStyleCheck | **Date** | 2026-06-08 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.8 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.8 | 2026-06-08 | Claude | ASPICE audit #238 — update SWE1/SWE3/SWE4 version refs; correct rule count 53→64; update test count 1041→1143, 38→49 modules |
 | 1.7 | 2026-06-05 | Claude | v1.3.0 release — update all version identifiers, release summary, change log, upgrade notes |
 | 1.6 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.5 | 2026-06-04 | Claude | Add §6.1 F-008 to F-012 for five new features (inline suppression, --fix, --init/--preset, per-dir config, HTML output); update §5.1 deliverables, §5.5 doc versions, §10 traceability — issues #188 #189 #190 #193 #192 |
@@ -40,10 +41,10 @@ This document satisfies the release-identification and configuration-status-acco
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.6 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.8 |
-| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.8 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.8 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.7 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.9 |
+| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.9 |
 | CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.4 |
 | CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.5 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.6 |
@@ -71,7 +72,7 @@ This document satisfies the release-identification and configuration-status-acco
 
 This is a **minor release** under Semantic Versioning. It is **backward-compatible** with v1.2.1: all existing `rules.yml` configurations, CLI flags, and pre-commit hook integrations continue to work without modification.
 
-New capabilities (inline suppression, `--fix`, `--init`/`--preset`, per-directory config, HTML report) are entirely additive. The CLI entry point, all 53 rule IDs, and all existing output formats are unchanged from the caller's perspective.
+New capabilities (inline suppression, `--fix`, `--init`/`--preset`, per-directory config, HTML report, and 11 new rules from issues #221–#232) are entirely additive. The CLI entry point, all 64 rule IDs, and all existing output formats are backward-compatible with v1.2.1.
 
 ---
 
@@ -88,7 +89,7 @@ New capabilities (inline suppression, `--fix`, `--init`/`--preset`, per-director
 | `src/cstylecheck/models.py` | Violation, CheckResult, shared constants | `src/cstylecheck/models.py` |
 | `src/cstylecheck/preprocessor.py` | Comment/string stripping, token extraction | `src/cstylecheck/preprocessor.py` |
 | `src/cstylecheck/utils.py` | Case matching helpers, module-name derivation | `src/cstylecheck/utils.py` |
-| `src/cstylecheck/checker.py` | Main Checker class — all 53 rule implementations | `src/cstylecheck/checker.py` |
+| `src/cstylecheck/checker.py` | Main Checker class — all 64 rule implementations | `src/cstylecheck/checker.py` |
 | `src/cstylecheck/sign_checker.py` | Cross-file sign-compatibility and declared_not_defined | `src/cstylecheck/sign_checker.py` |
 | `src/cstylecheck/baseline.py` | Baseline load / write | `src/cstylecheck/baseline.py` |
 | `src/cstylecheck/output.py` | Text / JSON / SARIF / HTML formatters, Tee, summary table | `src/cstylecheck/output.py` |
@@ -124,7 +125,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 ### 5.4 Test Suite
 
-**Total: 1041 tests across 38 modules** — all passing.
+**Total: 1143 tests across 49 modules** — all passing.
 
 | Item | Test Count | Description |
 |---|---|---|
@@ -166,7 +167,18 @@ Platforms: `linux/amd64`, `linux/arm64`.
 | `tests/test_init_wizard.py` | 15 | Config wizard and presets (`run_wizard`, `run_preset`) |
 | `tests/test_per_dir_config.py` | 15 | Per-directory config resolution (`resolve_per_dir_config`) |
 | `tests/test_html_report.py` | 20 | HTML report output (`_violations_to_html`) |
-| **Total** | **1041** | |
+| `tests/test_function_length.py` | 11 | `misc.function_length` rule |
+| `tests/test_function_doc_header.py` | 12 | `misc.function_doc_header` rule |
+| `tests/test_assert_density.py` | 8 | `misc.assert_density` rule |
+| `tests/test_null_statement_comment.py` | 9 | `misc.null_statement_comment` rule |
+| `tests/test_declaration_spacing.py` | 8 | `misc.declaration_spacing` rule |
+| `tests/test_file_length.py` | 8 | `misc.file_length` rule |
+| `tests/test_reserved_header_name.py` | 10 | `misc.reserved_header_name` rule |
+| `tests/test_macro_trailing_semicolon.py` | 9 | `macro.trailing_semicolon` rule |
+| `tests/test_macro_multistatement_wrapper.py` | 9 | `macro.multistatement_wrapper` rule |
+| `tests/test_identifier_length.py` | 10 | `naming.identifier_length` rule |
+| `tests/test_no_single_char_identifiers.py` | 8 | `naming.no_single_char_identifiers` rule |
+| **Total** | **1143** | |
 
 ### 5.5 Documentation
 

--- a/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
+++ b/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
@@ -48,7 +48,7 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.1 — Software Requir
 |---|---|---|
 | CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.5 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.4 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.6 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.7 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.5 |
 | Barr-C:2018 | Barr Group Embedded C Coding Standard | 2018 |
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |

--- a/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
+++ b/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE2-001 | **Version** | 1.6 |
+| **Document ID** | CSC-SWE2-001 | **Version** | 1.7 |
 | **Project** | CStyleCheck | **Date** | 2026-06-05 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.7 | 2026-06-08 | Claude | ASPICE audit #238 — add COMP-05h (naming rules); extend §10 RTM with SWE1-078–088 |
 | 1.6 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.5 | 2026-06-04 | Claude | Add COMP-08 (Fixer), COMP-09 (Config Wizard), COMP-10 (Per-dir Config); add `parse_inline_suppressions` to COMP-04; add `_violations_to_html` to COMP-07; update §8.1 sequence; update §10 RTM — issues #188 #189 #190 #193 #192 |
 | 1.4 | 2026-06-04 | Claude | Deep accuracy audit: fix §3 version text, update §3.1 referenced doc versions, fix COMP-05f functions (remove non-existent, add missing), add comment/whitespace ratio to §8.1 sequence, add SWE1-071/MISRA rows to §10 RTM, add config utility functions to COMP-02 — resolves issue #163 |
@@ -72,8 +73,14 @@ src/cstylecheck/   (package — 12 sub-modules)
 │   ├── [COMP-05e] Guard Checker       (_check_include_guard)
 │   ├── [COMP-05f] Misc Checker        (_check_misc, _check_yoda, _check_spelling,
 │   │                                   _check_reserved_names, _check_copyright_header,
-│   │                                   _check_comment_ratio, _check_whitespace_ratio)
-│   └── [COMP-05g] Sign Checker        (class SignChecker — _check_calls)
+│   │                                   _check_comment_ratio, _check_whitespace_ratio,
+│   │                                   _check_function_length, _check_function_doc_header,
+│   │                                   _check_assert_density, _check_null_statement_comment,
+│   │                                   _check_declaration_spacing, _check_file_length,
+│   │                                   _check_reserved_header_name)
+│   ├── [COMP-05g] Sign Checker        (class SignChecker — _check_calls)
+│   └── [COMP-05h] Naming Checker      (_check_identifier_length,
+│                                       _check_no_single_char_identifiers)
 ├── [COMP-06] Baseline Manager         (load_baseline, write_baseline, _baseline_key)
 ├── [COMP-07] Output Formatter         (_violations_to_json, _violations_to_sarif,
 │                                       _violations_to_html, print_summary,
@@ -189,6 +196,16 @@ The `Checker` class is the central analysis component. It is instantiated once p
 | **Responsibility** | Cross-file sign-compatibility analysis; resolves typedef chains; enforces `plain_char_is_signed` without global state mutation |
 | **Key method** | `_check_calls()` — finds function calls and validates argument signedness against parameter declarations |
 | **Rule enforced** | `sign_compatibility` |
+
+#### COMP-05h — Naming Constraints Checker
+
+| Attribute | Value |
+|---|---|
+| **Source module** | `checker.py` |
+| **Methods** | `_check_identifier_length()`, `_check_no_single_char_identifiers()` |
+| **Responsibility** | Enforce cross-category identifier naming constraints: uniform min/max length (`naming.identifier_length`) and single-character identifier prohibition (`naming.no_single_char_identifiers`); both rules are opt-in (disabled by default) |
+| **Config section** | `naming:` |
+| **Rules enforced** | `naming.identifier_length`, `naming.no_single_char_identifiers` |
 
 ### COMP-06 — Baseline Manager
 
@@ -349,6 +366,17 @@ main()
 | SWE1-075 | Config wizard and presets | COMP-09 |
 | SWE1-076 | Per-directory config | COMP-10 |
 | SWE1-077 | HTML report output | COMP-07 |
+| SWE1-078 | `misc.function_length` | COMP-05f |
+| SWE1-079 | `misc.function_doc_header` | COMP-05f |
+| SWE1-080 | `misc.assert_density` | COMP-05f |
+| SWE1-081 | `misc.null_statement_comment` | COMP-05f |
+| SWE1-082 | `misc.declaration_spacing` | COMP-05f |
+| SWE1-083 | `misc.file_length` | COMP-05f |
+| SWE1-084 | `misc.reserved_header_name` | COMP-05f |
+| SWE1-085 | `macro.trailing_semicolon` | COMP-05c |
+| SWE1-086 | `macro.multistatement_wrapper` | COMP-05c |
+| SWE1-087 | `naming.identifier_length` | COMP-05h |
+| SWE1-088 | `naming.no_single_char_identifiers` | COMP-05h |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -40,8 +40,8 @@ This document defines the detailed design of each software unit in **CStyleCheck
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.6 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.8 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.7 |
 | CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.8 |
 
 ---

--- a/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
+++ b/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE4-001 | **Version** | 1.9 |
+| **Document ID** | CSC-SWE4-001 | **Version** | 1.10 |
 | **Project** | CStyleCheck | **Date** | 2026-06-08 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.10 | 2026-06-08 | Claude | ASPICE audit #238 — correct CSC-SWE3 version reference 1.8→1.9 in §3.1 |
 | 1.9 | 2026-06-08 | Claude | Add 11 new test modules (102 tests) for issues #221–#232; update §6 totals; update §7 traceability |
 | 1.8 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.6 | 2026-06-04 | Claude | Automated accuracy audit: add §6 rows for test_preprocessor.py/test_comment_ratio/test_declared_not_defined/test_update_config/test_config_loading; update total 786→965; fix section header counts (§5.4/§5.6/§5.12/§5.13); update referenced doc versions; fix §3 version text; update coverage note — resolves issue #163 |
@@ -45,7 +46,7 @@ Unit verification covers both dynamic testing (pytest test suite) and static ver
 | Document ID | Title | Version |
 |---|---|---|
 | CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.8 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.9 |
 | CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.4 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.4 |
 


### PR DESCRIPTION
## Summary

Fixes all findings from ASPICE internal audit (issue #238).

- **SVD v1.8** — corrects five stale values: SWE1/SWE3/SWE4 version references, rule count (53→64), test count (1041→1143, 38→49 modules), adds 11 new test modules to §5.4
- **SWE4 v1.10** — corrects CSC-SWE3-001 version reference 1.8→1.9 in §3.1
- **SWE2 v1.7** — adds COMP-05h (naming constraints checker), updates package diagram, extends §10 RTM with SWE1-078–088
- **SWE1 v1.8** — updates SWE2 reference 1.6→1.7 in §3.2
- **SWE3 v1.9** — updates SWE1 reference 1.7→1.8 and SWE2 reference 1.6→1.7 in §3.1

## Test plan
- [ ] Doc-only change — no code changes; CI YAML-004 diff check should pass
- [ ] All version cross-references are internally consistent after this change

Closes #238

https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_