### PR TITLE
fix: update Rule IDs section header from 53 to 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Rule ID: `misc.eof_comment` · Default severity: `warning`
 
 ---
 
-## Rule IDs (53 total)
+## Rule IDs (64 total)
 
 | Category | Rule IDs |
 |---|---|


### PR DESCRIPTION
Fixes stale "53 total" in the `## Rule IDs` section header — all other README references were already updated to 64 when the 11 new rules were added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_