### PR TITLE
chore: sync develop → main (fix README rule count header)

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Rule ID: `misc.eof_comment` · Default severity: `warning`
 
 ---
 
-## Rule IDs (53 total)
+## Rule IDs (64 total)
 
 | Category | Rule IDs |
 |---|---|


### PR DESCRIPTION
Syncs the README Rule IDs header fix (53→64) to main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5MRLpufU8oLRn89uSmC6Y)_