### PR TITLE
Fix variable.pointer_prefix false positive on non-parameter scopes (#245)

### DIFF
--- a/embedded_c_coding_standard.md
+++ b/embedded_c_coding_standard.md
@@ -1,0 +1,1820 @@
+# Embedded C Coding Standard
+
+---
+
+| Field | Value |
+|---|---|
+| Document ID | CSC-STD-001 |
+| Title | Embedded C Coding Standard |
+| Version | 1.0 (DRAFT) |
+| Status | Draft — Pending Rule Population |
+| Date | 2026-06-08 |
+| Owner | Software Engineering Lead |
+| Applies To | All embedded C source and header files |
+| ASPICE Process Areas | SWE.3, SWE.4, SWE.5, SUP.1, SUP.8 |
+| Standards Alignment | MISRA C:2012/2023, Barr-C:2018, CERT C, NASA Power of Ten, ISO 26262 |
+
+> **Note:** Sections marked `[RULE: TBD]` are structural placeholders. They will be populated with specific rules derived from `src/rules.yml` (cstylecheck) and associated static analysis tool configurations. Do not remove placeholder sections.
+
+---
+
+## Table of Contents
+
+1. [Purpose and Scope](#1-purpose-and-scope)
+2. [Terms and Definitions](#2-terms-and-definitions)
+3. [Normative References](#3-normative-references)
+4. [ASPICE Compliance Notes](#4-aspice-compliance-notes)
+5. [Roles and Responsibilities](#5-roles-and-responsibilities)
+6. [Rule Classification System](#6-rule-classification-system)
+7. [Compiler and Toolchain Requirements](#7-compiler-and-toolchain-requirements)
+8. [Language Subset — Permitted C Features](#8-language-subset--permitted-c-features)
+9. [Language Subset — Prohibited C Features](#9-language-subset--prohibited-c-features)
+10. [Data Types and Type Safety](#10-data-types-and-type-safety)
+11. [Integer Types — Selection and Use](#11-integer-types--selection-and-use)
+12. [Integer Arithmetic and Overflow](#12-integer-arithmetic-and-overflow)
+13. [Implicit and Explicit Type Conversions](#13-implicit-and-explicit-type-conversions)
+14. [Pointer Types and Pointer Safety](#14-pointer-types-and-pointer-safety)
+15. [Arrays and Buffer Safety](#15-arrays-and-buffer-safety)
+16. [String Handling](#16-string-handling)
+17. [Boolean Expressions](#17-boolean-expressions)
+18. [Bitwise Operations](#18-bitwise-operations)
+19. [Memory Management — Static Allocation](#19-memory-management--static-allocation)
+20. [Memory Management — Dynamic Allocation](#20-memory-management--dynamic-allocation)
+21. [Memory Management — Stack Usage](#21-memory-management--stack-usage)
+22. [Memory Management — Volatile and Shared Data](#22-memory-management--volatile-and-shared-data)
+23. [Control Flow — General](#23-control-flow--general)
+24. [Control Flow — `goto`](#24-control-flow--goto)
+25. [Control Flow — Recursion](#25-control-flow--recursion)
+26. [Control Flow — Infinite Loops](#26-control-flow--infinite-loops)
+27. [Control Flow — `break` and `continue`](#27-control-flow--break-and-continue)
+28. [Control Flow — `switch` Statements](#28-control-flow--switch-statements)
+29. [Functions — Design Rules](#29-functions--design-rules)
+30. [Functions — Parameters and Return Values](#30-functions--parameters-and-return-values)
+31. [Functions — Prototypes and Declarations](#31-functions--prototypes-and-declarations)
+32. [Functions — Inline Functions](#32-functions--inline-functions)
+33. [Functions — Recursion](#33-functions--recursion)
+34. [Functions — Assertions](#34-functions--assertions)
+35. [Preprocessor — Conditional Compilation](#35-preprocessor--conditional-compilation)
+36. [Preprocessor — Header Inclusion](#36-preprocessor--header-inclusion)
+37. [Preprocessor — Macros vs. Functions](#37-preprocessor--macros-vs-functions)
+38. [Preprocessor — Token Pasting and Stringification](#38-preprocessor--token-pasting-and-stringification)
+39. [Global Variables](#39-global-variables)
+40. [File-Scope Static Variables](#40-file-scope-static-variables)
+41. [Constants — `const` vs. `#define`](#41-constants--const-vs-define)
+42. [Initialisation](#42-initialisation)
+43. [Scope and Lifetime](#43-scope-and-lifetime)
+44. [Linkage](#44-linkage)
+45. [Structures and Unions](#45-structures-and-unions)
+46. [Bit Fields](#46-bit-fields)
+47. [Enumerations](#47-enumerations)
+48. [Standard Library Usage](#48-standard-library-usage)
+49. [Restricted Standard Library Functions](#49-restricted-standard-library-functions)
+50. [Concurrency — Interrupt Safety](#50-concurrency--interrupt-safety)
+51. [Concurrency — RTOS Task Safety](#51-concurrency--rtos-task-safety)
+52. [Concurrency — Atomic Access](#52-concurrency--atomic-access)
+53. [Error Handling — Strategy](#53-error-handling--strategy)
+54. [Error Handling — Return Codes](#54-error-handling--return-codes)
+55. [Error Handling — Assertions](#55-error-handling--assertions)
+56. [Error Handling — Safe State and Fail-Safe Behaviour](#56-error-handling--safe-state-and-fail-safe-behaviour)
+57. [Hardware Abstraction](#57-hardware-abstraction)
+58. [Register Access](#58-register-access)
+59. [Interrupt Service Routines](#59-interrupt-service-routines)
+60. [Watchdog](#60-watchdog)
+61. [Timing and Delays](#61-timing-and-delays)
+62. [Floating-Point Arithmetic](#62-floating-point-arithmetic)
+63. [Portability](#63-portability)
+64. [Undefined, Unspecified, and Implementation-Defined Behaviour](#64-undefined-unspecified-and-implementation-defined-behaviour)
+65. [MISRA C:2012 Compliance Mapping](#65-misra-c2012-compliance-mapping)
+66. [CERT C Compliance Mapping](#66-cert-c-compliance-mapping)
+67. [Sign Compatibility](#67-sign-compatibility)
+68. [Declared-But-Not-Defined Identifiers](#68-declared-but-not-defined-identifiers)
+69. [Static Analysis Tools](#69-static-analysis-tools)
+70. [Code Review for Standards Compliance](#70-code-review-for-standards-compliance)
+71. [Unit Verification Criteria](#71-unit-verification-criteria)
+72. [Deviation Procedure](#72-deviation-procedure)
+73. [Document Change History](#73-document-change-history)
+
+---
+
+## 1. Purpose and Scope
+
+### 1.1 Purpose
+
+This document defines the **behavioural coding rules** that govern what embedded C code does and how it is constructed. It covers type safety, memory management, control flow, concurrency, error handling, and hardware interaction for all firmware developed on this project.
+
+Style and formatting rules (what code looks like) are covered in the companion C Style Guide (CSG-STY-001).
+
+This standard is designed to:
+
+- Prevent defects caused by undefined, unspecified, or implementation-defined C behaviour.
+- Ensure portability across target MCU architectures.
+- Satisfy the coding-related requirements of ASPICE v4 Level 2 (SWE.3, SWE.4).
+- Align with MISRA C:2012/2023 Required and Advisory rules applicable to safety-related embedded software.
+- Provide a machine-enforceable ruleset via cstylecheck and complementary static analysis tools.
+
+### 1.2 Scope
+
+This standard applies to:
+
+- All `.c` and `.h` files owned by this project and compiled into production firmware.
+- All new files created after this document reaches `Approved` status.
+- Existing files undergoing modification affecting more than 20 % of existing lines (incremental adoption).
+
+### 1.3 Out of Scope
+
+- Third-party or vendor-supplied source files (placed under `third_party/` or `vendor/`).
+- Auto-generated code from qualified code-generation tools.
+- Assembly (`.s`, `.asm`) files.
+- Test harness code (apply best-effort compliance; deviations are permitted with justification).
+
+### 1.4 Relationship to Other Documents
+
+| Document | ID | Relationship |
+|---|---|---|
+| Embedded C Style Guide | CSG-STY-001 | Companion — governs formatting |
+| External Standards Analysis | CSC-ANA-001 | Rationale for rule choices |
+| cstylecheck rules.yml | (tool config) | Machine-readable enforcement subset |
+| MISRA C:2012 | (external) | Primary normative standard |
+| Deviation Register | doc/deviation_register.md | Records all approved deviations |
+
+---
+
+## 2. Terms and Definitions
+
+| Term | Definition |
+|---|---|
+| **Undefined behaviour (UB)** | C11 §3.4.3 — Behaviour upon use of a non-portable or erroneous construct for which the standard imposes no requirements. The compiler may do anything. |
+| **Unspecified behaviour** | C11 §3.4.4 — Two or more behaviours are possible; the standard does not specify which. |
+| **Implementation-defined behaviour** | C11 §3.4.1 — Behaviour that is documented by the compiler vendor and consistent, but varies between implementations. |
+| **Constraint violation** | Failure to satisfy a syntax or semantic rule for which the standard requires a diagnostic. |
+| **Essential type** | The conceptual type of an expression under the MISRA C:2012 Essential Type Model, used to categorise operands for type safety checks. |
+| **Atomic operation** | An operation that completes without interruption and cannot be interleaved with other operations on the same data. |
+| **Critical section** | A code region protected against concurrent access by disabling interrupts or holding a mutex. |
+| **Safe state** | A system state in which no harm can occur while the system waits for recovery or shutdown. |
+| **ASIL** | Automotive Safety Integrity Level (ISO 26262), A through D, D being most stringent. |
+| **SIL** | Safety Integrity Level (IEC 61508), 1 through 4, 4 being most stringent. |
+| **RTOS** | Real-Time Operating System. |
+| **ISR** | Interrupt Service Routine — a function invoked directly by hardware interrupt. |
+| **HAL** | Hardware Abstraction Layer. |
+| **MCU** | Microcontroller Unit. |
+| **cstylecheck** | The project style and naming compliance checker. |
+
+---
+
+## 3. Normative References
+
+1. **MISRA C:2012** — Guidelines for the Use of the C Language in Critical Systems, MISRA Ltd, 2012 (including Amendment 1:2016 and MISRA C:2023).
+2. **CERT C Coding Standard** — SEI CERT C Coding Standard, Carnegie Mellon SEI, 2nd edition, 2016.
+3. **Barr-C:2018** — Embedded C Coding Standard, Barr Group, v2.0, 2018.
+4. **ASPICE v4.0** — Automotive SPICE Process Assessment/Reference Model, VDA QMC, 2023.
+5. **ISO/IEC 9899:2011 (C11)** — Programming languages — C.
+6. **ISO 26262-6:2018** — Functional safety — Software level.
+7. **IEC 61508-3:2010** — Functional safety — Software requirements.
+8. **NASA Power of Ten** — Power of Ten: Rules for Developing Safety-Critical Code, G. Holzmann, JPL, 2006.
+9. **JSF AV C++ Coding Standards** — Joint Strike Fighter Air Vehicle, Rev. C, 2005.
+
+---
+
+## 4. ASPICE Compliance Notes
+
+| ASPICE v4 Process Area | Base Practice | How This Document Contributes |
+|---|---|---|
+| SWE.3 Software Detailed Design and Unit Construction | BP5 — Implement software units | Rules in this standard govern unit construction |
+| SWE.3 | BP6 — Apply coding guidelines | This document IS the coding guidelines for SWE.3 BP6 |
+| SWE.4 Software Unit Verification | BP1 — Develop unit verification specification | Rules map to verifiable criteria (Section 71) |
+| SWE.4 | BP2 — Conduct static verification | cstylecheck and static analysis enforce a subset of rules |
+| SWE.5 Software Integration and Integration Test | BP3 — Agree interface | Interface/linkage rules (Sections 31, 44) |
+| SUP.1 Quality Assurance | BP3 — Assure compliance | Deviation procedure (Section 72), review checklist (Section 70) |
+| SUP.8 Configuration Management | BP1 — Identify CIs | This document is version-controlled |
+| SUP.9 Problem Resolution | BP1 — Record problems | Violation reports feed into problem resolution |
+| GP 2.1.1 | Define the process | This document defines the coding process |
+| GP 2.1.3 | Monitor and control | CI enforcement via cstylecheck and static analysis |
+| GP 2.2.1 | Define responsibility | Section 5 |
+| GP 2.3.1 | Identify information items | Document ID, version, status tracked in CM |
+
+---
+
+## 5. Roles and Responsibilities
+
+| Role | Responsibility |
+|---|---|
+| **Software Engineering Lead** | Owns this document; approves all changes and deviations |
+| **Developer** | Complies with all rules; raises deviation requests where impractical |
+| **Code Reviewer** | Verifies standards compliance before approving pull requests; uses Section 70 checklist |
+| **Quality Assurance** | Audits CI enforcement; tracks violation trends; ensures deviation register is maintained |
+| **Configuration Manager** | Maintains version history; publishes approved baseline |
+
+---
+
+## 6. Rule Classification System
+
+Rules in this standard are classified using the MISRA C model:
+
+| Class | Description |
+|---|---|
+| **Mandatory** | Shall be complied with in all cases. No deviation is possible. |
+| **Required** | Shall be complied with. Deviations are permitted only with formal approval (Section 72). |
+| **Advisory** | Should be complied with. Project may choose not to follow with documented rationale. |
+
+Each rule is also tagged with its source standard:
+- `[MISRA n.n]` — MISRA C:2012 rule number
+- `[CERT Xxx]` — CERT C rule identifier
+- `[BARR n.n]` — Barr-C:2018 section reference
+- `[JPL n]` — NASA Power of Ten rule number
+- `[JSF nnn]` — JSF AV C++ Coding Standard rule number
+
+---
+
+## 7. Compiler and Toolchain Requirements
+
+### 7.1 C Language Standard
+
+All source code shall be compiled as **C11** (`-std=c11`). Use of compiler-specific extensions is restricted as defined in Section 8. `[MISRA 1.1]`
+
+### 7.2 Warning Level
+
+Compilation shall be performed with the maximum warning level enabled. All warnings shall be treated as errors in CI builds (`-Wall -Wextra -Werror` or equivalent). `[MISRA 1.1]`
+
+### 7.3 Static Analysis
+
+At minimum, one of the following static analysis tools shall be run on all code:
+
+- cstylecheck (project tool — naming and misc rules)
+- PC-lint Plus / Flexelint
+- Polyspace Code Prover
+- Parasoft C/C++test
+- LDRA TBvision
+- Clang Static Analyzer / clang-tidy with CERT/MISRA checks
+
+### 7.4 Compiler Qualification
+
+For safety-critical code, the compiler shall be qualified according to ISO 26262-8 (tool confidence level). The qualified compiler version shall be recorded in the project Tool Qualification Plan.
+
+### 7.5 Compiler Diagnostic Pragmas
+
+Suppression of compiler warnings via pragma or attribute shall be:
+- Limited to the minimum necessary scope.
+- Accompanied by a comment explaining the suppression.
+- Reviewed and approved during code review.
+
+---
+
+## 8. Language Subset — Permitted C Features
+
+The following C features are explicitly permitted:
+
+- Fixed-width integer types from `<stdint.h>` and `<stdbool.h>`.
+- Standard control flow: `if`, `else`, `for`, `while`, `do`–`while`, `switch`.
+- Structs, unions, enums, and typedefs.
+- File-scope and block-scope variables with explicit storage class.
+- `const`-qualified objects.
+- `volatile`-qualified objects (with the restrictions of Section 22).
+- `static` functions and variables.
+- `extern` declarations.
+- Function pointers (with the restrictions of Section 29.6).
+- Designated initialisers (C99+).
+- Compound literals (C99+) — with restrictions noted in Section 42.
+- `_Bool` / `bool` (C99+ via `<stdbool.h>`).
+- `restrict` keyword for pointer parameters (C99+) — use with care.
+
+---
+
+## 9. Language Subset — Prohibited C Features
+
+The following C features are prohibited in production code. `[MISRA 1.1, MISRA 1.2, BARR 1.1]`
+
+| Feature | Reason | Rule Reference |
+|---|---|---|
+| `goto` | Unstructured control flow; see Section 24 for the single permitted exception | MISRA 15.1 |
+| `setjmp` / `longjmp` | Bypasses destructors and stack unwinding | MISRA 21.4 |
+| Recursion | Stack depth unpredictable; see Section 25 | MISRA 17.2, JPL 1 |
+| Dynamic memory allocation (`malloc`, `calloc`, `realloc`, `free`) | Heap fragmentation and non-determinism; see Section 20 | MISRA 21.3, JPL 3 |
+| Variable-length arrays (VLAs) | Stack overflow risk; size not deterministic at compile time | MISRA 18.8 |
+| `union` overlapping members for type punning | Undefined behaviour; use `memcpy` instead | MISRA 19.2 |
+| Flexible array members (C99 `struct s { int a[]; }`) | Allocation complexity | — |
+| Trigraphs | Silent character substitution | MISRA 4.2 |
+| Octal literals (e.g. `010`) | Misread as decimal | MISRA 7.1 |
+| `register` storage class | Ignored by modern compilers; misleading | Advisory |
+| `_Complex`, `_Imaginary` | No embedded use; UB risk | — |
+| Thread-local storage (`_Thread_local`) | Use RTOS task-local storage instead | — |
+| `asm` / `__asm` inline assembly in C functions | Use separate `.s` files or compiler intrinsics | Advisory |
+| `#pragma` without justification comment | Undocumented side effects | — |
+| `//` comments in C89/C90 mode | Language standard restriction | MISRA 3.1 |
+
+---
+
+## 10. Data Types and Type Safety
+
+### 10.1 Fixed-Width Integer Types
+
+All integer variables shall use fixed-width types from `<stdint.h>` in preference to basic types:
+
+| Preferred | Instead of |
+|---|---|
+| `int8_t`, `uint8_t` | `char`, `unsigned char` |
+| `int16_t`, `uint16_t` | `short`, `unsigned short` |
+| `int32_t`, `uint32_t` | `int`, `unsigned int`, `long` |
+| `int64_t`, `uint64_t` | `long long` |
+
+`[MISRA 4.6, BARR 2.1]`
+
+Exceptions:
+- `bool` (from `<stdbool.h>`) for boolean values.
+- `size_t` for sizes and counts returned by `sizeof` and string functions.
+- `ptrdiff_t` for pointer differences.
+- `char` when handling character data passed to standard library string functions.
+
+### 10.2 Plain `char` Signedness
+
+The signedness of plain `char` is implementation-defined. `[MISRA 10.4]`
+
+- When `char` is used (for string data), do not assume it is signed or unsigned.
+- For numeric data, always use `int8_t` or `uint8_t` explicitly.
+
+`[RULE: sign_compatibility.plain_char_is_signed]`
+
+### 10.3 Signedness Selection
+
+Use **unsigned** types for: bit masks, register values, buffer indices, sizes, and quantities that cannot be negative.
+
+Use **signed** types for: differences, offsets, error codes that may be negative, and values from external interfaces using signed representation.
+
+### 10.4 The Essential Type Model
+
+When mixing types in expressions, follow the MISRA C:2012 Essential Type Model: `[MISRA 10.x]`
+
+- Do not mix signed and unsigned types in binary expressions without an explicit cast.
+- Do not compare signed and unsigned values.
+- Do not assign a wider type to a narrower type without an explicit cast and range check.
+
+---
+
+## 11. Integer Types — Selection and Use
+
+### 11.1 Unsigned Literals for Unsigned Contexts
+
+Unsigned integer constants shall carry a `U` suffix when assigned to unsigned types or used in unsigned arithmetic. `[MISRA 7.2, BARR 7.3]` `[RULE: misc.unsigned_suffix]`
+
+### 11.2 Integer Suffix Uppercase
+
+Integer literal suffixes shall use uppercase letters. The lowercase `l` is forbidden because it is visually indistinguishable from `1`. `[MISRA 7.3]` `[RULE: misc.lowercase_l_suffix]`
+
+### 11.3 No Octal Literals
+
+Octal integer literals are forbidden. `[MISRA 7.1]` `[RULE: misc.octal_constant]`
+
+### 11.4 Hexadecimal Digits
+
+Hexadecimal digits `A`–`F` shall be uppercase: `0xDEADBEEFU`.
+
+### 11.5 Type Size Assumptions
+
+Code shall not assume a specific size for `int`, `long`, or pointer types. Use fixed-width types or `sizeof()` for size-dependent logic. `[MISRA 4.6]`
+
+---
+
+## 12. Integer Arithmetic and Overflow
+
+### 12.1 Signed Integer Overflow
+
+Signed integer overflow is **undefined behaviour** in C. Code shall not depend on wraparound of signed integers. `[CERT INT32-C]`
+
+Protect against overflow before arithmetic operations:
+
+```c
+/* Check before adding */
+if (a <= (INT32_MAX - b))
+{
+    result = a + b;
+}
+else
+{
+    /* handle overflow */
+}
+```
+
+### 12.2 Unsigned Integer Wraparound
+
+Unsigned integer wraparound is well-defined (modular arithmetic) but often unintentional. Validate inputs to prevent unintended wrap:
+
+```c
+/* Guard underflow before unsigned subtraction */
+if (b <= a)
+{
+    diff = a - b;
+}
+```
+
+### 12.3 Division and Modulo
+
+Check for division by zero before all `/` and `%` operations. `[CERT INT33-C]`
+
+### 12.4 Shift Operations
+
+- Left-shift on signed integers is undefined behaviour for values that overflow. Use unsigned types for shift operations. `[MISRA 12.2]`
+- Shift amounts shall not be negative or greater than or equal to the bit width of the type. `[MISRA 12.2, CERT INT34-C]`
+
+### 12.5 Mixed-Sign Arithmetic
+
+Do not mix signed and unsigned operands in arithmetic or comparison expressions without explicit cast and documented justification. `[MISRA 10.4]`
+
+---
+
+## 13. Implicit and Explicit Type Conversions
+
+### 13.1 No Implicit Narrowing
+
+Do not rely on implicit narrowing conversions. An explicit cast shall be used when converting from a wider to a narrower type:
+
+```c
+uint32_t val32 = 0x0000FFFFU;
+uint16_t val16 = (uint16_t)val32;  /* explicit — truncation intentional */
+```
+
+### 13.2 No Implicit Signed/Unsigned Conversion
+
+Implicit conversions between signed and unsigned shall be avoided. Use explicit casts. `[MISRA 10.3]`
+
+### 13.3 Boolean Context
+
+In boolean contexts (`if`, `while`, `for`), operands shall evaluate explicitly to a boolean:
+
+```c
+/* Correct */
+if (0U != byte_count)
+
+/* Wrong */
+if (byte_count)      /* implicit conversion from integer to boolean */
+```
+
+`[MISRA 14.4]`
+
+### 13.4 Pointer–Integer Conversions
+
+Conversion between pointer and integer types shall only be used for memory-mapped register access and shall be explicitly documented:
+
+```c
+volatile uint32_t *p_reg = (volatile uint32_t *)0x40020000U;  /* GPIOA base */
+```
+
+`[MISRA 11.1, MISRA 11.4, CERT INT36-C]`
+
+---
+
+## 14. Pointer Types and Pointer Safety
+
+### 14.1 Pointer Initialisation
+
+All pointers shall be initialised before use — either to a valid address, or to `NULL`:
+
+```c
+uint8_t *p_buffer = NULL;
+```
+
+### 14.2 NULL Pointer Checks
+
+Pointer parameters that may be `NULL` shall be checked before dereferencing:
+
+```c
+if (NULL == p_data)
+{
+    return UART_STATUS_ERROR;
+}
+byte = *p_data;
+```
+
+`[BARR 2.4, CERT EXP34-C]`
+
+### 14.3 No Pointer Arithmetic on Void Pointers
+
+Arithmetic on `void *` is undefined behaviour. Cast to a typed pointer before arithmetic. `[MISRA 18.2, MISRA 18.3]`
+
+### 14.4 No Function Pointer Casting
+
+Function pointers shall not be cast to or from `void *` or data pointers. `[MISRA 11.1]`
+
+### 14.5 Pointer Aliasing
+
+Do not alias two pointers of incompatible types (strict aliasing rule). Use `memcpy` for type-punning. `[CERT EXP39-C]`
+
+### 14.6 `const` Correctness
+
+Pointers to data that a function does not modify shall be declared `const`:
+
+```c
+uart_status_t uart_BufferTransmit(const uint8_t *p_data, uint16_t length);
+```
+
+`[BARR 2.3, MISRA 8.13]`
+
+### 14.7 Pointer Prefix
+
+Pointer variable names shall use the `p_` prefix for single indirection and `pp_` for double indirection. `[RULE: variables.pointer_prefix]`
+
+---
+
+## 15. Arrays and Buffer Safety
+
+### 15.1 Bounds Checking
+
+Array accesses shall be bounds-checked before use:
+
+```c
+if (idx < ARRAY_SIZE)
+{
+    val = array[idx];
+}
+```
+
+`[CERT ARR30-C]`
+
+### 15.2 No Variable-Length Arrays
+
+Variable-length arrays (VLAs) are prohibited. Use fixed-size arrays or dynamic allocation (when permitted). `[MISRA 18.8]`
+
+### 15.3 Buffer Overflow Prevention
+
+Functions that write to buffers shall always accept and respect a length parameter. Functions that read from null-terminated strings shall always specify a maximum length. `[CERT STR31-C, STR32-C]`
+
+### 15.4 Array Size via `sizeof`
+
+The number of elements in an array shall be computed with:
+
+```c
+#define ARRAY_SIZE(a)   (sizeof(a) / sizeof((a)[0]))
+```
+
+Do not hardcode array sizes in loop bounds. `[BARR 2.5]`
+
+---
+
+## 16. String Handling
+
+### 16.1 Null Termination
+
+All strings passed to standard library functions shall be null-terminated. `[CERT STR32-C]`
+
+### 16.2 Safe String Functions
+
+The following unsafe functions are prohibited: `strcpy`, `strcat`, `sprintf`, `gets`. Use length-limited alternatives:
+
+| Prohibited | Use instead |
+|---|---|
+| `strcpy(d, s)` | `strncpy(d, s, n)` + explicit termination |
+| `strcat(d, s)` | `strncat(d, s, n)` |
+| `sprintf(b, ...)` | `snprintf(b, size, ...)` |
+| `gets(b)` | `fgets(b, size, stdin)` |
+
+`[CERT STR31-C, BARR 2.6]`
+
+### 16.3 String Length
+
+String length shall never be assumed. Always use `strlen()` or explicit length tracking.
+
+---
+
+## 17. Boolean Expressions
+
+### 17.1 Use `bool`
+
+Boolean variables shall be of type `bool` (from `<stdbool.h>`):
+
+```c
+#include <stdbool.h>
+bool b_is_ready = false;
+```
+
+`[MISRA 14.4, BARR 2.8]`
+
+### 17.2 Boolean Comparisons
+
+Do not compare `bool` values against `true` or `false` with `==`. Test them directly:
+
+```c
+if (b_is_ready)          { /* correct */ }
+if (true == b_is_ready)  { /* wrong */ }
+```
+
+`[MISRA 14.4]`
+
+### 17.3 Bitwise vs. Logical Operators
+
+Logical operators (`&&`, `||`, `!`) shall be used for boolean conditions.
+Bitwise operators (`&`, `|`, `~`, `^`) shall be used only for bitwise manipulation, not for boolean logic.
+
+---
+
+## 18. Bitwise Operations
+
+### 18.1 Unsigned Types for Bit Manipulation
+
+Bitwise operations shall only be applied to **unsigned** types. `[MISRA 12.1, MISRA 10.1]`
+
+### 18.2 Mask and Shift Clarity
+
+Bit masks and shift values shall be named constants:
+
+```c
+#define UART_CR1_UE_POS   (0U)
+#define UART_CR1_UE_MASK  (1U << UART_CR1_UE_POS)
+
+p_uart->CR1 |= UART_CR1_UE_MASK;
+```
+
+### 18.3 Shift Amount
+
+Shift amounts shall be non-negative, less than the bit width of the type, and the shifted expression shall be of unsigned type. `[MISRA 12.2]`
+
+---
+
+## 19. Memory Management — Static Allocation
+
+### 19.1 Static Allocation Preferred
+
+Static and automatic (stack) allocation is strongly preferred over dynamic heap allocation for all embedded firmware. `[JPL 3, BARR 6.1]`
+
+### 19.2 Pre-allocated Pools
+
+Where variable-size data is needed at runtime, use pre-allocated memory pools of fixed-size blocks. Document the maximum pool size and element count.
+
+### 19.3 Compile-Time Sizing
+
+Buffer sizes shall be determined at compile time wherever possible. Use `#define` constants for all buffer dimensions.
+
+---
+
+## 20. Memory Management — Dynamic Allocation
+
+### 20.1 General Policy
+
+Dynamic memory allocation using `malloc`, `calloc`, `realloc`, and `free` is **prohibited** in interrupt context and in any code path on the ASIL/SIL-rated safety path. `[MISRA 21.3, JPL 3]`
+
+### 20.2 Permitted Use
+
+Dynamic allocation is permitted in non-safety-related code (e.g. development tools, logging, host-side utilities) subject to:
+
+- All allocations checked for `NULL` return.
+- Every `malloc`/`calloc` has an exactly paired `free`.
+- No allocation after system initialisation in RTOS tasks (allocate once at startup).
+
+### 20.3 RTOS Memory
+
+For RTOS heap usage, the project shall configure a fixed total heap size and use RTOS memory allocation APIs (e.g. `pvPortMalloc`/`vPortFree` in FreeRTOS) rather than direct `malloc`. RTOS heap usage shall be verified against maximum by stack and heap analysis.
+
+### 20.4 Memory Leak Prevention
+
+Every allocation shall have exactly one matching deallocation. Use RTOS memory pool objects where deterministic lifecycle is required.
+
+---
+
+## 21. Memory Management — Stack Usage
+
+### 21.1 Stack Size Analysis
+
+The maximum stack depth of every task and ISR shall be estimated at design time and confirmed by worst-case call-graph analysis.
+
+### 21.2 Large Local Variables
+
+Local variables larger than 64 bytes shall be declared at file scope (static) or in a statically allocated block. Avoid large stack-allocated arrays. `[BARR 6.2]`
+
+### 21.3 Stack Monitoring
+
+Production firmware shall include RTOS stack high-water-mark monitoring (e.g. `uxTaskGetStackHighWaterMark`) with an assertion or fault when remaining stack falls below a safety margin.
+
+---
+
+## 22. Memory Management — Volatile and Shared Data
+
+### 22.1 `volatile` for Hardware Registers
+
+All memory-mapped hardware registers shall be accessed through `volatile`-qualified pointers. `[MISRA 11.4, BARR 9.1]`
+
+```c
+volatile uint32_t * const p_GPIOA_IDR = (volatile uint32_t *)0x40020010U;
+```
+
+### 22.2 `volatile` for ISR-Shared Variables
+
+Variables shared between an ISR and non-ISR code shall be declared `volatile`. `[BARR 9.1, CERT DCL22-C]`
+
+```c
+volatile uint32_t uart_g_rx_count = 0U;
+```
+
+### 22.3 `volatile` Is Not Atomicity
+
+`volatile` alone does not guarantee atomicity on multi-byte variables or multi-core systems. Use atomic operations or critical sections (Section 52) for shared multi-byte data.
+
+### 22.4 No `volatile` Without Purpose
+
+`volatile` shall not be applied to variables that are not hardware registers, ISR-shared, or used in busy-wait loops. Gratuitous `volatile` inhibits optimisation without benefit.
+
+---
+
+## 23. Control Flow — General
+
+### 23.1 Single Entry, Single Exit (SESE)
+
+Each function shall have a single return point at the end of the function body. `[MISRA 15.5 — Advisory]`
+
+Where multiple return paths would otherwise improve clarity, the return value shall be written to a result variable and returned at the end:
+
+```c
+status = uart_CheckParam(p_data, length);
+if (UART_STATUS_OK == status)
+{
+    status = uart_DoTransmit(p_data, length);
+}
+return status;
+```
+
+### 23.2 Nesting Depth
+
+Control flow nesting depth shall not exceed **5 levels**. Functions exceeding this limit shall be decomposed. `[BARR 8.2, JSF 118]`
+
+### 23.3 Unreachable Code
+
+Code that is unreachable under all conditions is forbidden. `[MISRA 2.1]`
+
+Unreachable code introduced by conditional compilation shall be documented with a comment.
+
+### 23.4 Dead Code
+
+Dead code (code that is syntactically present but never executed) shall be removed, not commented out.
+
+---
+
+## 24. Control Flow — `goto`
+
+`goto` is prohibited with one permitted exception: forward `goto` to a single cleanup/error-exit label within the same function. `[MISRA 15.1]`
+
+```c
+uart_status_t uart_ComplexOperation(void)
+{
+    uart_status_t status = UART_STATUS_OK;
+
+    status = uart_StepA();
+    if (UART_STATUS_OK != status) { goto cleanup; }
+
+    status = uart_StepB();
+    if (UART_STATUS_OK != status) { goto cleanup; }
+
+cleanup:
+    uart_ReleaseResources();
+    return status;
+}
+```
+
+Rules for this exception:
+- The label name shall be `cleanup` or `error_exit`.
+- `goto` shall only jump **forward** (never backward).
+- There shall be at most one such label per function.
+
+---
+
+## 25. Control Flow — Recursion
+
+Direct and indirect recursion is **prohibited**. `[MISRA 17.2, JPL 1]`
+
+Stack depth resulting from recursion cannot be statically bounded, making stack overflow analysis impossible.
+
+Where tree or graph traversal would naturally use recursion, implement an iterative algorithm with an explicit, statically allocated stack.
+
+---
+
+## 26. Control Flow — Infinite Loops
+
+Deliberate infinite loops (e.g. the RTOS task main loop or the bare-metal superloop) shall be written with `while (true)` and a comment indicating intent:
+
+```c
+while (true)
+{
+    /* main superloop — intentional infinite loop */
+    uart_ProcessEvents();
+    can_ProcessMessages();
+}
+```
+
+A `for (;;)` form is also acceptable. `while (1)` is acceptable but `while (true)` is preferred for clarity.
+
+---
+
+## 27. Control Flow — `break` and `continue`
+
+- `break` is permitted inside `switch` statements and as the sole means of exiting a loop on an error condition.
+- `continue` is discouraged; use it only when it materially improves readability and with a comment.
+- More than one `break` per loop body requires justification in a comment.
+
+`[MISRA 15.4 — Advisory]`
+
+---
+
+## 28. Control Flow — `switch` Statements
+
+- Every `switch` shall have a `default` clause. `[MISRA 16.4 — Required]`
+- Every `case` shall terminate with `break`, `return`, or a `/* fall-through */` comment. Unintentional fall-through is prohibited. `[MISRA 16.3 — Required]`
+- `case` values shall be of the same essential type as the `switch` expression. `[MISRA 16.7]`
+- An enum `switch` should cover all enumeration values (compiler warning `-Wswitch` will catch omissions).
+
+---
+
+## 29. Functions — Design Rules
+
+### 29.1 Single Responsibility
+
+Each function shall perform one clearly defined task. Functions that perform multiple unrelated tasks shall be decomposed.
+
+### 29.2 Function Length
+
+Each function body shall not exceed **60 lines** (including blank lines and comments within the body). `[JPL 4]` `[RULE: misc.function_length]`
+
+Functions that cannot meet this limit due to a finite state machine or protocol handler require documented justification and a raised limit per the deviation procedure.
+
+### 29.3 Complexity
+
+The cyclomatic complexity of a function shall not exceed **10**. Verify with a static analysis tool.
+
+### 29.4 Side Effects in Expressions
+
+A function called as part of a complex expression shall not produce side effects that affect other sub-expressions. `[MISRA 13.2]`
+
+### 29.5 One Purpose Per Call
+
+Functions shall either perform an action OR return a value — not both. A function that both modifies state and returns a value shall document this dual nature explicitly.
+
+### 29.6 Function Pointers
+
+Function pointers are permitted but shall:
+- Point only to functions with compatible prototypes (no void cast).
+- Be checked for `NULL` before being called.
+- Be named according to the function naming convention.
+
+`[MISRA 11.1]`
+
+---
+
+## 30. Functions — Parameters and Return Values
+
+### 30.1 Parameter Count
+
+Functions shall have no more than **5 parameters**. `[BARR 9.3, JSF 120]` Functions requiring more context should pass a configuration struct.
+
+### 30.2 Output Parameters
+
+When a function needs to return multiple values, output parameters (passed by pointer) shall be used. Output parameters shall be named with a suffix or clearly documented in the Doxygen header.
+
+### 30.3 Return Value Checking
+
+The return value of every function that can return an error status shall be checked by the caller:
+
+```c
+status = uart_BufferTransmit(p_data, length);
+if (UART_STATUS_OK != status)
+{
+    /* handle error */
+}
+```
+
+Ignoring a return value shall be explicit:
+
+```c
+(void)uart_FlushBuffer();  /* intentional discard */
+```
+
+`[MISRA 17.7, CERT ERR33-C]`
+
+### 30.4 No Pointer Parameters Without NULL Check
+
+Any function receiving a pointer parameter shall check for `NULL` at entry unless the parameter is documented as always non-NULL (with the caller's obligation to guarantee this).
+
+---
+
+## 31. Functions — Prototypes and Declarations
+
+### 31.1 Explicit Prototypes
+
+All functions shall be declared with a full prototype before they are called. `[MISRA 8.2]`
+
+```c
+/* Header file */
+uart_status_t uart_BufferTransmit(const uint8_t *p_data, uint16_t length);
+```
+
+### 31.2 Matching Declaration and Definition
+
+A function's declaration (in the header) and definition (in the `.c` file) shall have identical parameter types and return types. `[MISRA 8.3]`
+
+### 31.3 No Implicit Function Declarations
+
+Calling an undeclared function is prohibited. `[MISRA 17.3]`
+
+`[RULE: misc.declared_not_defined]`
+
+### 31.4 `void` Parameter List
+
+A function that takes no parameters shall be explicitly declared with `void`:
+
+```c
+void uart_Init(void);    /* correct */
+void uart_Init();         /* wrong — pre-C11 meaning is implementation-defined */
+```
+
+`[MISRA 8.2]`
+
+---
+
+## 32. Functions — Inline Functions
+
+- `inline` functions shall only be used for very short functions (3 lines or fewer) where call overhead is measurable.
+- `inline` functions shall be defined in header files.
+- Inline functions are preferred over function-like macros for type safety. `[BARR 7.5]`
+
+---
+
+## 33. Functions — Recursion
+
+Recursion is prohibited (see Section 25). All functions shall have a statically deterministic call depth.
+
+---
+
+## 34. Functions — Assertions
+
+### 34.1 Assert Density
+
+`[RULE: misc.assert_density]`
+
+Non-trivial functions (≥ 10 lines) shall contain at least one `assert()` call or equivalent defensive check to validate preconditions or invariants. `[JPL 5]`
+
+### 34.2 Project Assert Macro
+
+The project shall define a `PROJ_ASSERT(cond)` macro that:
+- In debug builds: calls standard `assert()` or invokes a custom fault handler.
+- In release builds: either remains as a null expression or calls a safe-state handler (project decision, documented in the Deviation Register).
+
+```c
+#define PROJ_ASSERT(cond)   \
+    do {                    \
+        if (!(cond))        \
+        {                   \
+            fault_Handler(); \
+        }                   \
+    } while (0U)
+```
+
+---
+
+## 35. Preprocessor — Conditional Compilation
+
+### 35.1 Feature Flags
+
+Conditional compilation shall be used for:
+- Platform/target differences.
+- Debug vs. release builds.
+- Optional hardware features.
+
+Do not use conditional compilation to maintain multiple incompatible logic paths in the same file. Prefer separate source files.
+
+### 35.2 `#ifdef` vs. `#if defined()`
+
+`#if defined(SYMBOL)` is preferred over `#ifdef SYMBOL` for clarity and consistency with multi-condition tests:
+
+```c
+#if defined(UART_DMA_ENABLE) && defined(DMA1_SUPPORTED)
+```
+
+### 35.3 Nesting Depth
+
+Conditional compilation nesting shall not exceed 3 levels.
+
+### 35.4 `#else` and `#endif` Comments
+
+Every `#else` and `#endif` shall include a comment referencing the corresponding condition:
+
+```c
+#if defined(UART_DMA_ENABLE)
+    /* DMA path */
+#else
+    /* polled path */
+#endif /* UART_DMA_ENABLE */
+```
+
+---
+
+## 36. Preprocessor — Header Inclusion
+
+### 36.1 Include All Required Headers
+
+Each source file shall include every header that defines types, macros, or functions it uses. Do not rely on transitive inclusion. `[CERT PRE04-C]`
+
+### 36.2 No Cyclic Includes
+
+Header files shall not include each other in a cycle. Break cycles using forward declarations.
+
+### 36.3 System Header Names
+
+Project source files shall not share their base name with any standard C or POSIX header. `[CERT PRE04-C]` `[RULE: misc.reserved_header_name]`
+
+---
+
+## 37. Preprocessor — Macros vs. Functions
+
+### 37.1 Prefer Inline Functions
+
+Where a macro is used purely for performance (to avoid a function call), an `inline` function shall be used instead if the compiler supports inlining. Inline functions provide type safety; macros do not.
+
+### 37.2 Macro Side Effects
+
+Macro arguments shall not have side effects (e.g. `++`, function calls) because they may be evaluated more than once:
+
+```c
+#define MAX(a, b)   (((a) > (b)) ? (a) : (b))
+
+int result = MAX(x++, y);  /* WRONG — x incremented twice if x > y initially */
+```
+
+### 37.3 Object-Like Macro Constants
+
+Prefer `static const` typed variables over object-like `#define` for typed constants when the value is not needed in a preprocessor expression:
+
+```c
+static const uint32_t UART_TIMEOUT_MS = 100U;   /* preferred in C99+ */
+#define UART_TIMEOUT_MS   100U                    /* acceptable — both in scope */
+```
+
+---
+
+## 38. Preprocessor — Token Pasting and Stringification
+
+`##` (token pasting) and `#` (stringification) shall only be used when necessary for code generation and shall be accompanied by a comment explaining the pattern. `[MISRA 20.10, MISRA 20.11]`
+
+---
+
+## 39. Global Variables
+
+### 39.1 Minimise Global State
+
+Global variables (external linkage) shall be minimised. Prefer passing state through function parameters or using a module-private singleton pattern (file-scope static). `[JPL 6, BARR 8.4]`
+
+### 39.2 Global Variable Declaration
+
+All global variables shall be declared `extern` in the module's public header and defined exactly once in the module's `.c` file.
+
+### 39.3 Global Variable Naming
+
+Global variables shall use the `g_` prefix (after the module prefix): `uart_g_tx_count`. `[RULE: variables.global.g_prefix]`
+
+### 39.4 Const-Qualified Globals
+
+Read-only global data shall be declared `const` to prevent accidental modification and allow placement in read-only flash:
+
+```c
+const uint8_t uart_g_PREAMBLE[] = { 0xAAU, 0x55U };
+```
+
+---
+
+## 40. File-Scope Static Variables
+
+### 40.1 Prefer Static over Global
+
+Module state that is not needed externally shall use **file-scope static** variables rather than globals:
+
+```c
+static uart_state_t uart_s_state = UART_STATE_IDLE;
+```
+
+### 40.2 Static Variable Naming
+
+File-scope static variables shall use the `s_` prefix: `uart_s_rx_count`. `[RULE: variables.static.s_prefix]`
+
+### 40.3 Initialisation of Statics
+
+File-scope static variables shall be explicitly initialised. Relying on zero-initialisation by the C runtime is acceptable but should be documented:
+
+```c
+static uint32_t uart_s_byte_count = 0U;  /* explicit zero init */
+```
+
+---
+
+## 41. Constants — `const` vs. `#define`
+
+| Use case | Preferred form |
+|---|---|
+| Typed constant within a module | `static const TYPE NAME = value;` |
+| Typed constant exported in a header | `extern const TYPE NAME;` (defined in `.c`) |
+| Preprocessor-visible constant (e.g. array size in a struct) | `#define NAME valueU` |
+| Enum-related constant | `enum` member |
+
+`[BARR 7.2]`
+
+---
+
+## 42. Initialisation
+
+### 42.1 All Variables Initialised Before Use
+
+Every variable shall be initialised before its value is read. `[CERT EXP33-C, MISRA 9.1]`
+
+```c
+uart_status_t status = UART_STATUS_OK;
+uint8_t byte = 0U;
+```
+
+### 42.2 Struct Initialisation
+
+Structs shall be initialised using designated initialisers to avoid silent padding-byte issues and to improve readability:
+
+```c
+UART_CONFIG_T config =
+{
+    .baud_rate = 115200U,
+    .data_bits = 8U,
+    .stop_bits = 1U,
+    .parity    = UART_PARITY_NONE
+};
+```
+
+### 42.3 No Partial Initialisation
+
+Do not leave structure or array members un-initialised. If a member is intentionally unused, assign it a zero or default value with a comment.
+
+---
+
+## 43. Scope and Lifetime
+
+### 43.1 Minimise Scope
+
+Variables shall be declared at the narrowest applicable scope. Declare inside `for` loop initialisers when the variable is only needed in the loop:
+
+```c
+for (uint8_t i = 0U; i < count; i++) { ... }
+```
+
+### 43.2 Block Scope Declarations
+
+In C99+, block-scope declarations may appear anywhere before first use within the block. However, for readability in embedded code, declarations shall appear at the top of the function body unless there is a strong reason to declare at point of use.
+
+---
+
+## 44. Linkage
+
+### 44.1 Internal Linkage
+
+Functions and variables not referenced outside their translation unit shall be declared `static`:
+
+```c
+static void prv_uart_FifoFlush(void);
+static uint32_t uart_s_error_count = 0U;
+```
+
+`[MISRA 8.7, BARR 9.2]`
+
+### 44.2 No Implicit Linkage
+
+Do not rely on default (external) linkage for identifiers that should be private. Explicitly `static` all file-scope identifiers that are not part of the public API.
+
+### 44.3 One Definition Rule
+
+Every non-inline function and every non-`static` object shall have exactly one definition across all translation units. `[MISRA 8.6]`
+
+---
+
+## 45. Structures and Unions
+
+### 45.1 Struct Padding
+
+Be aware that the compiler may insert padding bytes between struct members for alignment. For safety-critical serialisation or memory-mapped registers:
+- Use explicit padding members.
+- Verify struct sizes with `_Static_assert`.
+- Use compiler-specific packing attributes only when necessary, with a comment.
+
+### 45.2 Union Restrictions
+
+Unions shall not be used to reinterpret the bytes of one type as another (type punning), as this is undefined behaviour in C. `[MISRA 19.2]`
+
+Use `memcpy` for type-safe byte reinterpretation.
+
+### 45.3 `_Static_assert` for Struct Sizes
+
+For all structs that are serialised, memory-mapped, or exchanged over a communication protocol, a `_Static_assert` shall verify the expected size:
+
+```c
+_Static_assert(sizeof(CAN_FRAME_T) == 13U, "CAN_FRAME_T size mismatch");
+```
+
+---
+
+## 46. Bit Fields
+
+Bit fields shall only be used with `unsigned int` or `_Bool` base types. `[MISRA 6.1]`
+
+The layout of bit fields in memory is implementation-defined. Do not use bit fields for memory-mapped hardware registers; use masks and shifts instead. `[MISRA 6.1, BARR 2.10]`
+
+---
+
+## 47. Enumerations
+
+### 47.1 Enums for Related Constants
+
+Use `enum` (not `#define`) for groups of related integer constants. `[BARR 7.2]`
+
+### 47.2 Enum Values
+
+The first member shall be explicitly assigned `0`. All members should be explicitly assigned. `[BARR 2.9]`
+
+### 47.3 Enum as Return Type
+
+Prefer returning an enum type rather than a raw integer for status/error codes:
+
+```c
+uart_status_t uart_ByteTransmit(uint8_t byte);
+```
+
+### 47.4 Enum Size
+
+Do not assume the size of an enum type. Use `_Static_assert` or a fixed-width integer cast when size matters.
+
+---
+
+## 48. Standard Library Usage
+
+### 48.1 Permitted Headers
+
+The following standard library headers are generally permitted in embedded projects:
+
+| Header | Use |
+|---|---|
+| `<stdint.h>` | Fixed-width integer types |
+| `<stdbool.h>` | Boolean type |
+| `<stddef.h>` | `NULL`, `size_t`, `offsetof` |
+| `<stdarg.h>` | Variable argument lists (logging only) |
+| `<string.h>` | `memcpy`, `memset`, `memcmp` (see Section 49 for unsafe functions) |
+| `<assert.h>` | `assert()` (debug builds only in strict SIL environments) |
+| `<limits.h>` | Integer limits |
+| `<math.h>` | Floating-point (see Section 62) |
+
+### 48.2 Restricted Headers
+
+The following headers require documented justification:
+
+| Header | Risk | Condition for Use |
+|---|---|---|
+| `<stdio.h>` | File I/O; `printf` can block | Allowed in debug/logging only |
+| `<stdlib.h>` | `malloc`/`free`/`exit`/`abort` | Only `abs`, `div`, `strtol` permitted; no heap functions |
+| `<time.h>` | Portability; timer resolution varies | Allowed with documented HAL wrapper |
+| `<errno.h>` | Thread-safety of `errno` varies | Allowed; check toolchain thread-safety |
+| `<setjmp.h>` | Bypasses stack unwinding | **Prohibited** |
+
+---
+
+## 49. Restricted Standard Library Functions
+
+The following functions are prohibited or restricted:
+
+| Function | Status | Alternative |
+|---|---|---|
+| `malloc`, `calloc`, `realloc`, `free` | Prohibited on safety path | Static allocation; RTOS pools |
+| `gets` | Prohibited | `fgets` |
+| `strcpy` | Prohibited | `strncpy` + explicit termination |
+| `strcat` | Prohibited | `strncat` |
+| `sprintf` | Prohibited | `snprintf` |
+| `scanf` | Prohibited | Explicit parsing |
+| `atoi`, `atof`, `atol` | Prohibited (no error detection) | `strtol`, `strtof`, `strtod` |
+| `strtok` | Prohibited (not reentrant) | `strtok_r` (POSIX) or custom |
+| `rand`, `srand` | Restricted | Use a qualified PRNG for safety use |
+| `exit`, `abort` | Restricted | Only in fault handler; never in normal flow |
+| `assert()` | Restricted | Use `PROJ_ASSERT()` macro |
+| `setjmp`, `longjmp` | Prohibited | — |
+
+`[MISRA 21.x, CERT STR31-C, CERT ERR04-C]`
+
+---
+
+## 50. Concurrency — Interrupt Safety
+
+### 50.1 Critical Section Protection
+
+Shared data accessed from both interrupt and non-interrupt context shall be protected by a critical section (disable/enable interrupts):
+
+```c
+taskENTER_CRITICAL();
+uart_g_rx_count++;
+taskEXIT_CRITICAL();
+```
+
+### 50.2 Critical Section Length
+
+Critical sections shall be as short as possible — only the minimum code necessary to access shared data. Long critical sections degrade interrupt latency.
+
+### 50.3 No Blocking in ISR
+
+ISR functions shall never block, call RTOS APIs that may block, or call `malloc`/`free`.
+
+### 50.4 No `printf` in ISR
+
+`printf` and all standard I/O functions are prohibited inside ISRs due to their non-reentrant nature and potential to block.
+
+---
+
+## 51. Concurrency — RTOS Task Safety
+
+### 51.1 Mutex Protection for Shared Resources
+
+Resources shared between RTOS tasks shall be protected by a mutex or semaphore:
+
+```c
+osMutexAcquire(h_uart_mutex, osWaitForever);
+uart_BufferTransmit(p_data, length);
+osMutexRelease(h_uart_mutex);
+```
+
+### 51.2 Deadlock Prevention
+
+Mutex acquisition order shall be documented and consistent across all tasks to prevent deadlock. A task shall not hold more than one mutex at a time (except where a documented hierarchical locking order is established).
+
+### 51.3 Priority Inversion
+
+Use priority-inheritance mutexes or priority-ceiling mutexes where priority inversion could cause timing violations.
+
+---
+
+## 52. Concurrency — Atomic Access
+
+### 52.1 Atomic Types
+
+For single-variable flags shared between tasks or between task and ISR, use `volatile` with appropriate critical-section protection (Section 50), or `_Atomic` (C11) where the toolchain supports it.
+
+### 52.2 Multi-Byte Atomicity
+
+Reading or writing a multi-byte variable (e.g. `uint32_t` on an 8-bit MCU) may require multiple bus cycles and is not inherently atomic. Protect with critical sections.
+
+---
+
+## 53. Error Handling — Strategy
+
+### 53.1 No Silent Failure
+
+Functions shall not silently ignore errors. Every detectable error condition shall:
+1. Return an error status code to the caller, OR
+2. Invoke a registered error callback, OR
+3. Transition the system to a defined safe state.
+
+`[BARR 8.5, CERT ERR00-C]`
+
+### 53.2 Error Propagation
+
+Errors shall propagate up the call stack until a layer that can meaningfully handle them. Intermediate layers shall pass error codes upward, not mask them.
+
+---
+
+## 54. Error Handling — Return Codes
+
+### 54.1 Module-Specific Status Enum
+
+Each module shall define its own status enumeration:
+
+```c
+typedef enum uart_status_t
+{
+    UART_STATUS_OK      = 0,
+    UART_STATUS_ERROR   = 1,
+    UART_STATUS_TIMEOUT = 2,
+    UART_STATUS_BUSY    = 3
+} uart_status_t;
+```
+
+### 54.2 Return Code Checking
+
+All return values that encode error status shall be checked. Explicit discard via `(void)` cast is required when a return value is intentionally ignored. `[MISRA 17.7]`
+
+---
+
+## 55. Error Handling — Assertions
+
+`assert()`-style checks validate programmer assumptions and preconditions — they are not user-input validation.
+
+In safety-critical software, the response to a failed assertion shall be a controlled shutdown or safe-state entry, not merely an abort. See Section 34.2 for the `PROJ_ASSERT` macro.
+
+---
+
+## 56. Error Handling — Safe State and Fail-Safe Behaviour
+
+### 56.1 Defined Safe States
+
+For each module with actuator or safety-relevant output, a safe state shall be defined and documented. The safe state shall be achievable from any error condition.
+
+### 56.2 Hardware Watchdog
+
+All production firmware shall configure and periodically service the hardware watchdog. The watchdog shall NOT be serviced from within an ISR. `[ISO 26262-6]`
+
+### 56.3 Fault Handler
+
+An unrecoverable fault (failed assertion, stack overflow detected, hardware fault) shall invoke a dedicated `fault_Handler()` that:
+1. Disables all actuator outputs.
+2. Enters the safe state.
+3. Logs a fault record if non-volatile storage is available.
+4. Either resets the system or halts (project policy decision, documented).
+
+---
+
+## 57. Hardware Abstraction
+
+### 57.1 HAL Layer
+
+All direct hardware register access shall be confined to a Hardware Abstraction Layer (HAL). Code above the HAL layer shall not access hardware registers directly.
+
+### 57.2 Port Abstraction
+
+Hardware-specific definitions (pin numbers, register base addresses, IRQ numbers) shall be isolated in a single port-configuration header (`<project>_port.h` or equivalent).
+
+### 57.3 HAL Interface Contracts
+
+HAL functions shall have clearly documented preconditions, postconditions, and side effects.
+
+---
+
+## 58. Register Access
+
+Memory-mapped hardware registers shall only be accessed through:
+- `volatile`-qualified pointers, OR
+- Compiler-specific intrinsics for atomic register read-modify-write.
+
+Never access hardware registers through un-qualified pointers; the compiler may optimise the access away.
+
+```c
+#define GPIOA_ODR   (*((volatile uint32_t *)0x40020014U))
+
+GPIOA_ODR |= (1U << 5U);  /* set pin 5 */
+```
+
+---
+
+## 59. Interrupt Service Routines
+
+### 59.1 ISR Design
+
+ISRs shall:
+- Be as short as possible.
+- Post data to a queue/buffer and signal a task for processing.
+- Not call blocking RTOS APIs.
+- Not perform complex computation.
+- Not use `printf` or any buffered I/O.
+
+### 59.2 ISR Naming
+
+ISRs shall use the `_IRQHandler` suffix per CMSIS convention. `[RULE: functions.isr_suffix]`
+
+### 59.3 ISR Re-entrancy
+
+ISRs are not re-entrant by default on ARM Cortex-M. If nested interrupts are enabled, ISR shared data access shall be protected accordingly.
+
+### 59.4 ISR Latency Budget
+
+The maximum execution time of each ISR shall be documented and verified against the interrupt latency budget.
+
+---
+
+## 60. Watchdog
+
+The hardware watchdog shall be:
+- Configured with a documented timeout period.
+- Serviced from the main task or a dedicated watchdog task.
+- Not serviced if any task heartbeat is missed (allow reset on deadlock).
+
+The watchdog timeout shall be documented in the System Safety Architecture.
+
+---
+
+## 61. Timing and Delays
+
+### 61.1 No Blocking Busy-Waits
+
+Blocking busy-waits (`while (x != y) {}`) are prohibited in task context except where the wait duration is strictly bounded and documented with its maximum bound.
+
+### 61.2 RTOS Delays
+
+Task delays shall use RTOS-provided delay functions (`osDelay`, `vTaskDelay`) rather than spin-wait loops.
+
+### 61.3 Timeout on All Blocking Operations
+
+Every RTOS blocking call (queue receive, mutex take, semaphore take) shall have a finite timeout. `osWaitForever` is permitted only where deadlock is provably impossible and documented.
+
+### 61.4 Timestamp Types
+
+Timestamps shall use `uint32_t` tick counts or a project-defined `TICK_T` typedef. Timestamp overflow and rollover shall be handled explicitly using subtraction (not comparison):
+
+```c
+uint32_t elapsed = current_tick - start_tick;  /* correct — wraps safely */
+if (current_tick > (start_tick + timeout))     /* WRONG — overflows */
+```
+
+---
+
+## 62. Floating-Point Arithmetic
+
+### 62.1 Floating-Point Use
+
+Floating-point arithmetic shall only be used where no fixed-point alternative exists. On MCUs without a hardware FPU, floating-point operations are slow and shall be minimised.
+
+### 62.2 NaN and Infinity Handling
+
+Code using floating-point shall check for and handle `NaN` and `Inf` conditions. Do not compare floating-point values for exact equality:
+
+```c
+/* Wrong */
+if (temperature == 0.0F)
+
+/* Correct */
+if (fabsf(temperature) < 1.0E-6F)
+```
+
+### 62.3 Floating-Point Type Selection
+
+Use `float` (single precision) unless `double` precision is explicitly required. On most embedded MCUs, `double` is emulated and significantly slower.
+
+---
+
+## 63. Portability
+
+### 63.1 Architecture Assumptions
+
+Code shall not assume:
+- Specific size of `int`, `long`, or pointer.
+- Specific byte order (endianness) unless explicitly isolated in a HAL function.
+- Specific alignment requirements without `_Static_assert` verification.
+
+`[MISRA 4.6, CERT INT13-C]`
+
+### 63.2 Endianness
+
+Code that serialises or deserialises multi-byte values shall explicitly handle byte order using documented conversion macros:
+
+```c
+#define UINT32_TO_BE(x)   \
+    ((((x) & 0xFF000000U) >> 24U) | \
+     (((x) & 0x00FF0000U) >>  8U) | \
+     (((x) & 0x0000FF00U) <<  8U) | \
+     (((x) & 0x000000FFU) << 24U))
+```
+
+### 63.3 Compiler Extensions
+
+Compiler-specific extensions (`__attribute__`, `#pragma`, intrinsics) shall be:
+- Isolated in a HAL or utility header.
+- Guarded by a `#if defined(__GNUC__)` or equivalent check.
+- Accompanied by a fallback definition for portable builds.
+
+---
+
+## 64. Undefined, Unspecified, and Implementation-Defined Behaviour
+
+Code shall not exhibit undefined behaviour (UB). `[MISRA Underpinning Principle]`
+
+Common sources of UB to avoid:
+
+| Source | Rule | Mitigation |
+|---|---|---|
+| Signed integer overflow | CERT INT32-C | Range-check before arithmetic |
+| Shift by negative or ≥ width | MISRA 12.2 | Assert shift amount |
+| NULL pointer dereference | CERT EXP34-C | NULL check before dereference |
+| Out-of-bounds array access | CERT ARR30-C | Bounds check |
+| Use of uninitialised variable | CERT EXP33-C, MISRA 9.1 | Always initialise |
+| Modifying `const` data via pointer | MISRA 11.3 | `const`-correct code |
+| Strict aliasing violation | CERT EXP39-C | Use `memcpy` for type punning |
+| Sequence point violations | MISRA 13.2 | One side effect per expression |
+| Modifying `volatile` without memory barrier | — | Use appropriate memory barriers |
+
+---
+
+## 65. MISRA C:2012 Compliance Mapping
+
+> **Placeholder:** A complete cross-reference table mapping each MISRA C:2012 Required and Advisory rule to the corresponding section of this standard, and its enforcement status (automated / manual / deviation) will be inserted here during the rule population phase.
+
+Key MISRA rules directly addressed by this standard:
+
+| MISRA Rule | Category | Section |
+|---|---|---|
+| 1.1 | Required | 7, 8, 9 |
+| 2.1 | Required | 23.3 |
+| 4.2 | Required (2023) | 9 |
+| 5.x | Required | 15–26 (Style Guide) |
+| 7.1 | Required | 11.3 |
+| 7.2 | Required | 11.1 |
+| 7.3 | Required | 11.2 |
+| 8.2 | Required | 31.1 |
+| 8.3 | Required | 31.2 |
+| 8.6 | Required | 44.3 |
+| 8.7 | Advisory | 44.1 |
+| 8.13 | Advisory | 14.6 |
+| 9.1 | Mandatory | 42.1 |
+| 10.1–10.8 | Required | 10.4, 12.5, 13.1–13.4 |
+| 11.1 | Required | 14.4, 29.6 |
+| 11.3 | Required | 64 |
+| 11.4 | Advisory | 13.4, 22.1 |
+| 12.1 | Advisory | 18.1 |
+| 12.2 | Required | 12.4, 18.3 |
+| 13.2 | Required | 29.4 |
+| 14.4 | Required | 17.1, 17.2, 13.3 |
+| 15.1 | Advisory | 24 |
+| 15.2 | Required | 24 |
+| 15.4 | Advisory | 27 |
+| 15.5 | Advisory | 23.1 |
+| 16.3 | Required | 28 |
+| 16.4 | Required | 28 |
+| 17.2 | Required | 25, 33 |
+| 17.3 | Mandatory | 31.3 |
+| 17.7 | Required | 30.3, 54.2 |
+| 18.2 | Required | 14.3 |
+| 18.3 | Required | 14.3 |
+| 18.8 | Required | 15.2 |
+| 19.2 | Advisory | 45.2 |
+| 20.7 | Required | Style Guide §37.2 |
+| 20.10 | Advisory | 38 |
+| 20.11 | Advisory | 38 |
+| 21.3 | Required | 20.1 |
+| 21.4 | Required | 9 |
+
+---
+
+## 66. CERT C Compliance Mapping
+
+> **Placeholder:** A complete cross-reference table mapping CERT C rules to sections of this standard will be inserted during the rule population phase.
+
+Key CERT C rules addressed:
+
+| CERT Rule | Title | Section |
+|---|---|---|
+| DCL22-C | Use volatile for data accessible in multiple contexts | 22.2 |
+| EXP33-C | Do not read uninitialized memory | 42.1 |
+| EXP34-C | Do not dereference null pointers | 14.2, 30.4 |
+| EXP39-C | Do not access a variable through a pointer of incompatible type | 14.5 |
+| INT32-C | Ensure signed integer operations do not overflow | 12.1 |
+| INT33-C | Ensure division and modulo do not divide by zero | 12.3 |
+| INT34-C | Do not shift an expression by a negative amount or by ≥ width | 12.4 |
+| INT36-C | Converting a pointer to integer or integer to pointer | 13.4 |
+| ARR30-C | Do not form or use out-of-bounds pointers | 15.1 |
+| STR31-C | Guarantee that storage for strings has sufficient space | 15.3 |
+| STR32-C | Do not pass a non-null-terminated character sequence | 16.1 |
+| ERR00-C | Adopt and implement a consistent and comprehensive error-handling policy | 53 |
+| ERR33-C | Detect and handle standard library errors | 30.3 |
+| PRE10-C | Wrap multistatement macros in a do-while loop | Style Guide §37.3 |
+| PRE11-C | Do not conclude a single statement object-like macro definition with a semicolon | Style Guide §37.4 |
+
+---
+
+## 67. Sign Compatibility
+
+`[RULE: sign_compatibility]`
+
+The cstylecheck sign-compatibility checker validates that unsigned literals are not passed to signed parameters and vice versa, based on function prototypes found in header files.
+
+The project setting `plain_char_is_signed = true` is the default. Change this if the toolchain defaults to unsigned `char`.
+
+---
+
+## 68. Declared-But-Not-Defined Identifiers
+
+`[RULE: misc.declared_not_defined]`
+
+Functions and variables declared `extern` but never defined in any scanned translation unit are flagged. This catches missing BSP stubs and forward-declaration mismatches.
+
+Symbols intentionally left undefined (e.g. HAL stubs to be linked from a library) may be suppressed with:
+
+```c
+extern void HAL_UART_Init(void);  /* cstylecheck: disable misc.declared_not_defined */
+```
+
+---
+
+## 69. Static Analysis Tools
+
+### 69.1 cstylecheck
+
+The cstylecheck tool (this repository) enforces naming conventions, macro rules, literal formatting, line metrics, and a growing set of MISRA/CERT rules. It shall be run in CI on every pull request with zero new violations allowed.
+
+Configuration: `src/rules.yml`
+
+### 69.2 Complementary Tools
+
+For full MISRA compliance, complement cstylecheck with one of:
+- **PC-lint Plus** (MISRA C:2012 / CERT C profiles)
+- **Polyspace Code Prover** (formal verification + MISRA)
+- **LDRA TBvision** (MISRA, DO-178C)
+- **Parasoft C/C++test** (MISRA, CERT, AUTOSAR)
+- **Clang-tidy** (cert-* checks, bugprone-*, concurrency-*)
+
+### 69.3 Static Analysis in CI
+
+Static analysis shall run on every PR branch. The maximum permitted violation count is defined in the project Quality Plan. A ratcheting policy (violations may not increase) shall be enforced.
+
+---
+
+## 70. Code Review for Standards Compliance
+
+The following checklist shall be used during code review to verify coding standard compliance for items not covered by automated tools.
+
+**Design and Architecture:**
+- [ ] Function performs a single, well-defined task (Section 29.1).
+- [ ] No global state where file-scope static suffices (Section 39.1).
+- [ ] Error return codes checked at all call sites (Section 30.3).
+- [ ] No silent error swallowing (Section 53.1).
+
+**Type Safety:**
+- [ ] Fixed-width types used throughout (Section 10.1).
+- [ ] No mixed signed/unsigned arithmetic without explicit cast (Section 12.5).
+- [ ] All pointer parameters NULL-checked (Section 14.2, 30.4).
+- [ ] `const` applied to pointers not modified (Section 14.6).
+
+**Memory:**
+- [ ] No VLAs (Section 15.2).
+- [ ] No dynamic allocation on safety path (Section 20.1).
+- [ ] All variables initialised before use (Section 42.1).
+- [ ] ISR-shared variables declared `volatile` (Section 22.2).
+
+**Concurrency:**
+- [ ] Shared data protected by critical section or mutex (Sections 50, 51).
+- [ ] No blocking calls in ISRs (Section 50.3).
+- [ ] All blocking RTOS calls have finite timeout (Section 61.3).
+
+**Control Flow:**
+- [ ] No recursion (Section 25).
+- [ ] No `goto` except forward-to-cleanup (Section 24).
+- [ ] All `switch` statements have `default` (Section 28).
+- [ ] All fall-throughs commented (Section 28).
+
+**Hardware:**
+- [ ] Hardware registers accessed only through `volatile` pointers (Section 58).
+- [ ] Watchdog serviced correctly (Section 60).
+
+---
+
+## 71. Unit Verification Criteria
+
+For ASPICE SWE.4 (Software Unit Verification), each unit shall satisfy:
+
+| Criterion | Verification Method | Pass Condition |
+|---|---|---|
+| Zero cstylecheck errors | CI automated | No `error`-severity violations |
+| Zero cstylecheck warnings | CI automated | No new `warning`-severity violations (ratchet policy) |
+| MISRA compliance | Static analysis tool | No unapproved deviations |
+| No uninitialised variable warnings | Compiler (`-Wall -Wextra`) | Zero warnings with warnings-as-errors |
+| Cyclomatic complexity ≤ 10 | Static analysis | All functions pass |
+| Function length ≤ 60 lines | cstylecheck | Zero violations |
+| Code review checklist complete | Peer review | Reviewer approval |
+| Unit tests pass with ≥ 80 % branch coverage | Unit test suite | Coverage report |
+
+---
+
+## 72. Deviation Procedure
+
+### 72.1 When a Deviation Is Needed
+
+A deviation is required when:
+- A Required or Mandatory rule cannot be complied with for technical reasons.
+- Third-party code violates this standard and cannot be modified.
+- A specific tool or framework pattern conflicts with a rule.
+
+### 72.2 Deviation Request Form
+
+A Deviation Request shall document:
+1. Rule reference (section and tag, e.g. `[MISRA 15.1]`).
+2. Location in source code (file, function, line range).
+3. Reason compliance is impractical.
+4. Alternative safety measures applied.
+5. Risk assessment.
+6. Approval by Software Engineering Lead and Quality Assurance.
+
+### 72.3 Deviation Register
+
+All approved deviations shall be recorded in `doc/deviation_register.md` with:
+- Unique deviation ID.
+- Approval date and approver.
+- Expiry condition (e.g. "until third-party library is updated to v3.x").
+
+### 72.4 In-Code Suppression
+
+Where a cstylecheck rule must be suppressed, use the inline suppression comment:
+
+```c
+uint8_t legacy_API(int x);  /* cstylecheck: disable sign_compatibility */
+```
+
+Every suppression shall reference a deviation ID:
+
+```c
+/* Deviation DEV-0042: MISRA 15.1 — goto to cleanup label — see deviation register */
+goto cleanup;
+```
+
+---
+
+## 73. Document Change History
+
+| Version | Date | Author | Change Description |
+|---|---|---|---|
+| 1.0 | 2026-06-08 | (initial draft) | Initial document structure — compliance mapping tables are placeholders pending full MISRA/CERT cross-reference population |
+
+---
+
+*End of CSC-STD-001 Embedded C Coding Standard v1.0*

--- a/embedded_c_style_guide.md
+++ b/embedded_c_style_guide.md
@@ -1,0 +1,1362 @@
+# Embedded C Style Guide
+
+---
+
+| Field | Value |
+|---|---|
+| Document ID | CSG-STY-001 |
+| Title | Embedded C Style Guide |
+| Version | 1.0 (DRAFT) |
+| Status | Draft — Pending Rule Population |
+| Date | 2026-06-08 |
+| Owner | Software Engineering Lead |
+| Applies To | All embedded C source and header files |
+| ASPICE Process Areas | SWE.3, SWE.4, SUP.1, SUP.8 |
+| Toolchain | cstylecheck (rules.yml), AStyle |
+
+> **Note:** Sections marked `[RULE: TBD]` are structural placeholders. They will be populated with specific rules derived from `src/rules.yml` (cstylecheck) and the project AStyle configuration file. Do not remove placeholder sections.
+
+---
+
+## Table of Contents
+
+1. [Purpose and Scope](#1-purpose-and-scope)
+2. [Terms and Definitions](#2-terms-and-definitions)
+3. [Normative References](#3-normative-references)
+4. [ASPICE Compliance Notes](#4-aspice-compliance-notes)
+5. [Roles and Responsibilities](#5-roles-and-responsibilities)
+6. [File Organisation](#6-file-organisation)
+7. [File Header and Footer](#7-file-header-and-footer)
+8. [Include Guards](#8-include-guards)
+9. [Indentation and Tabs](#9-indentation-and-tabs)
+10. [Line Length](#10-line-length)
+11. [Blank Lines and Vertical Whitespace](#11-blank-lines-and-vertical-whitespace)
+12. [Horizontal Whitespace](#12-horizontal-whitespace)
+13. [Brace Style](#13-brace-style)
+14. [Parenthesis Style](#14-parenthesis-style)
+15. [Naming Conventions — Overview](#15-naming-conventions--overview)
+16. [Naming — Files](#16-naming--files)
+17. [Naming — Module Prefix](#17-naming--module-prefix)
+18. [Naming — Variables](#18-naming--variables)
+19. [Naming — Constants and Object-Like Macros](#19-naming--constants-and-object-like-macros)
+20. [Naming — Function-Like Macros](#20-naming--function-like-macros)
+21. [Naming — Functions](#21-naming--functions)
+22. [Naming — Types (typedef)](#22-naming--types-typedef)
+23. [Naming — Struct and Union Tags](#23-naming--struct-and-union-tags)
+24. [Naming — Enumeration Types and Members](#24-naming--enumeration-types-and-members)
+25. [Naming — Interrupt Service Routines](#25-naming--interrupt-service-routines)
+26. [Naming — Prefixes Summary Table](#26-naming--prefixes-summary-table)
+27. [Comment Style — Line Comments](#27-comment-style--line-comments)
+28. [Comment Style — Block Comments](#28-comment-style--block-comments)
+29. [Comment Style — Doxygen Headers](#29-comment-style--doxygen-headers)
+30. [Comment Style — File Header](#30-comment-style--file-header)
+31. [Comment Style — Section Banners](#31-comment-style--section-banners)
+32. [Comment Style — Inline Comments](#32-comment-style--inline-comments)
+33. [Comment Density](#33-comment-density)
+34. [Integer Literals](#34-integer-literals)
+35. [Floating-Point Literals](#35-floating-point-literals)
+36. [String Literals](#36-string-literals)
+37. [Preprocessor Directives — Layout](#37-preprocessor-directives--layout)
+38. [Preprocessor Directives — Include Order](#38-preprocessor-directives--include-order)
+39. [Expressions and Operators](#39-expressions-and-operators)
+40. [Control Flow Statement Layout](#40-control-flow-statement-layout)
+41. [Switch Statement Layout](#41-switch-statement-layout)
+42. [Function Definition Layout](#42-function-definition-layout)
+43. [Struct and Union Layout](#43-struct-and-union-layout)
+44. [Typedef Layout](#44-typedef-layout)
+45. [Enum Layout](#45-enum-layout)
+46. [Variable Declaration Layout](#46-variable-declaration-layout)
+47. [Pointer Declarators](#47-pointer-declarators)
+48. [Cast Expressions](#48-cast-expressions)
+49. [Yoda Conditions](#49-yoda-conditions)
+50. [Magic Numbers](#50-magic-numbers)
+51. [End-of-File](#51-end-of-file)
+52. [AStyle Configuration Reference](#52-astyle-configuration-reference)
+53. [cstylecheck Configuration Reference](#53-cstylecheck-configuration-reference)
+54. [Automated Enforcement](#54-automated-enforcement)
+55. [Style Review Checklist](#55-style-review-checklist)
+56. [Deviations](#56-deviations)
+57. [Document Change History](#57-document-change-history)
+
+---
+
+## 1. Purpose and Scope
+
+### 1.1 Purpose
+
+This document defines the **visual and formatting conventions** for all embedded C source code produced by the project. It governs how code looks — indentation, spacing, naming, commenting, and layout — independently of what the code does (behavioural rules are covered in the companion C Coding Standard, CSC-STD-001).
+
+Consistent style reduces cognitive load during code review, simplifies static analysis tooling, and supports traceability requirements under ASPICE v4 Level 2.
+
+### 1.2 Scope
+
+This guide applies to:
+
+- All `.c` and `.h` files that are owned by this project and compiled into production firmware.
+- All new files created after this document reaches `Approved` status.
+- Existing files undergoing a modification that touches more than 20 % of existing lines (incremental adoption).
+
+### 1.3 Out of Scope
+
+- Third-party or vendor-supplied files (placed under `third_party/` or `vendor/`).
+- Auto-generated files from code-generation tools, provided the generator is version-controlled and qualified.
+- Assembly (`.s`, `.asm`) files.
+- Build system files (`Makefile`, `CMakeLists.txt`).
+
+### 1.4 Relationship to Other Documents
+
+| Document | ID | Relationship |
+|---|---|---|
+| Embedded C Coding Standard | CSC-STD-001 | Companion — governs behavioural rules |
+| External Standards Analysis | CSC-ANA-001 | Rationale for rule choices |
+| cstylecheck rules.yml | (tool config) | Machine-readable enforcement of this guide |
+| AStyle .astylerc | (tool config) | Automated reformatter config derived from this guide |
+
+---
+
+## 2. Terms and Definitions
+
+| Term | Definition |
+|---|---|
+| **Module** | A logical grouping of functionality, consisting of one `.c` and one or more `.h` files sharing a common prefix. |
+| **Module prefix** | A short lowercase identifier (e.g. `uart`, `can`, `adc`) prepended to all public identifiers in a module. |
+| **File scope** | Identifiers declared at the top level of a translation unit, outside any function. |
+| **Block scope** | Identifiers declared inside a function body or compound statement. |
+| **Snake case** | Words separated by underscores, all lowercase: `my_variable`. |
+| **Upper snake case** | Words separated by underscores, all uppercase: `MY_CONSTANT`. |
+| **Pascal case** | Each word starts with a capital letter, no separator: `MyFunction`. |
+| **Object-like macro** | A `#define` whose replacement list does not include a parameter list. |
+| **Function-like macro** | A `#define` whose name is immediately followed by `(`. |
+| **Magic number** | A numeric literal embedded directly in code without a named constant. |
+| **ISR** | Interrupt Service Routine — a function invoked by hardware interrupt. |
+| **Yoda condition** | A comparison where the constant appears on the left: `if (0 == x)`. |
+| **Doxygen** | A documentation generator that parses structured comment tags (`@brief`, `@param`, `@return`). |
+| **AStyle** | Artistic Style — an open-source source code formatter for C/C++. |
+| **cstylecheck** | The project style checker (this repository) that enforces naming and miscellaneous rules. |
+
+---
+
+## 3. Normative References
+
+The following documents are referenced normatively. When a conflict exists, the order of precedence is as listed.
+
+1. **MISRA C:2012** — Guidelines for the Use of the C Language in Critical Systems, MISRA Ltd, 2012 (including Amendment 1:2016 and MISRA C:2023 corrigendum).
+2. **Barr-C:2018** — Embedded C Coding Standard, Barr Group, version 2.0, 2018.
+3. **ASPICE v4.0** — Automotive SPICE Process Assessment / Reference Model, VDA QMC, 2023.
+4. **ISO/IEC 9899:2011 (C11)** — Programming languages — C.
+5. **CERT C Coding Standard** — SEI CERT C Coding Standard, Carnegie Mellon University, 2016.
+6. **NASA/JPL C Coding Standard** — Power of Ten Rules, Gerard Holzmann, JPL, 2006.
+7. **ISO 26262-6:2018** — Road vehicles — Functional safety — Part 6: Product development at the software level.
+
+---
+
+## 4. ASPICE Compliance Notes
+
+This document supports the following ASPICE v4 Level 2 process areas and generic practices:
+
+| ASPICE Process Area | Relevant Practice | How This Document Contributes |
+|---|---|---|
+| SWE.3 Software Detailed Design and Unit Construction | BP3 — Define software unit interfaces | Naming conventions ensure consistent interface identifiers |
+| SWE.3 | BP5 — Implement software units | Style rules applied during unit construction |
+| SWE.4 Software Unit Verification | BP2 — Conduct static verification | Style guide rules are automatically enforced by cstylecheck |
+| SUP.1 Quality Assurance | BP2 — Assure compliance of work products | Style review checklist (Section 55) |
+| SUP.8 Configuration Management | BP1 — Identify configuration items | This document is under version control as a configuration item |
+| GP 2.1.1 | Define the process | This document is the defined process for C style |
+| GP 2.2.1 | Define responsibility and authority | Section 5 defines ownership |
+| GP 2.3.1 | Identify process information items | Document ID, version, and status are tracked |
+
+---
+
+## 5. Roles and Responsibilities
+
+| Role | Responsibility |
+|---|---|
+| **Software Engineering Lead** | Owns this document; approves changes; resolves interpretation disputes |
+| **Developer** | Complies with all rules; raises deviation requests where compliance is impractical |
+| **Code Reviewer** | Verifies style compliance before approving pull requests |
+| **Quality Assurance** | Audits that cstylecheck is enabled in CI and that violation counts do not regress |
+| **Configuration Manager** | Maintains version history; ensures approved version is the current baseline |
+
+---
+
+## 6. File Organisation
+
+### 6.1 Source File Pairs
+
+Each module shall consist of exactly one `.c` implementation file and one `.h` public header. A module may have additional private header files (suffix `_priv.h` or `_internal.h`).
+
+```
+uart/
+    uart.c          /* implementation */
+    uart.h          /* public API */
+    uart_priv.h     /* internal definitions (optional) */
+```
+
+### 6.2 File Naming
+
+- File names shall use **lowercase snake case**: `motor_control.c`, `adc_driver.h`.
+- File names shall not exceed 31 characters (excluding extension).
+- File names shall not duplicate any C standard library header name (e.g. `string.h`, `stdio.h` are forbidden). `[RULE: misc.reserved_header_name]`
+
+### 6.3 Directory Structure
+
+```
+src/
+    app/            /* application-layer modules */
+    drivers/        /* hardware-driver modules */
+    middleware/     /* platform-independent middleware */
+    hal/            /* hardware abstraction layer */
+    rtos/           /* RTOS integration/wrappers */
+    common/         /* shared utilities, types, macros */
+inc/                /* public headers exposed to host applications */
+tests/              /* unit tests */
+third_party/        /* vendor code — exempt from this guide */
+```
+
+### 6.4 Maximum File Length
+
+Each source file shall not exceed **500 lines** in total (including blanks, comments, and code). `[RULE: misc.file_length]`
+
+Files approaching this limit should be split into logical sub-modules.
+
+---
+
+## 7. File Header and Footer
+
+### 7.1 File Header
+
+Every `.c` and `.h` file shall begin with a copyright block comment, followed by exactly one blank line.
+
+```c
+/*
+ * (C) Copyright 2026 <Organisation Name>
+ *
+ * SPDX-License-Identifier: <licence-identifier>
+ *
+ * File:    uart.c
+ * Module:  UART Driver
+ * Brief:   UART transmit/receive driver for STM32F4.
+ *
+ * ASPICE:  SWE.3
+ * MISRA:   Compliant subset — see project deviation list
+ */
+```
+
+`[RULE: misc.copyright_header]` — The copyright block must match the template in `src/copyright_header.txt`; year may differ.
+
+### 7.2 File Footer (Optional)
+
+When enabled, each file shall end with a single-line EOF comment followed by exactly one blank line:
+
+```c
+/* EOF: uart.c */
+
+```
+
+`[RULE: misc.eof_comment]`
+
+---
+
+## 8. Include Guards
+
+### 8.1 Macro-Based Guards
+
+Every `.h` file shall use an include guard whose macro name matches the pattern:
+
+```
+{FILENAME_UPPER}_{EXT_UPPER}_
+```
+
+Example for `uart_driver.h`:
+
+```c
+#ifndef UART_DRIVER_H_
+#define UART_DRIVER_H_
+
+/* ... header content ... */
+
+#endif /* UART_DRIVER_H_ */
+```
+
+`[RULE: include_guards]`
+
+### 8.2 `#pragma once`
+
+`#pragma once` is permitted as an alternative to macro guards when supported by the toolchain. When used, it shall appear as the very first non-comment line of the file.
+
+---
+
+## 9. Indentation and Tabs
+
+### 9.1 Indentation Character
+
+`[RULE: misc.indentation]`
+
+> **Placeholder:** This section will specify whether the project uses **tabs** or **spaces** and the visual width, derived from `src/rules.yml → misc.indentation` and the AStyle `--indent` option.
+
+Current `rules.yml` default: `tabs`, width 8. AStyle configuration will be the authoritative source.
+
+### 9.2 Continuation Lines
+
+Lines that are broken across multiple lines for length shall be indented **two indent levels** beyond the opening line:
+
+```c
+result = some_very_long_function_name(
+        first_argument,
+        second_argument,
+        third_argument);
+```
+
+### 9.3 Preprocessor Directives
+
+Preprocessor directives shall be left-aligned at column 0. Nested directives shall indent the body keyword only (not the `#`):
+
+```c
+#if defined(UART_ENABLE)
+#  if defined(UART_DMA)
+    /* DMA path */
+#  else
+    /* polling path */
+#  endif
+#endif
+```
+
+---
+
+## 10. Line Length
+
+`[RULE: misc.line_length]`
+
+> **Placeholder:** The maximum line length will be derived from `src/rules.yml → misc.line_length.max` and the AStyle `--max-code-length` option.
+
+Current `rules.yml` default: 180 characters. This placeholder will be updated when the AStyle config is finalised.
+
+### 10.1 Breaking Long Lines
+
+When a line exceeds the limit:
+
+- Break after a comma in an argument list.
+- Break before a binary operator (`&&`, `||`, `+`, etc.); the operator leads the continuation line.
+- Break after `=` or `return`.
+- Do not break inside a string literal unless using implicit concatenation.
+
+---
+
+## 11. Blank Lines and Vertical Whitespace
+
+### 11.1 Between Top-Level Declarations
+
+- **Two blank lines** shall separate top-level function definitions.
+- **One blank line** shall separate `#include` blocks, `typedef` declarations, and non-function file-scope declarations from each other.
+
+### 11.2 Within a Function Body
+
+- **One blank line** shall follow the local variable declaration block before the first executable statement. `[RULE: misc.declaration_spacing]`
+- **One blank line** shall precede a block comment that introduces a logical section.
+- No more than **one consecutive blank line** inside a function body.
+
+### 11.3 Whitespace Ratio
+
+`[RULE: misc.whitespace_ratio]`
+
+The ratio of blank lines to code lines in a file shall not fall below the configured thresholds, ensuring adequate readability spacing.
+
+---
+
+## 12. Horizontal Whitespace
+
+### 12.1 Around Operators
+
+- A single space shall appear on both sides of all binary and ternary operators: `a + b`, `x == y`, `a ? b : c`.
+- No space between a unary operator and its operand: `!flag`, `~mask`, `*p_buf`, `&var`.
+- No space between `sizeof` / `alignof` and `(type)` when used as a type query: `sizeof(uint32_t)`.
+
+### 12.2 After Keywords
+
+A single space shall follow control-flow keywords: `if (`, `for (`, `while (`, `switch (`, `do {`.
+
+No space between a function name and its `(`: `uart_Init()`, not `uart_Init ()`.
+
+### 12.3 After Commas
+
+A single space shall follow each comma in argument lists, initialiser lists, and parameter declarations.
+
+### 12.4 Inside Brackets
+
+No space immediately inside parentheses or square brackets:
+
+```c
+/* Correct */
+result = func(a, b);
+val = array[idx];
+
+/* Wrong */
+result = func( a, b );
+val = array[ idx ];
+```
+
+### 12.5 Pointer and Address-of Operators
+
+The `*` (dereference / pointer declarator) and `&` (address-of) operators shall be written adjacent to the **type**, not the variable name, in declarations:
+
+```c
+uint8_t *p_buffer;   /* correct */
+uint8_t* p_buffer;   /* also acceptable per AStyle config */
+uint8_t * p_buffer;  /* wrong */
+```
+
+`[AStyle: --align-pointer=type | --align-pointer=middle]` — authoritative setting comes from the AStyle configuration file.
+
+---
+
+## 13. Brace Style
+
+`[AStyle: --style=]`
+
+> **Placeholder:** The brace placement style (Allman, K&R, Linux, etc.) will be derived from the project AStyle configuration file.
+
+### 13.1 Mandatory Braces
+
+Braces **shall** be used around the body of every `if`, `else`, `for`, `while`, and `do` statement, even when the body is a single statement. (MISRA C:2012 Rule 15.6, Barr-C 8.3.)
+
+```c
+/* Correct */
+if (NULL == p_buf)
+{
+    return ERROR;
+}
+
+/* Wrong */
+if (NULL == p_buf)
+    return ERROR;
+```
+
+### 13.2 Empty Blocks
+
+An empty block shall contain a comment explaining why it is intentionally empty:
+
+```c
+while (uart_RxBufferIsEmpty())
+{
+    /* intentional busy-wait — timeout handled by caller */
+}
+```
+
+---
+
+## 14. Parenthesis Style
+
+### 14.1 Explicit Parentheses for Clarity
+
+Use parentheses to make operator precedence explicit whenever mixing operators from different precedence groups:
+
+```c
+result = (a + b) * c;           /* explicit */
+result = a + b * c;             /* relies on precedence — avoid */
+```
+
+### 14.2 Return Statements
+
+`return` is a statement, not a function. Do not enclose its expression in superfluous parentheses unless the parentheses are needed for line-breaking:
+
+```c
+return status;          /* correct */
+return (status);        /* wrong */
+```
+
+---
+
+## 15. Naming Conventions — Overview
+
+All identifiers shall be:
+
+- Written in **English**.
+- **Self-documenting** — the name shall convey meaning without relying on comments for basic understanding.
+- Free of cryptic abbreviations not listed in the project abbreviation list (`src/aliases.txt`).
+- Not shorter than **3 characters**, except for permitted single-character loop counters (`i`, `j`, `k`). `[RULE: variables.min_length]`
+- Not longer than **40 characters** for variables, **60 characters** for functions and macros. `[RULE: variables.max_length, functions.max_length]`
+- Free of reserved C/POSIX/C++ names (checked by `[RULE: reserved_names]`).
+
+---
+
+## 16. Naming — Files
+
+- Lowercase snake case: `motor_control.c`.
+- The base name (without extension) forms the **module prefix** for all identifiers within that file.
+- Header file names shall match their corresponding source file: `uart.c` → `uart.h`.
+
+---
+
+## 17. Naming — Module Prefix
+
+`[RULE: file_prefix]`
+
+All identifiers at file scope (global variables, static variables, functions, object-like macros, constants) **shall** be prefixed with the module name followed by the separator `_`:
+
+```
+uart_      →  uart_TxBufferSend, uart_g_tx_count, UART_BAUD_RATE
+can_       →  can_MessageReceive, can_s_rx_queue, CAN_MAX_PAYLOAD
+```
+
+- The module prefix shall be **lowercase**.
+- The separator shall be `_`.
+- `main.c` and `main.h` are exempt from the prefix requirement. `[RULE: file_prefix.exempt_main]`
+
+---
+
+## 18. Naming — Variables
+
+`[RULE: variables]`
+
+### 18.1 Case
+
+All variable names shall use **lower snake case**: `tx_byte_count`, `buffer_index`.
+
+### 18.2 Scope Prefixes
+
+| Scope | Required prefix (local part, after module prefix) | Example |
+|---|---|---|
+| Global (extern linkage) | `g_` | `uart_g_tx_count` |
+| File-scope static | `s_` | `uart_s_rx_queue` |
+| Local variable | none | `byte_count` |
+| Parameter | none (see 18.3) | `buffer_size` |
+
+`[RULE: variables.global.g_prefix, variables.static.s_prefix]`
+
+### 18.3 Parameter Prefix (Optional)
+
+When `variables.parameter.p_prefix.enabled` is set to `true`, all function parameters shall begin with `p_`:
+
+```c
+void uart_BufferWrite(uint8_t *p_p_data, uint16_t p_length);
+```
+
+### 18.4 Pointer Prefix
+
+Single-pointer variables shall have their local part begin with `p_`: `p_buffer`, `uart_s_p_rx_head`. `[RULE: variables.pointer_prefix]`
+
+Double-pointer variables shall begin with `pp_`: `pp_device_list`. `[RULE: variables.pp_prefix]`
+
+### 18.5 Boolean Prefix (Optional)
+
+When enabled, `bool`/`_Bool` variables shall begin with `b_` and be phrased as a question: `b_is_full`, `b_transmit_active`. `[RULE: variables.bool_prefix]`
+
+### 18.6 Handle Prefix
+
+Variables holding RTOS or POSIX handles (e.g. `TaskHandle_t`, `FILE *`) shall begin with `h_`: `h_uart_task`, `h_log_file`. `[RULE: variables.handle_prefix]`
+
+### 18.7 Numeric Suffixes in Names
+
+`[RULE: variables.no_numeric_in_name]`
+
+Variable names shall not embed a numeric value that is duplicated elsewhere (e.g. `buffer32` when the type is `uint32_t`). Hardware peripheral instance numbers (e.g. `uart2`, `spi1`) are exempt.
+
+### 18.8 Prefix Ordering
+
+When multiple prefixes apply, they shall appear in the order: `[g_] [p_|pp_] [b_|h_]`. `[RULE: variables.prefix_order]`
+
+Example: a global pointer to a boolean: `uart_g_p_b_overflow_flag`.
+
+---
+
+## 19. Naming — Constants and Object-Like Macros
+
+`[RULE: constants, macros (object-like)]`
+
+All object-like `#define` constants and `const`-qualified file-scope variables shall use **UPPER\_SNAKE\_CASE**:
+
+```c
+#define UART_BAUD_RATE    115200U
+#define MAX_PACKET_SIZE   256U
+
+static const uint8_t uart_s_PREAMBLE[] = { 0xAAU, 0x55U };
+```
+
+- Minimum length: 2 characters. Maximum length: 60 characters.
+- Module prefix applies: `UART_`, `CAN_`, etc.
+- RTOS configuration macros (`configUSE_*`, `portMAX_DELAY`, etc.) are exempt. `[RULE: constants.exempt_patterns]`
+
+---
+
+## 20. Naming — Function-Like Macros
+
+`[RULE: macros]`
+
+Function-like macros shall also use **UPPER\_SNAKE\_CASE**:
+
+```c
+#define UART_SET_BAUD(baud)   (USART1->BRR = (baud))
+#define MAX(a, b)             (((a) > (b)) ? (a) : (b))
+```
+
+An optional `_M` suffix may be required by the project configuration to distinguish function-like macros from constants: `UART_SET_BAUD_M(baud)`. `[RULE: macros.function_like_suffix]`
+
+---
+
+## 21. Naming — Functions
+
+`[RULE: functions]`
+
+### 21.1 Style
+
+The project shall use **Object–Verb** style: `<Module>_<Object><Verb>`
+
+```
+uart_BufferRead       (module=uart, object=Buffer, verb=Read)
+can_MessageSend       (module=can, object=Message, verb=Send)
+adc_ChannelConvert    (module=adc, object=Channel, verb=Convert)
+```
+
+`[RULE: functions.style = object_verb]`
+
+Object and verb segments shall use **PascalCase**. `[RULE: functions.object_case = pascal, functions.verb_case = pascal]`
+
+Minimum length: 4 characters. Maximum length: 60 characters.
+
+### 21.2 Static (Private) Functions
+
+When `functions.static_prefix.enabled` is `true`, file-scope static functions shall be prefixed with `prv_`:
+
+```c
+static void prv_uart_FifoFlush(void);
+```
+
+### 21.3 Permitted Object Exclusions
+
+Short verbs that act as both object and verb (`Wr`, `Rd`, `Init`, `IoCntrl`) exempt the function from the full object\_verb check. `[RULE: functions.object_exclusions]`
+
+---
+
+## 22. Naming — Types (typedef)
+
+`[RULE: typedefs]`
+
+All project-defined `typedef` names shall use **UPPER\_SNAKE\_CASE** with a `_T` suffix:
+
+```c
+typedef struct uart_config_s  UART_CONFIG_T;
+typedef uint16_t              MOTOR_SPEED_T;
+typedef void (*UART_CALLBACK_T)(uint8_t byte);
+```
+
+Standard fixed-width types (`uint8_t`, `int32_t`, etc.) from `<stdint.h>` are exempt.
+
+---
+
+## 23. Naming — Struct and Union Tags
+
+`[RULE: structs]`
+
+Struct and union **tags** shall use **lower snake case** with a `_s` suffix (struct) or `_u` suffix (union):
+
+```c
+struct uart_config_s
+{
+    uint32_t baud_rate;
+    uint8_t  stop_bits;
+};
+
+union sensor_data_u
+{
+    float    f_value;
+    uint32_t raw;
+};
+```
+
+Struct **member names** shall use lower snake case, with no module prefix required.
+
+---
+
+## 24. Naming — Enumeration Types and Members
+
+`[RULE: enums]`
+
+- Enum **type names** shall use lower snake case with a `_t` suffix: `uart_status_t`.
+- Enum **member names** shall use UPPER\_SNAKE\_CASE prefixed with the type name (minus the `_t` suffix, uppercased):
+
+```c
+typedef enum uart_status_t
+{
+    UART_STATUS_OK      = 0,
+    UART_STATUS_ERROR   = 1,
+    UART_STATUS_TIMEOUT = 2,
+    UART_STATUS_BUSY    = 3
+} uart_status_t;
+```
+
+`[RULE: enums.type_suffix = _t, enums.member_prefix_from_type = true]`
+
+---
+
+## 25. Naming — Interrupt Service Routines
+
+`[RULE: functions.isr_suffix]`
+
+ISR functions shall use the suffix `_IRQHandler` as required by the CMSIS/STM32 vector table naming convention:
+
+```c
+void USART1_IRQHandler(void);
+void TIM2_IRQHandler(void);
+void DMA1_Stream0_IRQHandler(void);
+```
+
+ISR functions are exempt from the module prefix requirement. `[RULE: file_prefix.exempt_patterns → ISR]`
+
+---
+
+## 26. Naming — Prefixes Summary Table
+
+| Category | Case | Prefix / Suffix | Example |
+|---|---|---|---|
+| File name | lower\_snake | — | `uart_driver.c` |
+| Module prefix | lower | `<module>_` | `uart_` |
+| Global variable | lower\_snake | `<mod>_g_` | `uart_g_tx_count` |
+| Static variable | lower\_snake | `<mod>_s_` | `uart_s_rx_head` |
+| Local variable | lower\_snake | — | `byte_count` |
+| Parameter | lower\_snake | `p_` (optional) | `p_buffer` |
+| Pointer | lower\_snake | `p_` prefix on local part | `p_data` |
+| Double pointer | lower\_snake | `pp_` | `pp_handle` |
+| Boolean | lower\_snake | `b_` (optional) | `b_is_ready` |
+| Handle | lower\_snake | `h_` | `h_uart_task` |
+| Constant (`#define`) | UPPER\_SNAKE | `<MOD>_` | `UART_BAUD_RATE` |
+| Function-like macro | UPPER\_SNAKE | `<MOD>_` | `UART_SET_BAUD` |
+| Function | Module + PascalCase | `<mod>_<Object><Verb>` | `uart_BufferRead` |
+| typedef | UPPER\_SNAKE | `_T` suffix | `UART_CONFIG_T` |
+| Struct tag | lower\_snake | `_s` suffix | `uart_config_s` |
+| Union tag | lower\_snake | `_u` suffix | `sensor_data_u` |
+| Enum type | lower\_snake | `_t` suffix | `uart_status_t` |
+| Enum member | UPPER\_SNAKE | `<TYPE_PREFIX>_` | `UART_STATUS_OK` |
+| ISR | UPPER / mixed | `_IRQHandler` suffix | `USART1_IRQHandler` |
+
+---
+
+## 27. Comment Style — Line Comments
+
+Line comments (`//`) shall be permitted and preferred for brief end-of-line annotations:
+
+```c
+uint32_t baud_rate;     /* baud rate in bits/second */
+uint8_t  stop_bits;     /* 1 or 2 */
+```
+
+Both `//` and `/* */` are acceptable. Projects using C89/C90 compatibility shall restrict to `/* */` only.
+
+---
+
+## 28. Comment Style — Block Comments
+
+Multi-line block comments shall use the following format:
+
+```c
+/*
+ * This is a multi-line block comment.
+ * Each continuation line begins with a space and asterisk.
+ * The closing delimiter is on its own line.
+ */
+```
+
+`[RULE: misc.block_comment_spacing]` — After the closing `*/`, at least one and at most two blank lines shall follow before the next non-blank line (when the rule is enabled).
+
+---
+
+## 29. Comment Style — Doxygen Headers
+
+`[RULE: misc.function_doc_header]`
+
+Every function definition shall be immediately preceded by a Doxygen block comment containing at minimum:
+
+```c
+/**
+ * @brief   Reads a byte from the UART receive buffer.
+ *
+ * @param[out] p_byte    Pointer to storage for the received byte.
+ * @param[in]  timeout   Timeout in milliseconds; 0 = non-blocking.
+ *
+ * @return  UART_STATUS_OK on success.
+ * @return  UART_STATUS_TIMEOUT if no data arrived within timeout.
+ * @return  UART_STATUS_ERROR on hardware fault.
+ */
+uart_status_t uart_BufferRead(uint8_t *p_byte, uint32_t timeout)
+{
+```
+
+Required tags: `@brief`, `@param` (one per parameter), `@return` (for non-void functions).
+
+---
+
+## 30. Comment Style — File Header
+
+See Section 7.1. The file header comment shall contain at minimum: copyright, SPDX licence, file name, module name, and a one-line brief description.
+
+---
+
+## 31. Comment Style — Section Banners
+
+Logical sections within a source file may be separated by a banner comment:
+
+```c
+/* =========================================================================
+ * Receive Path
+ * ========================================================================= */
+```
+
+Banners shall not exceed the line-length limit.
+
+---
+
+## 32. Comment Style — Inline Comments
+
+Inline comments on the same line as code shall be separated from the code by **at least two spaces**:
+
+```c
+uint32_t timeout_ms = 100U;  /* default 100 ms per UART spec §4.2 */
+```
+
+Inline comments shall not state the obvious. Comment the **why**, not the **what**.
+
+---
+
+## 33. Comment Density
+
+`[RULE: misc.comment_ratio]`
+
+The ratio of explanatory comment lines to code lines shall not fall below the configured thresholds:
+
+- Warning threshold: 15 % (default).
+- Error threshold: 5 % (default).
+
+File header blocks and Doxygen blocks are excluded from this count (they are documentation, not explanatory comments).
+
+---
+
+## 34. Integer Literals
+
+### 34.1 Unsigned Suffix
+
+Unsigned integer constants shall carry a `U` suffix. `[RULE: misc.unsigned_suffix]`
+
+```c
+#define BUFFER_SIZE  256U
+uint8_t mask = 0xFFU;
+```
+
+The literal `0` is neutral and does not require `U`.
+
+### 34.2 Uppercase Suffixes
+
+Integer suffixes shall use **uppercase** letters only. The lowercase `l` is visually ambiguous with `1` and is forbidden. `[RULE: misc.lowercase_l_suffix]` (MISRA C:2012 Rule 7.3)
+
+```c
+/* Correct */
+int32_t val = 1000L;
+uint32_t big = 1000000UL;
+
+/* Wrong */
+int32_t val = 1000l;    /* lowercase l */
+```
+
+### 34.3 Hexadecimal Digits
+
+Hexadecimal digits `A`–`F` shall be uppercase: `0xDEADBEEFU`.
+
+### 34.4 Octal Constants
+
+Octal integer constants are forbidden (MISRA C:2012 Rule 7.1). `[RULE: misc.octal_constant]`
+
+```c
+/* Wrong */
+uint8_t mode = 010;  /* octal 8, not decimal 10 */
+
+/* Correct */
+uint8_t mode = 8U;
+```
+
+The bare literal `0` (zero alone) is always permitted.
+
+### 34.5 Trigraphs
+
+Trigraphs are forbidden in all source and header files. `[RULE: misc.trigraph]` (MISRA C:2012/2023 Rule 4.2)
+
+---
+
+## 35. Floating-Point Literals
+
+Floating-point literals shall always include a decimal point and at least one digit on each side:
+
+```c
+float gain = 1.0F;       /* correct */
+float gain = 1.F;        /* wrong — no digit after decimal */
+float gain = 1;          /* wrong — integer literal assigned to float */
+```
+
+The `F` suffix shall be used for `float` literals; no suffix for `double`.
+
+---
+
+## 36. String Literals
+
+- String literals shall be declared `const` when assigned to a pointer: `const char *p_name = "uart";`.
+- String literal concatenation across lines is permitted:
+
+```c
+const char *p_msg = "First part of a very long "
+                    "message string.";
+```
+
+---
+
+## 37. Preprocessor Directives — Layout
+
+### 37.1 `#define` Alignment
+
+When multiple related `#define` constants are grouped together, their values may be vertically aligned:
+
+```c
+#define UART_BAUD_9600    9600U
+#define UART_BAUD_115200  115200U
+#define UART_BAUD_921600  921600U
+```
+
+### 37.2 Macro Parameter Parentheses
+
+Every macro parameter shall be enclosed in parentheses in the replacement text (MISRA C:2012 Rule 20.7):
+
+```c
+#define SQUARE(x)   ((x) * (x))   /* correct */
+#define SQUARE(x)   (x * x)       /* wrong */
+```
+
+### 37.3 Multi-Statement Macros
+
+Function-like macros containing two or more statements shall be wrapped in `do { ... } while (0U)`. `[RULE: macros.multistatement_wrapper]` (CERT PRE10-C)
+
+```c
+#define UART_ASSERT_AND_LOG(cond, msg)  \
+    do {                                \
+        if (!(cond)) {                  \
+            log_Error(msg);             \
+            assert(false);              \
+        }                               \
+    } while (0U)
+```
+
+### 37.4 Trailing Semicolon in Macros
+
+A `#define` body shall not end with a bare semicolon. `[RULE: macros.trailing_semicolon]` (CERT PRE11-C)
+
+---
+
+## 38. Preprocessor Directives — Include Order
+
+`#include` directives shall be ordered as follows, each group separated by one blank line:
+
+1. The module's own header (for `.c` files): `#include "uart.h"`
+2. Other project headers: `#include "can.h"`
+3. RTOS and middleware headers: `#include "FreeRTOS.h"`
+4. HAL and driver headers: `#include "stm32f4xx_hal.h"`
+5. C standard library headers: `#include <stdint.h>`
+
+All project-relative headers shall use double-quote syntax. All system/library headers shall use angle-bracket syntax.
+
+---
+
+## 39. Expressions and Operators
+
+### 39.1 Explicit Precedence
+
+Parentheses shall be used to make operator precedence explicit when combining operators from different precedence levels. Relying on non-obvious precedence is prohibited.
+
+### 39.2 Compound Assignment
+
+Compound assignment operators (`+=`, `-=`, etc.) are permitted. Do not expand them to verbose form unless clarity requires it.
+
+### 39.3 Comma Operator
+
+The comma operator shall not be used outside `for` loop initialisers/increments.
+
+### 39.4 Sizeof
+
+`sizeof` shall always be applied to a **variable** or **expression**, not a **type name**, in contexts where the variable type is known:
+
+```c
+memset(p_buf, 0, sizeof(*p_buf));  /* preferred */
+memset(p_buf, 0, sizeof(BUF_T));   /* acceptable, not preferred */
+```
+
+---
+
+## 40. Control Flow Statement Layout
+
+### 40.1 `if` / `else`
+
+```c
+if (UART_STATUS_OK == status)
+{
+    /* ... */
+}
+else if (UART_STATUS_TIMEOUT == status)
+{
+    /* ... */
+}
+else
+{
+    /* ... */
+}
+```
+
+- `else` shall be on the same line as the closing `}` or on the next line (AStyle-controlled).
+- Braces are mandatory even for single-statement bodies (Section 13.1).
+
+### 40.2 `for`
+
+```c
+for (uint8_t i = 0U; i < UART_BUFFER_SIZE; i++)
+{
+    /* ... */
+}
+```
+
+### 40.3 `while`
+
+```c
+while (0U == uart_RxBufferIsEmpty())
+{
+    /* ... */
+}
+```
+
+### 40.4 `do … while`
+
+```c
+do
+{
+    status = uart_ByteReceive(&byte);
+} while (UART_STATUS_BUSY == status);
+```
+
+### 40.5 Null Statements
+
+A null (empty) statement shall be on its own line with a comment. `[RULE: misc.null_statement_comment]` (JSF Rule 192)
+
+```c
+while (uart_TxBufferIsEmpty())
+{
+    ; /* intentional spin-wait */
+}
+```
+
+---
+
+## 41. Switch Statement Layout
+
+```c
+switch (uart_status)
+{
+    case UART_STATUS_OK:
+        uart_ProcessByte(byte);
+        break;
+
+    case UART_STATUS_TIMEOUT:
+        uart_HandleTimeout();
+        break;
+
+    default:
+        uart_HandleError(uart_status);
+        break;
+}
+```
+
+Rules:
+- Every `case` and `default` label shall be indented one level from the `switch`.
+- The body of each `case` shall be indented one further level.
+- Every `case` shall end with `break`, `return`, or `/* fall-through */` comment.
+- A `default` label shall always be present (MISRA C:2012 Rule 16.4).
+
+---
+
+## 42. Function Definition Layout
+
+```c
+/**
+ * @brief  Transmits a buffer over UART.
+ * @param[in] p_data    Pointer to data buffer.
+ * @param[in] length    Number of bytes to transmit.
+ * @return              UART_STATUS_OK on success.
+ */
+uart_status_t uart_BufferTransmit(const uint8_t *p_data, uint16_t length)
+{
+    uart_status_t status = UART_STATUS_OK;
+    uint16_t      byte_idx;
+
+    for (byte_idx = 0U; byte_idx < length; byte_idx++)
+    {
+        status = uart_ByteTransmit(p_data[byte_idx]);
+        if (UART_STATUS_OK != status)
+        {
+            break;
+        }
+    }
+
+    return status;
+}
+```
+
+- The return type and function name shall be on the **same line**.
+- The opening brace shall be placed as configured by AStyle.
+- Local variable declarations shall appear at the **top** of the function body, before the first executable statement.
+- The function shall have a **single return point** (MISRA C:2012 Rule 15.5, advisory).
+
+### 42.1 Function Length
+
+Each function body shall not exceed **60 lines**. `[RULE: misc.function_length]` (NASA Power of Ten Rule 4)
+
+---
+
+## 43. Struct and Union Layout
+
+```c
+typedef struct uart_config_s
+{
+    uint32_t  baud_rate;      /* baud rate in bits/s */
+    uint8_t   data_bits;      /* 7 or 8 */
+    uint8_t   stop_bits;      /* 1 or 2 */
+    uint8_t   parity;         /* UART_PARITY_NONE / ODD / EVEN */
+    uint8_t   pad[3];         /* explicit padding — MISRA C:2012 Rule 6.1 */
+} UART_CONFIG_T;
+```
+
+- Member names shall use lower snake case.
+- Explicit padding members shall be named `pad[n]` with a comment.
+- `typedef` and `struct` declaration shall be combined where the tag is also needed.
+
+---
+
+## 44. Typedef Layout
+
+```c
+/* Scalar typedef */
+typedef uint16_t MOTOR_SPEED_T;
+
+/* Struct typedef — combined form */
+typedef struct sensor_sample_s
+{
+    uint32_t timestamp_ms;
+    int16_t  temperature_raw;
+} SENSOR_SAMPLE_T;
+
+/* Function-pointer typedef */
+typedef void (*UART_RX_CALLBACK_T)(uint8_t byte, void *p_context);
+```
+
+---
+
+## 45. Enum Layout
+
+```c
+typedef enum motor_state_t
+{
+    MOTOR_STATE_IDLE    = 0,
+    MOTOR_STATE_RUNNING = 1,
+    MOTOR_STATE_FAULT   = 2,
+    MOTOR_STATE_COUNT       /* sentinel — not a valid state */
+} motor_state_t;
+```
+
+- Members shall be vertically aligned at the `=` where practical.
+- A sentinel member (`_COUNT`, `_MAX`, `_LAST`) is recommended for array sizing.
+- The first member shall be explicitly initialised to `0`.
+
+---
+
+## 46. Variable Declaration Layout
+
+### 46.1 One Declaration Per Line
+
+Each variable shall be declared on its own line:
+
+```c
+/* Correct */
+uint8_t  byte_count;
+uint32_t timeout_ms;
+
+/* Wrong */
+uint8_t byte_count, timeout_ms;
+```
+
+### 46.2 Initialisation
+
+All variables shall be initialised at the point of declaration or immediately following:
+
+```c
+uint8_t  status      = 0U;
+uint16_t packet_size = 0U;
+```
+
+### 46.3 Scope Minimisation
+
+Variables shall be declared at the narrowest applicable scope.
+
+---
+
+## 47. Pointer Declarators
+
+The `*` in a pointer declaration shall be placed as configured by the AStyle `--align-pointer` option. Within a single declaration group, placement shall be consistent.
+
+```c
+uint8_t  *p_buffer;          /* pointer-to-type style */
+uint8_t  *p_src, *p_dst;     /* only if both are pointers */
+```
+
+Multiple pointer and non-pointer variables shall not share a single declaration line.
+
+---
+
+## 48. Cast Expressions
+
+- Casts shall be used sparingly and only when a conversion is explicitly required.
+- Every cast shall be accompanied by a comment explaining why it is safe.
+- C-style casts are the only form available in C; they shall be written with no space between the type and the cast expression:
+
+```c
+uint8_t byte = (uint8_t)raw_value;  /* truncation intentional: only lower 8 bits needed */
+```
+
+---
+
+## 49. Yoda Conditions
+
+`[RULE: misc.yoda_conditions]`
+
+In equality comparisons (`==`, `!=`), the **constant or rvalue** shall appear on the **left**:
+
+```c
+if (NULL == p_buffer)       { /* correct */ }
+if (UART_STATUS_OK == ret)  { /* correct */ }
+
+if (p_buffer == NULL)       { /* wrong */ }
+```
+
+This prevents accidental assignment in place of comparison.
+
+---
+
+## 50. Magic Numbers
+
+`[RULE: misc.magic_numbers]`
+
+Numeric literals other than `0`, `1`, `-1`, and a project-defined exempt list shall not appear directly in code. Use named constants:
+
+```c
+/* Correct */
+#define UART_RX_TIMEOUT_MS   100U
+if (elapsed_ms > UART_RX_TIMEOUT_MS)
+
+/* Wrong */
+if (elapsed_ms > 100U)
+```
+
+---
+
+## 51. End-of-File
+
+Every source file shall end with exactly **one newline character** after the last non-blank content. Most editors and git tools enforce this automatically. Files that do not end with a newline produce compiler warnings on some toolchains.
+
+---
+
+## 52. AStyle Configuration Reference
+
+> **Placeholder:** This section will be populated with the complete project AStyle (`.astylerc`) configuration when the file is finalised. Key options to document include:
+>
+> - `--style=` (brace placement)
+> - `--indent=` (tab/space and width)
+> - `--max-code-length=` (line length)
+> - `--align-pointer=` (pointer declarator alignment)
+> - `--pad-oper` / `--pad-paren` (operator spacing)
+> - `--break-blocks` (blank lines between blocks)
+> - `--add-brackets` (mandatory braces on single-line bodies)
+
+The AStyle configuration file shall be version-controlled at `.astylerc` in the project root. Any deviation from AStyle-reformatted output is a style violation.
+
+---
+
+## 53. cstylecheck Configuration Reference
+
+> **Placeholder:** This section will document which rules in `src/rules.yml` enforce each section of this style guide. A cross-reference table mapping rule IDs to style guide sections will be inserted here after the rule population phase.
+
+The cstylecheck tool enforces naming conventions, prefix rules, magic numbers, line length, indentation, comment density, and other rules defined in `src/rules.yml`. All rules shall be run in CI on every pull request.
+
+---
+
+## 54. Automated Enforcement
+
+### 54.1 CI Pipeline
+
+Style checks shall run automatically as part of the CI pipeline:
+
+1. **AStyle** — reformats code to canonical style (or fails if output differs from committed code).
+2. **cstylecheck** — enforces naming conventions and miscellaneous rules from `src/rules.yml`.
+3. **pre-commit hook** — runs both tools locally before each commit.
+
+### 54.2 Zero-Violation Policy
+
+No new style violations shall be introduced in a pull request. The baseline violation count shall not increase. `[RULE: misc.baseline]`
+
+### 54.3 Suppression
+
+Per-line suppression: `/* cstylecheck: disable <rule.id> */`
+
+Per-file suppression: add an entry to `src/exclusions.yml`.
+
+Suppressions require a justification comment and shall be reviewed during code review.
+
+---
+
+## 55. Style Review Checklist
+
+Use this checklist during code review to verify style compliance. Automated tools cover most items; this list targets items requiring human judgement.
+
+- [ ] File header is present and correct (Section 7).
+- [ ] Include guard matches the pattern (Section 8).
+- [ ] Indentation is consistent throughout (Section 9).
+- [ ] No line exceeds the configured maximum (Section 10).
+- [ ] All identifiers follow naming conventions (Sections 15–26).
+- [ ] All function parameters and return values are documented (Section 29).
+- [ ] Braces are present on all control flow bodies (Section 13.1).
+- [ ] All magic numbers have named constants (Section 50).
+- [ ] Yoda conditions used for `==` and `!=` (Section 49).
+- [ ] No octal literals present (Section 34.4).
+- [ ] All integer constants have uppercase suffixes (Section 34.2).
+- [ ] No trigraphs present (Section 34.5).
+- [ ] Comments explain "why", not "what" (Section 32).
+- [ ] No commented-out code (dead code shall be deleted, not commented out).
+- [ ] Function length does not exceed the limit (Section 42.1).
+- [ ] File length does not exceed the limit (Section 6.4).
+
+---
+
+## 56. Deviations
+
+### 56.1 Deviation Request Process
+
+When strict compliance with a rule in this guide is impractical, a deviation shall be requested using the project Deviation Request form. The request shall include:
+
+- Rule reference (section number and `[RULE:]` tag).
+- Reason compliance is impractical.
+- Alternative measures taken to mitigate the risk.
+- Approval from the Software Engineering Lead.
+
+### 56.2 Deviation Register
+
+All approved deviations shall be recorded in the project Deviation Register (`doc/deviation_register.md`) with a unique deviation ID, approval date, and expiry condition.
+
+---
+
+## 57. Document Change History
+
+| Version | Date | Author | Change Description |
+|---|---|---|---|
+| 1.0 | 2026-06-08 | (initial draft) | Initial document structure — rule sections are placeholders pending cstylecheck rules.yml and AStyle config population |
+
+---
+
+*End of CSG-STY-001 Embedded C Style Guide v1.0*

--- a/external_standards_analysis.md
+++ b/external_standards_analysis.md
@@ -1,0 +1,1143 @@
+# External C Coding Standards — Survey and Analysis
+
+---
+
+| Field | Value |
+|---|---|
+| Document ID | CSC-ANA-001 |
+| Title | External C Coding Standards — Survey and Analysis |
+| Version | 1.0 (DRAFT) |
+| Status | Draft |
+| Date | 2026-06-08 |
+| Owner | Software Engineering Lead |
+| Purpose | Rationale for rule selection in CSG-STY-001 and CSC-STD-001 |
+| ASPICE Process Areas | SWE.3, SUP.1 |
+
+---
+
+## Table of Contents
+
+1. [Purpose and Scope](#1-purpose-and-scope)
+2. [Methodology](#2-methodology)
+3. [Documents Surveyed](#3-documents-surveyed)
+4. [Per-Document Analysis](#4-per-document-analysis)
+   - 4.1 [MISRA C:2012 / MISRA C:2023](#41-misra-c2012--misra-c2023)
+   - 4.2 [SEI CERT C Coding Standard](#42-sei-cert-c-coding-standard)
+   - 4.3 [Barr Group Embedded C Coding Standard (Barr-C:2018)](#43-barr-group-embedded-c-coding-standard-barr-c2018)
+   - 4.4 [Google C Style Guide](#44-google-c-style-guide)
+   - 4.5 [Linux Kernel Coding Style](#45-linux-kernel-coding-style)
+   - 4.6 [NASA/JPL Power of Ten Rules](#46-nasajpl-power-of-ten-rules)
+   - 4.7 [GNU Coding Standards](#47-gnu-coding-standards)
+   - 4.8 [LLVM Coding Standards](#48-llvm-coding-standards)
+   - 4.9 [AUTOSAR Guidelines for C](#49-autosar-guidelines-for-c)
+   - 4.10 [Motor Industry Research Association (MIRA / MISRA origin)](#410-motor-industry-research-association-mira--misra-origin)
+   - 4.11 [Netrino / Jack Ganssle Embedded C Coding Standard](#411-netrino--jack-ganssle-embedded-c-coding-standard)
+   - 4.12 [IAR Embedded Workbench Recommendations](#412-iar-embedded-workbench-recommendations)
+   - 4.13 [JSF AV C++ Coding Standards (Joint Strike Fighter)](#413-jsf-av-c-coding-standards-joint-strike-fighter)
+   - 4.14 [HICPP (High Integrity C++)](#414-hicpp-high-integrity-c)
+   - 4.15 [IEC 61508 / ISO 26262 C Coding Guidance](#415-iec-61508--iso-26262-c-coding-guidance)
+5. [Comparison Matrices](#5-comparison-matrices)
+   - 5.1 [Safety Criticality and Domain](#51-safety-criticality-and-domain)
+   - 5.2 [Naming Convention Approach](#52-naming-convention-approach)
+   - 5.3 [Formatting Rules](#53-formatting-rules)
+   - 5.4 [Memory Management Policy](#54-memory-management-policy)
+   - 5.5 [Control Flow Restrictions](#55-control-flow-restrictions)
+   - 5.6 [MISRA and ASPICE Alignment](#56-misra-and-aspice-alignment)
+6. [Cross-Cutting Themes](#6-cross-cutting-themes)
+7. [Gaps and Conflicts Between Standards](#7-gaps-and-conflicts-between-standards)
+8. [Conclusions](#8-conclusions)
+9. [Recommendations for CSG-STY-001 and CSC-STD-001](#9-recommendations-for-csg-sty-001-and-csc-std-001)
+10. [Adopted vs. Rejected Rules by Source](#10-adopted-vs-rejected-rules-by-source)
+11. [Document Change History](#11-document-change-history)
+
+---
+
+## 1. Purpose and Scope
+
+### 1.1 Purpose
+
+This document records the survey of fifteen widely used C coding standards and style guides. Its purpose is to:
+
+1. Provide an auditable evidence trail for rule selection in the project C Style Guide (CSG-STY-001) and Coding Standard (CSC-STD-001).
+2. Identify consensus rules across multiple standards (high-confidence requirements).
+3. Identify conflicting rules and document the project's resolution.
+4. Identify gaps — hazards or good practices not covered by any single standard.
+5. Support ASPICE v4 Level 2 compliance by demonstrating that the project coding rules are grounded in industry best practice (SWE.3 BP6 evidence).
+
+### 1.2 Scope
+
+Fifteen external standards were surveyed. The survey covers:
+- Naming conventions
+- Formatting and layout
+- Commenting and documentation
+- Data types and type safety
+- Memory management
+- Control flow restrictions
+- Preprocessor usage
+- Standard library restrictions
+- Concurrency and interrupt handling
+- Safety-critical applicability
+- MISRA C and ASPICE alignment
+
+### 1.3 Limitations
+
+- MISRA C:2012 and IEC 61508 / ISO 26262 are not freely available documents. The analysis is based on published summaries, publicly available rule tables, and the authors' working knowledge.
+- Google, Linux, GNU, and LLVM coding standards are primarily C++ or general-purpose software oriented; their C-relevant subsets were extracted.
+- The IAR Embedded Workbench style recommendations are embedded within tool documentation; they do not constitute a formal standalone standard.
+
+---
+
+## 2. Methodology
+
+Documents were surveyed using the following structured approach:
+
+1. **Identify document** — title, version/year, issuing organisation.
+2. **Classify domain** — safety-critical embedded, general embedded, general software, vendor-specific.
+3. **Extract rules by category** — naming, formatting, memory, control flow, types, library.
+4. **Rate safety-critical applicability** — Low / Medium / High / Very High / Extreme.
+5. **Assess MISRA alignment** — Full / High / Partial / Low / Conflict.
+6. **Assess ASPICE alignment** — whether the standard supports SWE.3/SWE.4 evidence.
+7. **Record conclusions** — what this standard contributes to the project rules.
+
+---
+
+## 3. Documents Surveyed
+
+| # | Document | Organisation | Version / Year | Domain |
+|---|---|---|---|---|
+| 1 | MISRA C:2012 (incl. Amendment 1:2016, MISRA C:2023) | MISRA Consortium | 2012/2016/2023 | Safety-critical embedded |
+| 2 | SEI CERT C Coding Standard | Carnegie Mellon SEI | 2nd ed., 2016 | Secure software |
+| 3 | Barr Group Embedded C Coding Standard (Barr-C:2018) | Barr Group | v2.0, 2018 | Embedded systems |
+| 4 | Google C Style Guide | Google LLC | Continuous (2024 snapshot) | Large-scale software |
+| 5 | Linux Kernel Coding Style | Linux Foundation / L. Torvalds | Continuous (6.x era) | OS kernel |
+| 6 | NASA/JPL Power of Ten Rules | NASA Jet Propulsion Laboratory | 2006 | Space / safety-critical |
+| 7 | GNU Coding Standards | Free Software Foundation | v1.6, 2019 | Open-source software |
+| 8 | LLVM Coding Standards | LLVM Project | Continuous (LLVM 18 era) | Compiler infrastructure |
+| 9 | AUTOSAR Guidelines for the use of C | AUTOSAR Partnership | R23-11 | Automotive embedded |
+| 10 | MIRA / MISRA Origins | Motor Industry Research Association | (see MISRA C) | Automotive |
+| 11 | Netrino / Ganssle Embedded C Coding Standard | Netrino LLC / Jack Ganssle | Continuous | Embedded systems |
+| 12 | IAR Embedded Workbench Style Recommendations | IAR Systems | EW 9.x era | Embedded (vendor) |
+| 13 | JSF AV C++ Coding Standards | US Department of Defense (F-35) | Revision C, 2005 | Flight-critical |
+| 14 | HICPP (High Integrity C++ Coding Standard) | Programming Research Ltd | v4.0, 2016 | High-integrity |
+| 15 | IEC 61508-3 / ISO 26262-6 C coding guidance | IEC / ISO | 2010 / 2018 | Functional safety |
+
+---
+
+## 4. Per-Document Analysis
+
+---
+
+### 4.1 MISRA C:2012 / MISRA C:2023
+
+**Organisation:** MISRA Ltd (Motor Industry Software Reliability Association)
+**Year:** 2012; Amendment 1 published 2016; MISRA C:2023 corrigendum released 2023
+**Domain:** Safety-critical embedded software
+**Availability:** Paid publication (~£25 per PDF)
+
+#### Overview
+
+MISRA C:2012 is the primary international coding standard for safety-critical embedded C software. It defines 262 rules and 16 directives, classified as Mandatory, Required, or Advisory. It is specifically designed to prevent undefined, unspecified, and implementation-defined C behaviour in systems where incorrect operation could cause harm.
+
+MISRA C:2023 is not a new edition but a set of corrections (errata and clarifications) to MISRA C:2012 Amendment 1. The most significant change is promoting Rule 4.2 (no trigraphs) from Advisory to Required.
+
+#### Key Rule Categories
+
+| Category | Rule Range | Notable Rules |
+|---|---|---|
+| Language environment | Dir 1–2, R 1.1–1.4 | C99 or later; no extensions; all translation units compile cleanly |
+| Unused code | R 2.1–2.7 | No unreachable code; no dead code; all declarations used |
+| Comments | R 3.1–3.2 | No nested `/**/`; `//` only in C99+ |
+| Character sets | R 4.1–4.2 | No trigraphs; escape sequences defined |
+| Identifiers | R 5.1–5.9 | 31-char uniqueness; reserved names; identifier hiding |
+| Types | R 6.1–6.2 | Bit field types; single-bit signed |
+| Literals | R 7.1–7.4 | No octal; unsigned suffix; uppercase suffix; signed char |
+| Declarations | R 8.1–8.14 | Implicit int; function declarations; typedef; const; extern |
+| Initialisers | R 9.1–9.5 | All paths initialised; designator |
+| Expressions | R 10.1–10.8 | Essential type model (signed/unsigned/boolean/enum mixing) |
+| Side effects | R 13.1–13.6 | Initialiser ordering; sequence point; logical operators; comma |
+| Control flow | R 14.1–14.4 | Reachability; infinite loops; `bool` in conditions |
+| Switch | R 16.1–16.7 | Single `switch` per expression; `default`; fall-through; case range |
+| Functions | R 17.1–17.8 | No variadic args in safety code; recursion; prototype; return value |
+| Pointers | R 18.1–18.8 | Arithmetic; comparison; function pointers; VLAs |
+| Overlapping objects | R 19.1–19.2 | Union; memcpy aliasing |
+| Preprocessing | R 20.1–20.14 | Include guards; macro hazards; `##`; `#include` in macro |
+| Standard library | R 21.1–21.21 | Banned names; banned functions; banned headers |
+| Resources | R 22.1–22.10 | Dynamic allocation; file handles; signal |
+
+#### Naming Conventions
+
+MISRA C:2012 defines constraints on identifier uniqueness (Rules 5.1–5.9) but does not prescribe a specific naming style. It forbids identifiers that could clash with standard library names and requires that identifiers be distinct within the required scope. The naming style adopted in this project (module prefix, snake case, prefix conventions) is compliant with and supplementary to MISRA C requirements.
+
+#### Formatting Rules
+
+MISRA C:2012 does not prescribe indentation, brace style, or line length. These are left to project convention. The project's AStyle configuration and CSG-STY-001 fill this gap.
+
+#### Memory Management
+
+Rule 21.3 prohibits `malloc`, `calloc`, `realloc`, and `free` in safety-critical contexts. This is the definitive basis for the project's static-allocation-first policy.
+
+#### Safety Criticality
+
+**EXTREMELY HIGH.** MISRA C:2012 is referenced by ISO 26262 (automotive), IEC 61508 (industrial), EN 50128 (railway), and DO-178C (avionics) as an acceptable language subset.
+
+#### MISRA Alignment
+
+N/A — this IS the MISRA standard.
+
+#### ASPICE Alignment
+
+**Full.** MISRA C:2012 adoption directly satisfies SWE.3 BP6 (Apply coding guidelines) in ASPICE.
+
+#### Project Conclusions
+
+- MISRA C:2012 Required rules are adopted as **Required** in CSC-STD-001 unless a documented deviation exists.
+- MISRA C:2012 Advisory rules are adopted as **Advisory** (should-comply) in CSC-STD-001.
+- MISRA C:2023 changes (primarily promoting trigraph rule to Required) are adopted immediately.
+- Automated enforcement via cstylecheck covers a subset of MISRA rules; full MISRA coverage requires a supplementary static analysis tool.
+
+---
+
+### 4.2 SEI CERT C Coding Standard
+
+**Organisation:** Carnegie Mellon University Software Engineering Institute
+**Year:** 2nd edition, 2016; community wiki continuously updated
+**Domain:** Secure software engineering
+**Availability:** Free online (https://wiki.sei.cmu.edu/confluence/display/c)
+
+#### Overview
+
+The CERT C Coding Standard is organised as 98 rules and numerous recommendations, targeting the prevention of security vulnerabilities (buffer overflows, integer overflows, race conditions, use-after-free) and undefined behaviour. Its focus is distinct from MISRA C: CERT targets security exploitability, whereas MISRA targets functional safety. The two standards are highly complementary.
+
+#### Key Rules Adopted by This Project
+
+| CERT Rule | Title | Project Section |
+|---|---|---|
+| EXP33-C | Do not read uninitialized memory | CSC-STD-001 §42.1 |
+| EXP34-C | Do not dereference null pointers | CSC-STD-001 §14.2 |
+| EXP39-C | Do not access via incompatible pointer | CSC-STD-001 §14.5 |
+| INT32-C | Signed integer overflow prevention | CSC-STD-001 §12.1 |
+| INT33-C | No division by zero | CSC-STD-001 §12.3 |
+| INT34-C | No shift by negative or ≥ width | CSC-STD-001 §12.4 |
+| INT36-C | Pointer–integer conversion | CSC-STD-001 §13.4 |
+| ARR30-C | No out-of-bounds array access | CSC-STD-001 §15.1 |
+| STR31-C | Sufficient storage for strings | CSC-STD-001 §15.3 |
+| STR32-C | Null-terminated strings | CSC-STD-001 §16.1 |
+| ERR00-C | Consistent error-handling policy | CSC-STD-001 §53 |
+| ERR33-C | Check standard library errors | CSC-STD-001 §30.3 |
+| DCL22-C | volatile for multi-context data | CSC-STD-001 §22.2 |
+| PRE10-C | do-while wrapper for multi-statement macros | CSG-STY-001 §37.3 |
+| PRE11-C | No trailing semicolon in macros | CSG-STY-001 §37.4 |
+
+#### Safety Criticality
+
+**MEDIUM–HIGH.** CERT C is primarily a security standard, not a functional safety standard. However, the types of defects it prevents (memory corruption, integer overflow) are equally relevant to safety-critical embedded software.
+
+#### Gaps Relative to MISRA
+
+CERT C does not cover:
+- Essential Type Model (MISRA's type-safety system for conversions).
+- `switch` statement completeness (MISRA 16.4).
+- Recursion prohibition (MISRA 17.2).
+- Standard library function restrictions as broad as MISRA 21.x.
+
+#### Project Conclusions
+
+- CERT C rules for integer safety (INT32-C, INT33-C, INT34-C) and memory safety (ARR30-C, EXP34-C, MEM30-C) are adopted in full.
+- CERT C macro rules (PRE10-C, PRE11-C) are automated via cstylecheck (`macros.multistatement_wrapper`, `macros.trailing_semicolon`).
+- CERT C's security focus supplements MISRA's safety focus; together they provide defence in depth.
+
+---
+
+### 4.3 Barr Group Embedded C Coding Standard (Barr-C:2018)
+
+**Organisation:** Barr Group (Michael Barr)
+**Year:** Version 2.0, 2018
+**Domain:** Professional embedded systems development
+**Availability:** Paid publication; excerpts freely available
+
+#### Overview
+
+Barr-C:2018 is the closest practical complement to MISRA C for embedded systems. It fills the gap left by MISRA's deliberate silence on naming conventions and formatting, providing a complete, opinionated style for embedded C projects. The cstylecheck tool was designed around Barr-C:2018 conventions.
+
+#### Key Contributions
+
+**Naming conventions:**
+- Module prefix for all public identifiers.
+- `g_` prefix for globals, `s_` for statics, `p_` for pointers, `pp_` for double pointers, `b_` for booleans, `h_` for handles.
+- Enum type names end in `_t`; typedef names end in `_T`.
+- ISR functions use `_IRQHandler` suffix.
+
+**Formatting:**
+- Mandatory braces around all control-flow bodies (prevents Apple goto-fail class of bug).
+- One declaration per line.
+- Explicit `void` in parameter list for zero-parameter functions.
+
+**Type safety:**
+- Fixed-width integer types mandatory.
+- `bool`/`_Bool` for boolean variables.
+
+**Memory:**
+- Static allocation preferred.
+- Dynamic allocation only with explicit justification.
+- Large local variables moved to static scope.
+
+**Hardware:**
+- `volatile` required for all hardware register accesses.
+- `volatile` required for ISR-shared variables.
+
+#### Naming Conventions
+
+Barr-C:2018 is the primary naming convention source for CSG-STY-001 Sections 18–26. The cstylecheck rules.yml file implements Barr-C naming rules directly.
+
+#### Safety Criticality
+
+**HIGH.** Barr-C:2018 is widely used in automotive, medical device, and industrial embedded firmware. It is compatible with ISO 26262 ASIL B/C environments.
+
+#### MISRA Alignment
+
+**Very high.** Barr-C:2018 is designed as a complement to MISRA C, not a replacement. It does not contradict any MISRA required rule.
+
+#### ASPICE Alignment
+
+**High.** Barr-C:2018 addresses SWE.3 BP5 and BP6. The named prefix conventions also support SWE.3 BP3 (interface definition).
+
+#### Project Conclusions
+
+- Barr-C:2018 is the **primary naming convention source** for this project.
+- All naming prefix rules (`g_`, `s_`, `p_`, `pp_`, `b_`, `h_`, `_t`, `_T`, `_s`, `_u`, `_IRQHandler`) are adopted directly.
+- Barr-C:2018's formatting rules (mandatory braces, one declaration per line) are adopted in CSG-STY-001.
+- Some Barr-C defaults are made configurable in cstylecheck (e.g. `p_` parameter prefix is disabled by default; `b_` bool prefix is disabled by default).
+
+---
+
+### 4.4 Google C Style Guide
+
+**Organisation:** Google LLC
+**Year:** Continuously updated; C++ focused with C-relevant rules
+**Domain:** Large-scale software engineering
+**Availability:** Free online
+
+#### Overview
+
+Google's style guide is primarily for C++ but contains guidance applicable to C. It is widely known and influences many open-source projects. Its design goals differ significantly from embedded safety-critical work: Google prioritises readability at scale and developer productivity rather than safety or determinism.
+
+#### Relevant Rules (C-applicable subset)
+
+| Topic | Google Approach | Project Decision |
+|---|---|---|
+| Naming | `snake_case` for functions and variables; `kConstantName` for constants | **Rejected** — project uses module prefix and Barr-C naming |
+| Indentation | 2 spaces | **Rejected** — embedded projects standardise on 4 spaces or tabs |
+| Line length | 80 characters | **Partially adopted** — project uses configurable limit; 80 is too restrictive for embedded identifiers |
+| Comments | Explain "why" not "what" | **Adopted** — CSG-STY-001 §32 |
+| Header order | Own header first, then project, then system | **Adopted** — CSG-STY-001 §38 |
+| File names | lowercase with underscores | **Adopted** — CSG-STY-001 §16 |
+| Trailing commas in enums | Permitted | **Advisory** |
+| TODO comments | `// TODO(user): description` | **Adopted** — permitted format for deferred items |
+
+#### Safety Criticality
+
+**LOW.** Google C Style is not designed for safety-critical or embedded systems. It assumes a hosted environment with a full OS, heap, and C++ standard library.
+
+#### MISRA Alignment
+
+**Very low.** Google style conflicts with MISRA in several respects (e.g. implicit type conversions, `goto` prohibition not universal, dynamic memory permitted). Google C cannot substitute for MISRA compliance.
+
+#### ASPICE Alignment
+
+**Low.** Google C addresses code readability and team consistency but does not address functional safety, traceability, or verification requirements of ASPICE.
+
+#### Project Conclusions
+
+- Google C Style Guide is **not adopted** as a primary standard.
+- Two rules are adopted as best practice: comments explain "why" (§32), and `#include` order (§38).
+- The 2-space indentation and constant naming (`kConstant`) conventions are explicitly rejected in favour of Barr-C:2018 and project conventions.
+
+---
+
+### 4.5 Linux Kernel Coding Style
+
+**Organisation:** Linux Foundation / Linus Torvalds
+**Year:** Continuously updated; current for Linux 6.x kernel
+**Domain:** OS kernel development
+**Availability:** Free online (Documentation/process/coding-style.rst)
+
+#### Overview
+
+The Linux Kernel Coding Style is a pragmatic, readable style for kernel systems programming. It is opinionated, concise, and unapologetically pragmatic. Linus Torvalds designed it for kernel contributors who work primarily in C on high-stakes, high-performance code. It explicitly permits patterns (8-space tabs, `goto` for cleanup) that other standards restrict.
+
+#### Key Rules and Their Relevance to This Project
+
+| Rule | Linux Kernel Approach | Project Decision |
+|---|---|---|
+| Indentation | Hard tabs, 8-space visual width | **Noted** — 8-space tabs deter excessive nesting. Project uses configurable tab width. |
+| Line length | 80 characters (pragmatic exceptions) | **Noted** — project limit is configurable |
+| Braces | K&R style; omit for single-line bodies in some cases | **Not adopted** — project mandates braces |
+| `goto` | Explicitly permitted for cleanup/error paths | **Partially adopted** — forward-to-cleanup goto only (CSC-STD-001 §24) |
+| Naming | lowercase_with_underscores | **Partially adopted** — project uses snake_case for variables |
+| Comment style | Explain "why"; kernel-doc for exported functions | **Adopted** |
+| Function length | One screen (~24 lines) | **Not directly adopted** — project uses 60-line limit (JPL) |
+
+The Linux kernel is not a safety-critical system. It uses dynamic memory allocation, unbounded recursion, and complex pointer arithmetic — all prohibited by this project's standard.
+
+#### Safety Criticality
+
+**VERY LOW.** The Linux kernel coding style has no functional safety targets. It explicitly uses patterns (goto, dynamic allocation, variable-length arrays) that are prohibited in safety-critical embedded code.
+
+#### MISRA Alignment
+
+**Very low.** Linux style conflicts with MISRA in many areas. Linux is not a MISRA-compliant codebase and was not designed to be.
+
+#### Project Conclusions
+
+- Linux Kernel Coding Style is **not adopted** as a primary standard.
+- The `goto`-for-cleanup pattern is adopted with restrictions (Section 24 of CSC-STD-001).
+- The principle of explaining "why" in comments is adopted.
+- The 8-space-tab nesting-deterrent principle is noted but not mandated.
+
+---
+
+### 4.6 NASA/JPL Power of Ten Rules
+
+**Organisation:** NASA Jet Propulsion Laboratory
+**Author:** Gerard Holzmann
+**Year:** 2006 (published in IEEE Software)
+**Domain:** Space systems software — highest criticality
+**Availability:** Free online (NASA/JPL internal publication; publicly summarised)
+
+#### Overview
+
+The Power of Ten is ten simple rules designed to make code analysable by automated tools. Their primary purpose is enabling static analysis and model checking on space-vehicle software where a single defect can cause mission failure. The rules are intentionally conservative — stricter than MISRA in several respects.
+
+#### The Ten Rules
+
+| # | Rule | Adopted in Project | Reference |
+|---|---|---|---|
+| 1 | Restrict to simple control flow constructs (no goto, no setjmp/longjmp, no recursion) | **Adopted** — no recursion, no setjmp (CSC-STD-001 §9, §24, §25) | CSC-STD-001 §25 |
+| 2 | All loops shall have a fixed upper-bound (statically provable) | **Adopted as advisory** — loops with provable bounds preferred | CSC-STD-001 §26 |
+| 3 | No dynamic memory allocation after initialisation | **Adopted** — dynamic allocation prohibited on safety path | CSC-STD-001 §20 |
+| 4 | No function shall be longer than 60 lines | **Adopted** | `[RULE: misc.function_length]` |
+| 5 | Two assertions per function minimum | **Adopted as advisory** | `[RULE: misc.assert_density]` |
+| 6 | Data objects declared at the smallest possible scope | **Adopted** | CSC-STD-001 §43 |
+| 7 | Each calling function shall check the return value | **Adopted** | CSC-STD-001 §30.3 |
+| 8 | Limit preprocessor use to `#include` and simple `#define` | **Partially adopted** — complex macros restricted | CSC-STD-001 §37 |
+| 9 | Restrict pointer use to single dereference; no function pointers | **Partially adopted** — function pointers permitted with NULL check | CSC-STD-001 §14, §29.6 |
+| 10 | All warnings treated as errors with maximum warning level | **Adopted** | CSC-STD-001 §7.2 |
+
+#### Safety Criticality
+
+**EXTREME.** Designed for space vehicle software at the highest reliability level. The rules are provably static-analysis-enabling.
+
+#### MISRA Alignment
+
+**Very high.** All ten rules are consistent with MISRA C:2012. JPL rules are generally stricter (e.g. JPL 3 bans all dynamic allocation; MISRA 21.3 only requires a justification for it).
+
+#### ASPICE Alignment
+
+**High.** JPL rules support SWE.3 and SWE.4 by reducing complexity to a statically analysable level.
+
+#### Project Conclusions
+
+- The 60-line function limit (JPL Rule 4) is **adopted as a required rule** (`[RULE: misc.function_length]`).
+- The assert-density requirement (JPL Rule 5) is **adopted as an advisory/configurable rule** (`[RULE: misc.assert_density]`).
+- The dynamic-allocation prohibition after initialisation (JPL Rule 3) is **adopted**.
+- The no-recursion rule (JPL Rule 1) is **adopted**.
+- The return-value-check rule (JPL Rule 7) is **adopted** (CSC-STD-001 §30.3).
+- The function-pointer restriction (JPL Rule 9) is relaxed to: function pointers permitted with NULL check.
+
+---
+
+### 4.7 GNU Coding Standards
+
+**Organisation:** Free Software Foundation
+**Year:** Version 1.6, 2019; maintained continuously
+**Domain:** GNU/open-source software
+**Availability:** Free online (https://www.gnu.org/prep/standards/)
+
+#### Overview
+
+GNU Coding Standards are designed for GNU project contributors. They emphasise portability, documentation, and Makefile/autoconf conventions. For C code, they provide naming and formatting guidelines. The standard is not designed for safety-critical or embedded work.
+
+#### Relevant Rules
+
+| Topic | GNU Approach | Project Decision |
+|---|---|---|
+| Naming | lowercase_with_underscores | **Noted** — project uses Barr-C naming |
+| Indentation | 2 spaces (or editor-defined) | **Not adopted** — project uses 4 spaces/tabs |
+| Brace style | Allman (opening brace on new line) | **Noted** — project defers to AStyle configuration |
+| Line length | 79 characters | **Not adopted** — project limit configurable |
+| Comments | GNU-doc style (Texinfo) | **Not adopted** — project uses Doxygen |
+| Return value | Check all return values | **Adopted** |
+
+#### Safety Criticality
+
+**LOW.** GNU Coding Standards target general-purpose open-source software. No safety-critical provisions.
+
+#### MISRA Alignment
+
+**Low.** GNU standards permit dynamic allocation, recursion, and standard library use without restriction. Not MISRA-compatible as written.
+
+#### Project Conclusions
+
+- GNU Coding Standards are **not adopted** as a primary standard.
+- The return-value-check principle is adopted (already in JPL Rule 7 and CERT ERR33-C).
+- GNU formatting rules (2-space indent, 79-char line) are explicitly rejected in favour of project-specific AStyle configuration.
+
+---
+
+### 4.8 LLVM Coding Standards
+
+**Organisation:** LLVM Project
+**Year:** Continuously updated; current for LLVM 18 era
+**Domain:** Compiler infrastructure (primarily C++)
+**Availability:** Free online (https://llvm.org/docs/CodingStandards.html)
+
+#### Overview
+
+LLVM Coding Standards target the LLVM/Clang compiler infrastructure. They are primarily C++ focused with some C guidance. The style is designed for a large compiler codebase where performance, template metaprogramming, and compile-time correctness dominate. Almost none of this is relevant to embedded C.
+
+#### Relevant Rules (limited C applicability)
+
+| Topic | LLVM Approach | Project Decision |
+|---|---|---|
+| Comments | Explain "why" with Doxygen | **Adopted** — consistent with project approach |
+| Naming | camelCase variables; CapitalCase types | **Not adopted** — conflicts with Barr-C |
+| Indentation | 2 spaces | **Not adopted** |
+| Line length | 80 characters | **Not adopted** |
+| Include order | Own header, project, system | **Adopted** — consistent with Google/project |
+
+#### Safety Criticality
+
+**VERY LOW.** LLVM Coding Standards are not designed for embedded or safety-critical work.
+
+#### MISRA Alignment
+
+**Very low.** LLVM heavily uses C++ features and dynamic allocation — incompatible with MISRA C.
+
+#### Project Conclusions
+
+- LLVM Coding Standards are **not adopted** as a source of rules for this project.
+- The Doxygen comment approach and include-order principle are consistent with the project's independently chosen approach.
+
+---
+
+### 4.9 AUTOSAR Guidelines for C
+
+**Organisation:** AUTOSAR Partnership (BMW, Volkswagen, Bosch, Continental, and others)
+**Year:** Part of AUTOSAR R23-11 release
+**Domain:** Automotive embedded software
+**Availability:** Free download from autosar.org
+
+#### Overview
+
+AUTOSAR defines software architecture, communication stacks, and development guidelines for automotive ECUs. The coding guidelines for C are part of the Software Component (SWC) and Basic Software (BSW) design rules. They align closely with MISRA C:2012 and ISO 26262.
+
+#### Key Contributions
+
+**Module prefix system:**
+AUTOSAR requires all public identifiers to carry a module abbreviation prefix (e.g. `Uart_Init`, `Can_Write`, `Spi_Read`). The project's module prefix convention (CSG-STY-001 §17) is directly inspired by this approach.
+
+**Fixed-width types:**
+AUTOSAR mandates `uint8`, `uint16`, `uint32` type aliases (from `Platform_Types.h`) rather than `<stdint.h>` types. The project uses `<stdint.h>` types directly, which achieves the same objective without AUTOSAR-specific headers.
+
+**Static allocation:**
+Dynamic heap allocation is prohibited in BSW code. Memory pools are used for variable-size needs. This aligns with the project policy in CSC-STD-001 §20.
+
+**Doxygen documentation:**
+AUTOSAR BSW modules use Doxygen with mandatory `@brief`, `@param`, and `@return` tags for all public functions. This aligns with CSG-STY-001 §29.
+
+#### Safety Criticality
+
+**VERY HIGH.** AUTOSAR guidelines are written for ISO 26262 compliance (ASIL A–D). They are one of the industry's most mature embedded coding guideline sets.
+
+#### MISRA Alignment
+
+**Very high.** AUTOSAR guidelines are designed to be a superset of MISRA C:2012 compliance.
+
+#### ASPICE Alignment
+
+**Very high.** AUTOSAR is explicitly used in automotive ASPICE compliance. AUTOSAR process requirements align closely with ASPICE v4.
+
+#### Project Conclusions
+
+- AUTOSAR module prefix convention is **adopted** (inspired CSG-STY-001 §17).
+- AUTOSAR Doxygen documentation requirements are **adopted** (CSG-STY-001 §29).
+- AUTOSAR's prohibition of dynamic allocation in safety code is **adopted** (CSC-STD-001 §20).
+- AUTOSAR-specific type aliases (`uint8`, `uint16`) are **not adopted** — project uses standard `<stdint.h>` types.
+- AUTOSAR BSW naming (PascalCase module prefix + PascalCase function: `Uart_Init`) is **partially adopted**: the project uses lowercase module prefix with PascalCase object+verb body (`uart_BufferRead`), which is a variant of the AUTOSAR pattern.
+
+---
+
+### 4.10 Motor Industry Research Association (MIRA / MISRA Origin)
+
+**Organisation:** Motor Industry Research Association (MIRA Ltd)
+**Year:** MISRA C founded 1998; MIRA is the founding organisation
+**Domain:** Automotive software reliability
+
+#### Overview
+
+MIRA is the organisation that founded the MISRA consortium in 1998. The MISRA C coding standard was originally created under a UK government initiative (SafeIT) to improve the reliability of automotive software. MIRA itself does not publish a separate coding standard distinct from MISRA C.
+
+#### Relevance to This Survey
+
+This entry exists because "MIRA guidance" is sometimes cited as a source distinct from MISRA C. It is not. MIRA's contribution is the founding of the MISRA consortium and the ongoing maintenance of MISRA C. All relevant rules are captured in §4.1 (MISRA C:2012/2023).
+
+---
+
+### 4.11 Netrino / Jack Ganssle Embedded C Coding Standard
+
+**Organisation:** Netrino LLC / Jack Ganssle (independent embedded consultant)
+**Year:** Originally published ~2008; updated continuously through consulting engagements
+**Domain:** Professional embedded systems development
+**Availability:** Partially available online; full version through Netrino
+
+#### Overview
+
+The Netrino/Ganssle standard is a practical embedded coding standard written by Jack Ganssle, a highly respected figure in embedded systems engineering. It covers naming, formatting, commenting, and hardware-specific patterns. It is closely related to the Barr Group standard (both authors are from the same embedded engineering community) but with some differing choices.
+
+#### Key Rules and Alignment
+
+| Topic | Netrino/Ganssle | Alignment with Project |
+|---|---|---|
+| Module prefix | Required for all public symbols | **Adopted** — CSG-STY-001 §17 |
+| Global prefix `g_` | Required | **Adopted** — CSG-STY-001 §18.2 |
+| Pointer prefix `p_` | Required | **Adopted** — CSG-STY-001 §18.4 |
+| Type suffix `_t` | Required for enum types | **Adopted** — CSG-STY-001 §24 |
+| Function naming | Module + object + verb | **Adopted** — CSG-STY-001 §21 |
+| Mandatory braces | Required | **Adopted** — CSG-STY-001 §13.1 |
+| Comment headers | Mandatory for all functions | **Adopted** — CSG-STY-001 §29 |
+| Static allocation | Preferred | **Adopted** — CSC-STD-001 §19 |
+| Fixed-width types | Mandatory | **Adopted** — CSC-STD-001 §10 |
+| Yoda conditions | Recommended | **Adopted** — CSG-STY-001 §49 |
+
+#### Safety Criticality
+
+**MEDIUM–HIGH.** Widely used in medical device, industrial, and automotive embedded firmware without a formal safety certification.
+
+#### MISRA Alignment
+
+**High.** Netrino rules do not conflict with MISRA C and serve as a practical implementation guide for MISRA-compliant naming and formatting.
+
+#### ASPICE Alignment
+
+**Medium.** Addresses SWE.3 coding quality but does not address ASPICE process requirements directly.
+
+#### Project Conclusions
+
+- Netrino/Ganssle provides **corroborating evidence** for the naming and formatting conventions chosen from Barr-C:2018.
+- Where Barr-C and Netrino agree, the rule has high consensus support.
+- Yoda conditions (CSG-STY-001 §49, `[RULE: misc.yoda_conditions]`) are adopted, consistent with both Netrino and Barr-C recommendations.
+
+---
+
+### 4.12 IAR Embedded Workbench Recommendations
+
+**Organisation:** IAR Systems (compiler/IDE vendor)
+**Year:** Part of IAR EW documentation; version EW 9.x era
+**Domain:** Embedded systems (vendor-specific)
+**Availability:** IAR Embedded Workbench documentation (free with tool registration)
+
+#### Overview
+
+IAR Systems provides coding style recommendations as part of the EW documentation. These are not a formal coding standard but a set of best-practice guidelines for getting the most out of the IAR compiler and debugger. Topics include memory model selection, intrinsics usage, optimisation-friendly code patterns, and MISRA checking setup.
+
+#### Key Contributions to This Survey
+
+| Topic | IAR Recommendation | Project Decision |
+|---|---|---|
+| MISRA checking | IAR MISRA C checker plug-in available | **Noted** — project uses cstylecheck + supplementary tool |
+| Memory models | near/far/huge considerations | **Not adopted** — project targets ARM Cortex-M with flat memory |
+| Interrupt handlers | Attribute `__interrupt` or CMSIS `_IRQHandler` | **Adopted** — CMSIS naming used (CSG-STY-001 §25) |
+| Optimisation-friendly | Avoid complex `volatile` patterns; use intrinsics | **Noted** |
+| Stack analysis | IAR stack usage analysis tool | **Adopted** as process recommendation (CSC-STD-001 §21) |
+
+#### Safety Criticality
+
+**MEDIUM.** IAR recommendations support safety-critical development but are not themselves a safety standard. IAR provides ISO 26262-qualified compiler versions.
+
+#### MISRA Alignment
+
+**Supportive.** IAR provides a MISRA C:2012 checker plug-in. The recommendations complement MISRA adoption.
+
+#### Project Conclusions
+
+- IAR Embedded Workbench Recommendations are **not adopted** as a primary standard.
+- CMSIS naming conventions for ISR handlers are adopted (consistent with ST HAL and most ARM Cortex-M projects).
+- Stack usage analysis as part of the verification process is adopted as a recommendation.
+
+---
+
+### 4.13 JSF AV C++ Coding Standards (Joint Strike Fighter)
+
+**Organisation:** Lockheed Martin / US Department of Defense
+**Year:** Revision C, 2005
+**Domain:** Flight-critical avionics software (F-35 Lightning II)
+**Availability:** Public domain (US DoD publication)
+
+#### Overview
+
+The JSF AV (Air Vehicle) C++ Coding Standard is one of the most comprehensive safety-critical coding standards ever published. Though nominally a C++ standard, it contains extensive guidance applicable to C. It was developed for DO-178B (avionics certification) compliance and is widely cited in other safety-critical domains.
+
+With over 230 rules, it is more comprehensive and stricter than MISRA C in several areas. It defines function complexity limits, file length limits, and assert density requirements that the project has directly adopted.
+
+#### Key Rules Adopted
+
+| JSF Rule | Content | Project Adoption | Reference |
+|---|---|---|---|
+| JSF 118 | Max nesting depth 5 levels | **Adopted** | CSC-STD-001 §23.2 |
+| JSF 120 | Max 5 function parameters | **Adopted** | CSC-STD-001 §30.1 |
+| JSF 192 | Null statements require comment | **Adopted** | `[RULE: misc.null_statement_comment]` |
+| JSF Rule on length | File length recommendation | **Adopted** | `[RULE: misc.file_length]` |
+| JSF 45 | Identifier length (3–31 chars) | **Adopted** | naming section |
+
+#### Safety Criticality
+
+**EXTREME.** JSF AV rules were designed for DO-178B Level A (most critical) avionics software where software failure could cause loss of the aircraft.
+
+#### MISRA Alignment
+
+**Very high.** JSF C++ rules were designed to be compatible with MISRA C in the C subset. Many rules are equivalent or stricter.
+
+#### ASPICE Alignment
+
+**High.** JSF rules support thorough static verification and complexity control, mapping to SWE.4 requirements.
+
+#### Project Conclusions
+
+- JSF nesting depth limit (5 levels) is **adopted** (CSC-STD-001 §23.2).
+- JSF parameter count limit (5 parameters) is **adopted** (CSC-STD-001 §30.1).
+- JSF null-statement comment rule (JSF 192) is **adopted** and automated (`[RULE: misc.null_statement_comment]`).
+- JSF file length recommendation supports the project's 500-line file limit.
+- JSF identifier length guidance (3–31 characters) is adopted as advisory.
+
+---
+
+### 4.14 HICPP (High Integrity C++ Coding Standard)
+
+**Organisation:** Programming Research Ltd (now Perforce/LDRA)
+**Year:** Version 4.0, 2016
+**Domain:** High-integrity software (safety + security + reliability)
+**Availability:** Free download from hicpp.org
+
+#### Overview
+
+HICPP 4.0 is a comprehensive coding standard for C++ with extensive coverage of C-relevant principles. It is designed for systems requiring both functional safety and security. It builds on MISRA C, JSF, and CERT C, providing a unified framework.
+
+HICPP is supported by static analysis tools from Perforce (formerly Programming Research), LDRA, and others.
+
+#### Key Contributions
+
+| Topic | HICPP Approach | Project Alignment |
+|---|---|---|
+| Type safety | Strict; aligned with MISRA Essential Type Model | **High alignment** |
+| Naming | Intentional, consistent; type indication | **Consistent** with project approach |
+| Memory | Explicit allocation/deallocation; prefer stack | **Adopted** |
+| Control flow | Structured; nesting limits; complexity limits | **Adopted** |
+| Documentation | Non-obvious behaviour explained | **Adopted** |
+| Security | Defensive programming; input validation | **Adopted** |
+
+#### Safety Criticality
+
+**HIGH.** HICPP covers both functional safety (aligned with IEC 61508) and security. Used in medical devices, avionics, and industrial control systems.
+
+#### MISRA Alignment
+
+**Very high.** HICPP is designed as a superset of MISRA C practices. HICPP compliance implies MISRA compliance in most areas.
+
+#### ASPICE Alignment
+
+**High.** HICPP supports SWE.3, SWE.4, and SUP.1 evidence generation.
+
+#### Project Conclusions
+
+- HICPP provides **corroborating evidence** for many rules already adopted from MISRA C:2012, Barr-C, and CERT C.
+- HICPP's unified approach to safety + security reinforces the project's use of both MISRA and CERT C together.
+- HICPP does not contribute rules not already covered by the adopted sources.
+
+---
+
+### 4.15 IEC 61508 / ISO 26262 C Coding Guidance
+
+**Organisation:** International Electrotechnical Commission / International Organization for Standardization
+**Year:** IEC 61508-3:2010; ISO 26262-6:2018 (second edition)
+**Domain:** Functional safety — industrial machinery (IEC) and road vehicles (ISO)
+**Availability:** Paid publication (IEC and ISO webstores)
+
+#### Overview
+
+IEC 61508 and ISO 26262 are the foundational functional safety standards. They do not prescribe a specific C coding standard but provide requirements and guidance in their software requirements parts (IEC 61508-3, ISO 26262-6) that constrain how C code must be written for SIL/ASIL-rated systems.
+
+ISO 26262-6 Table 1 lists software design and coding guidelines for each ASIL level. For ASIL B and above, use of a language subset (e.g. MISRA C:2012) is "highly recommended" (++). For ASIL C and D, it becomes effectively mandatory.
+
+IEC 61508-3 Part 7 Annex C lists recommended C coding techniques by SIL level, covering:
+- Language subsets
+- Coding guidelines
+- Defensive programming
+- Memory management
+- Control flow
+
+#### Project Relevance
+
+| Requirement | Standard | Project Rule |
+|---|---|---|
+| Language subset (MISRA C) | ISO 26262-6 Table 1 (ASIL B+), IEC 61508-3 | CSC-STD-001 §8, §9 |
+| No dynamic allocation (SIL 3–4 / ASIL C–D) | IEC 61508-3 Annex C | CSC-STD-001 §20 |
+| Single entry, single exit (advisory) | ISO 26262-6 | CSC-STD-001 §23.1 |
+| Structured programming (no goto) | IEC 61508-3 | CSC-STD-001 §24 |
+| No recursion (SIL 3–4) | IEC 61508-3 | CSC-STD-001 §25 |
+| Static analysis mandatory (SIL 3–4) | ISO 26262-6 | CSC-STD-001 §69 |
+| Coding guideline compliance evidence | ISO 26262-6 Clause 8 | ASPICE §4 of this project |
+| Defensive programming | IEC 61508-3 | CSC-STD-001 §34, §55 |
+| Safe state definition | IEC 61508-1, ISO 26262-4 | CSC-STD-001 §56 |
+
+#### Safety Criticality
+
+**EXTREME.** IEC 61508 and ISO 26262 are the legal and regulatory basis for functional safety in their respective domains.
+
+#### MISRA Alignment
+
+**Full.** MISRA C:2012 was designed specifically to satisfy the coding guideline requirements of IEC 61508 and ISO 26262. They are complementary, not competing.
+
+#### ASPICE Alignment
+
+**Full.** ASPICE is the process assessment model for ISO 26262 compliance. IEC 61508 has its own lifecycle model, but ASPICE is the de facto standard in automotive.
+
+#### Project Conclusions
+
+- IEC 61508 and ISO 26262 are the **top-level normative framework** within which this project operates.
+- All coding rules in CSC-STD-001 ultimately derive their safety rationale from IEC 61508 / ISO 26262 requirements.
+- The specific C coding rules are satisfied through MISRA C:2012 adoption, which is the accepted industry practice for meeting IEC 61508-3 coding requirements.
+- The project's ASPICE v4 Level 2 compliance provides the process evidence required by ISO 26262-6 Clause 8.
+
+---
+
+## 5. Comparison Matrices
+
+### 5.1 Safety Criticality and Domain
+
+| Standard | Domain | Safety Level | Regulatory Basis |
+|---|---|---|---|
+| IEC 61508 / ISO 26262 | Industrial / Automotive | EXTREME | Legal / regulatory |
+| NASA Power of Ten | Space systems | EXTREME | Internal NASA mandate |
+| JSF AV C++ | Avionics | EXTREME | DO-178B Level A |
+| MISRA C:2012/2023 | Multi-domain safety | VERY HIGH | ISO 26262, IEC 61508 |
+| AUTOSAR Guidelines | Automotive | VERY HIGH | ISO 26262 |
+| HICPP | High-integrity | HIGH | IEC 61508 |
+| Barr-C:2018 | Embedded systems | HIGH | Best practice |
+| Netrino / Ganssle | Embedded systems | MEDIUM–HIGH | Best practice |
+| CERT C | Secure software | MEDIUM–HIGH | SANS / CERT |
+| IAR EW | Embedded (vendor) | MEDIUM | Vendor guidance |
+| Google C | Large-scale software | LOW | Team convention |
+| GNU Coding Standards | Open-source | LOW | Project convention |
+| LLVM Coding Standards | Compiler infrastructure | LOW | Project convention |
+| Linux Kernel | OS kernel | LOW | Community convention |
+| MIRA | (see MISRA) | — | (see MISRA) |
+
+### 5.2 Naming Convention Approach
+
+| Standard | Variables | Functions | Types | Constants |
+|---|---|---|---|---|
+| MISRA C:2012 | No prescription | No prescription | No prescription | No prescription |
+| Barr-C:2018 | `lower_snake` + scope prefix | `<mod>_<Object><Verb>` | `UPPER_SNAKE_T` | `UPPER_SNAKE` |
+| AUTOSAR | `lower_snake` + module prefix | `<Mod>_<Verb>` | `<Mod>_<Name>Type` | `<MOD>_<CONST>` |
+| Google C | `snake_case` | `snake_case` | `TypeName` | `kConstantName` |
+| Linux Kernel | `lowercase` | `action_object` | `lowercase_t` | `UPPER_CASE` |
+| NASA Power of Ten | Descriptive | Descriptive | — | — |
+| JSF AV | Descriptive | Module prefix | `CapWords` | `UPPER_CASE` |
+| CERT C | Descriptive | — | — | — |
+| GNU | `lower_underscore` | `lower_underscore` | — | `UPPER_CASE` |
+| **Project (adopted)** | `lower_snake` + `g_`/`s_`/`p_` | `<mod>_<Object><Verb>` | `UPPER_SNAKE_T` | `UPPER_SNAKE` |
+
+### 5.3 Formatting Rules
+
+| Standard | Indentation | Line Length | Brace Style | Mandatory Braces |
+|---|---|---|---|---|
+| MISRA C:2012 | No rule | No rule | No rule | No rule |
+| Barr-C:2018 | 4 spaces | 80–120 | K&R | YES |
+| AUTOSAR | 2–4 spaces | 120 | K&R | YES |
+| Google C | 2 spaces | 80 | K&R | YES |
+| Linux Kernel | Tabs (8 wide) | 80 | K&R | NO (single stmt ok) |
+| NASA Power of Ten | No rule | No rule | No rule | No rule |
+| GNU | 2 spaces | 79 | Allman | No rule |
+| JSF AV | 2–4 spaces | 80 | Allman | YES |
+| **Project (adopted)** | `[AStyle config]` | `[AStyle config]` | `[AStyle config]` | YES |
+
+### 5.4 Memory Management Policy
+
+| Standard | Dynamic Allocation | Static Allocation | VLAs |
+|---|---|---|---|
+| MISRA C:2012 | Restricted (Rule 21.3) | Preferred | Prohibited (Rule 18.8) |
+| NASA Power of Ten | **Prohibited** | Mandatory | — |
+| JSF AV | Highly restricted | Preferred | — |
+| IEC 61508 (SIL 3–4) | **Prohibited** | Mandatory | — |
+| ISO 26262 (ASIL C–D) | **Prohibited** | Mandatory | — |
+| Barr-C:2018 | Use sparingly | Preferred | Not recommended |
+| AUTOSAR (BSW) | **Prohibited** | Mandatory | Not used |
+| CERT C | Carefully | Acceptable | Restrict |
+| Google C | Permitted | Acceptable | Permitted |
+| Linux Kernel | Permitted | Context-dependent | Context-dependent |
+| **Project (adopted)** | **Prohibited on safety path** | **Mandatory** | **Prohibited** |
+
+### 5.5 Control Flow Restrictions
+
+| Standard | goto | Recursion | Nesting Depth | Switch Default |
+|---|---|---|---|---|
+| MISRA C:2012 | Advisory restriction | **Prohibited** (R17.2) | No rule | **Required** (R16.4) |
+| NASA Power of Ten | **Prohibited** | **Prohibited** | No rule | — |
+| JSF AV | **Prohibited** | Restricted | **5 levels** | Required |
+| Barr-C:2018 | **Prohibited** | Restricted | — | Required |
+| CERT C | No rule | No rule | No rule | No rule |
+| Google C | No rule | No rule | No rule | No rule |
+| Linux Kernel | Permitted (cleanup) | Permitted | No rule | Recommended |
+| **Project (adopted)** | Forward-to-cleanup only | **Prohibited** | **5 levels** | **Required** |
+
+### 5.6 MISRA and ASPICE Alignment
+
+| Standard | MISRA Alignment | ASPICE SWE.3 Support | ASPICE SWE.4 Support |
+|---|---|---|---|
+| MISRA C:2012/2023 | N/A (IS MISRA) | Direct | Via static analysis |
+| IEC 61508 / ISO 26262 | Full | Direct | Direct |
+| AUTOSAR | Very High | Very High | High |
+| JSF AV | Very High | High | Very High |
+| NASA Power of Ten | Very High | High | High |
+| HICPP | Very High | High | High |
+| Barr-C:2018 | High | High | Medium |
+| CERT C | Complementary | Medium | Medium |
+| Netrino / Ganssle | High | Medium | Medium |
+| IAR EW | Supportive | Medium | Low |
+| Google C | Low | Low | Low |
+| Linux Kernel | Low | Low | Low |
+| GNU | Low | Low | Low |
+| LLVM | Low | Low | Low |
+
+---
+
+## 6. Cross-Cutting Themes
+
+The following themes emerge consistently across multiple standards:
+
+### 6.1 Fixed-Width Integer Types (Universal Consensus)
+
+**14 out of 15** standards either require or strongly recommend fixed-width integer types from `<stdint.h>`. Only the Linux Kernel style is indifferent (kernel has its own type aliases). This is the single most universally adopted rule in embedded C.
+
+**Adopted:** CSC-STD-001 §10.1 — mandatory.
+
+### 6.2 Mandatory Braces on All Control Bodies (High Consensus)
+
+**9 out of 15** standards require or strongly recommend braces on all `if`/`else`/`for`/`while` bodies. The historical `goto fail` SSL bug (Apple, 2014) — caused by a brace-free `if` body — is frequently cited as justification.
+
+**Adopted:** CSG-STY-001 §13.1 — mandatory.
+
+### 6.3 No Dynamic Memory Allocation on Safety Path (Safety-Critical Consensus)
+
+**5 out of 5** safety-critical standards (MISRA, NASA, JSF, IEC 61508, ISO 26262) prohibit or severely restrict dynamic allocation. Non-determinism and fragmentation are the primary concerns.
+
+**Adopted:** CSC-STD-001 §20 — prohibited on safety path.
+
+### 6.4 No Recursion (Safety-Critical Consensus)
+
+**4 out of 5** safety-critical standards prohibit recursion. Stack overflow from unbounded recursion is undetectable in the general case without formal verification.
+
+**Adopted:** CSC-STD-001 §25 — prohibited.
+
+### 6.5 Comments Explain "Why" Not "What" (Universal Principle)
+
+All 15 standards, in some form, express that comments should add value beyond what the code itself states. This is the one principle that transcends the safety/general divide.
+
+**Adopted:** CSG-STY-001 §32.
+
+### 6.6 Return Value Checking (High Consensus)
+
+MISRA C (Rule 17.7), CERT C (ERR33-C), NASA Power of Ten (Rule 7), Barr-C, Netrino, and JSF all require or recommend that all function return values encoding status are checked.
+
+**Adopted:** CSC-STD-001 §30.3 — mandatory.
+
+### 6.7 `volatile` for Hardware Registers and ISR-Shared Data (Embedded Consensus)
+
+Barr-C:2018, Netrino, IAR, AUTOSAR, and MISRA C all require `volatile` on hardware registers and ISR-shared variables.
+
+**Adopted:** CSC-STD-001 §22 — mandatory.
+
+---
+
+## 7. Gaps and Conflicts Between Standards
+
+### 7.1 Gaps (Not Covered by Any Single Standard)
+
+| Gap | Identified In | Project Mitigation |
+|---|---|---|
+| RTOS-specific patterns (queue/semaphore safety) | None comprehensively | CSC-STD-001 §51 |
+| Watchdog management rules | JSF (partially) | CSC-STD-001 §60 |
+| Timestamp overflow handling | None | CSC-STD-001 §61.4 |
+| ISR latency budgets | None | CSC-STD-001 §59.4 |
+| Stack high-water monitoring | None | CSC-STD-001 §21.3 |
+| ASPICE process compliance of the coding standard itself | ASPICE | CSC-STD-001 §4, §5 |
+
+### 7.2 Conflicts Between Surveyed Standards
+
+| Topic | Conflict | Project Resolution |
+|---|---|---|
+| `goto` | Linux: permitted; MISRA: advisory restriction; NASA/JSF: prohibited | Adopted: forward-to-cleanup only (compromise between MISRA advisory and pragmatic Linux pattern) |
+| Line length | Google: 80; AUTOSAR: 120; Linux: 80 pragmatic | Adopted: configurable via AStyle; currently 180 (allows long embedded identifiers) |
+| Indentation width | Linux: 8 spaces (tabs); Google/LLVM: 2; Barr-C: 4 | Adopted: configurable via AStyle; default 4/tab |
+| Brace style | GNU: Allman; K&R style: same-line; JSF: Allman | Adopted: AStyle-configured (project choice) |
+| Constant naming | Barr-C: `UPPER_SNAKE`; Google: `kConstantName`; Linux: `UPPER_CASE` | Adopted: `UPPER_SNAKE` (Barr-C/MISRA aligned) |
+| Function naming case | AUTOSAR: PascalCase; Barr-C: module+PascalCase; Google: snake_case | Adopted: `<module>_<Object><Verb>` (Barr-C) |
+| Comment style | Linux/Google: `//` preferred; MISRA: allows both; C89 projects: `/* */` only | Adopted: both permitted; C89 mode restricts to `/* */` |
+| Switch default | MISRA: Required; Google: not prescribed | Adopted: Required (MISRA wins for safety) |
+| `bool` comparisons | MISRA: no comparison against `true`/`false`; some guides: permit | Adopted: MISRA rule — no comparison against `true`/`false` |
+
+---
+
+## 8. Conclusions
+
+### 8.1 Primary Standards Selected
+
+Based on this survey, the project has adopted the following standards as its primary sources:
+
+| Priority | Standard | Rationale |
+|---|---|---|
+| 1 | **MISRA C:2012/2023** | Definitive safety-critical C standard; required for ISO 26262 / IEC 61508 compliance |
+| 2 | **Barr-C:2018** | Best practical naming and formatting convention for embedded C; cstylecheck implements it directly |
+| 3 | **CERT C** | Complements MISRA with security-oriented rules; fills gaps in integer safety and secure string handling |
+| 4 | **NASA Power of Ten** | Adds function length, assert density, and return-value-check requirements that MISRA does not prescribe |
+| 5 | **JSF AV C++ Standard** | Adds nesting depth, parameter count, and null-statement comment rules |
+| 6 | **AUTOSAR Guidelines** | Corroborates module prefix naming; confirms automotive best practice alignment |
+| 7 | **IEC 61508 / ISO 26262** | Top-level normative framework; the ultimate justification for all safety rules |
+
+### 8.2 Standards Surveyed but Not Adopted as Primary Sources
+
+| Standard | Reason Not Adopted as Primary |
+|---|---|
+| Google C Style Guide | Not suitable for safety-critical embedded; conflicting naming/formatting conventions |
+| Linux Kernel Coding Style | Not suitable for safety-critical embedded; permits goto, dynamic allocation, recursion |
+| GNU Coding Standards | General-purpose open-source focus; no embedded or safety-critical relevance |
+| LLVM Coding Standards | C++ compiler focus; no embedded relevance |
+| IAR EW Recommendations | Vendor-specific tool guidance; not a formal standard |
+| Netrino / Ganssle | Overlaps with Barr-C:2018; provides corroborating evidence only |
+| HICPP | C++ focused; C rules subsumed by adopted standards |
+| MIRA | Not a separate standard; MISRA C covers this |
+
+### 8.3 Rule Confidence by Consensus Count
+
+| Rule Type | Consensus Count | Confidence |
+|---|---|---|
+| Fixed-width integer types | 14/15 | VERY HIGH |
+| No dynamic allocation (safety path) | 5/5 safety standards | VERY HIGH |
+| `volatile` for hardware/ISR | 6+ standards | VERY HIGH |
+| Mandatory braces | 9+ standards | HIGH |
+| Return value checking | 6+ standards | HIGH |
+| Comments explain "why" | 15/15 | HIGH (universal principle) |
+| No recursion | 4/5 safety standards | HIGH |
+| Module prefix naming | 6+ embedded/automotive standards | HIGH |
+| 60-line function limit | 2 standards (JPL, JSF near-equivalent) | MEDIUM |
+| 5-level nesting limit | 2 standards (JSF, Barr-C) | MEDIUM |
+
+### 8.4 ASPICE v4 Level 2 Compliance Assessment
+
+This analysis document, together with CSG-STY-001 and CSC-STD-001, constitutes evidence for:
+
+| ASPICE Requirement | Evidence |
+|---|---|
+| SWE.3 BP6 — Apply coding guidelines | CSC-STD-001 defines coding guidelines derived from this analysis |
+| SWE.4 BP2 — Static verification | cstylecheck + static analysis tool enforce rules automatically |
+| SUP.1 BP2 — Assure compliance | Deviation procedure (CSC-STD-001 §72) and review checklist (CSC-STD-001 §70) |
+| SUP.8 BP1 — Identify CIs | All three documents are version-controlled configuration items |
+| GP 2.1.1 — Define process | CSC-STD-001 defines the coding process |
+| GP 2.2.1 — Define responsibility | Section 5 in both standards |
+| GP 2.3.1 — Identify information items | Document IDs, versions, statuses tracked |
+
+---
+
+## 9. Recommendations for CSG-STY-001 and CSC-STD-001
+
+1. **Maintain MISRA C:2012 as the primary normative reference.** All conflicts with other surveyed standards shall be resolved in favour of MISRA C when a rule is classified as Required or Mandatory.
+
+2. **Use Barr-C:2018 as the primary naming standard.** The cstylecheck tool implements it; consistency between the tool and the document is essential.
+
+3. **Retain CERT C coverage for integer and memory safety.** These rules address exploitable vulnerabilities not fully covered by MISRA.
+
+4. **Adopt JPL function length and assert density as required rules.** The 60-line limit and assert-density requirement measurably reduce complexity and increase verifiability.
+
+5. **Adopt JSF nesting depth and parameter count limits.** These reduce complexity and improve testability.
+
+6. **Maintain a deviation register.** The survey shows that some rules (e.g. `goto`, specific macro patterns) will need deviations for legacy code or third-party integration. The register makes deviations auditable.
+
+7. **Populate the `[RULE: TBD]` placeholders in CSG-STY-001 and CSC-STD-001** by mapping each section to the corresponding cstylecheck rule ID from `src/rules.yml` once the rule configuration is finalised.
+
+8. **Supplement cstylecheck with a MISRA-compliant static analysis tool** for full MISRA C:2012 coverage beyond what cstylecheck implements.
+
+9. **Review this analysis document** when MISRA C:2023 (next full edition, expected ~2025–2026) is published, as it may promote more Advisory rules to Required.
+
+---
+
+## 10. Adopted vs. Rejected Rules by Source
+
+### Rules Adopted
+
+| Rule | Source | Classification | cstylecheck Rule ID |
+|---|---|---|---|
+| No octal literals | MISRA 7.1 | Required | `misc.octal_constant` |
+| Unsigned suffix on unsigned literals | MISRA 7.2 / Barr-C | Required | `misc.unsigned_suffix` |
+| Uppercase integer suffixes | MISRA 7.3 | Required | `misc.lowercase_l_suffix` |
+| No trigraphs | MISRA 4.2 / MISRA C:2023 | Required | `misc.trigraph` |
+| Module prefix on all public identifiers | Barr-C 7.1 / AUTOSAR | Required | `file_prefix` |
+| `g_` prefix on global variables | Barr-C 7.1.b | Required | `variables.global.g_prefix` |
+| `s_` prefix on static variables | Barr-C 7.1.c | Required | `variables.static.s_prefix` |
+| `p_` prefix on pointer variables | Barr-C 7.1.k | Required | `variables.pointer_prefix` |
+| `pp_` prefix on double-pointer variables | Barr-C 7.1.l | Required | `variables.pp_prefix` |
+| `h_` prefix on handle variables | Barr-C 7.1.n | Advisory | `variables.handle_prefix` |
+| `_t` suffix on enum types | Barr-C / AUTOSAR | Required | `enums.type_suffix` |
+| `_T` suffix on typedef names | Barr-C | Advisory | `typedefs.suffix` |
+| `_s` suffix on struct tags | Barr-C | Advisory | `structs.tag_suffix` |
+| UPPER\_SNAKE\_CASE for macros and constants | All sources | Required | `macros`, `constants` |
+| `<mod>_<Object><Verb>` function naming | Barr-C / project | Required | `functions.style` |
+| `_IRQHandler` suffix on ISRs | Barr-C / CMSIS | Required | `functions.isr_suffix` |
+| Include guard pattern `{FILE}_{EXT}_` | Barr-C / project | Required | `include_guards` |
+| `#pragma once` as alternative | Project policy | Advisory | `include_guards.allow_pragma_once` |
+| Magic number detection | Barr-C / JPL | Required | `misc.magic_numbers` |
+| Line length limit | Multiple | Required | `misc.line_length` |
+| Indentation consistency | Multiple | Required | `misc.indentation` |
+| Yoda conditions for `==` and `!=` | Barr-C / Netrino | Required | `misc.yoda_conditions` |
+| Null statement comment | JSF 192 | Required | `misc.null_statement_comment` |
+| Function length ≤ 60 lines | JPL Rule 4 | Required | `misc.function_length` |
+| File length ≤ 500 lines | JSF / ESA practice | Advisory | `misc.file_length` |
+| Function documentation header | ESA / AUTOSAR | Advisory | `misc.function_doc_header` |
+| Assert density | JPL Rule 5 | Advisory | `misc.assert_density` |
+| Trailing semicolon in macros | CERT PRE11-C | Required | `macros.trailing_semicolon` |
+| Multi-statement macro wrapper | CERT PRE10-C | Required | `macros.multistatement_wrapper` |
+| Reserved header names | CERT PRE04-C | Required | `misc.reserved_header_name` |
+| Sign compatibility | MISRA 10.x | Required | `sign_compatibility` |
+| Comment ratio | Barr-C / ESA | Advisory | `misc.comment_ratio` |
+| Whitespace ratio | Project practice | Advisory | `misc.whitespace_ratio` |
+| Block comment spacing | Project practice | Advisory | `misc.block_comment_spacing` |
+| Copyright header | Project practice | Required | `misc.copyright_header` |
+| Enum member prefix from type | Barr-C | Required | `enums.member_prefix_from_type` |
+| No single-char identifiers | JSF 45 / ESA | Advisory | `naming.no_single_char_identifiers` |
+| Identifier length limits | JSF 45 / ESA | Advisory | `naming.identifier_length` |
+| Reserved names (C/POSIX) | CERT PRE04-C / MISRA 5.x | Required | `reserved_names` |
+| Declared-not-defined detection | CERT / project | Advisory | `misc.declared_not_defined` |
+
+### Rules Surveyed but Not Adopted
+
+| Rule | Source | Reason Not Adopted |
+|---|---|---|
+| 2-space indentation | Google, LLVM, GNU | Conflicts with embedded convention; AStyle-controlled |
+| 80-character hard line limit | Google, Linux, GNU | Too restrictive for embedded identifiers with module prefix; configurable limit adopted |
+| `kConstantName` constant naming | Google | Conflicts with Barr-C UPPER\_SNAKE convention |
+| Function pointer prohibition | JPL Rule 9 | Too restrictive; function pointers with NULL check are acceptable |
+| All loop bounds must be provable | JPL Rule 2 | Formal proof not practical for all loops; handled by code review |
+| No `//` comments | MISRA 3.1 (in C89 mode) | Project uses C11; both comment styles permitted |
+| Hard tabs 8-space visual | Linux Kernel | Too opinionated; AStyle-controlled |
+| `_Thread_local` prohibition | Project | Covered by RTOS guidelines; formal rule not required |
+
+---
+
+## 11. Document Change History
+
+| Version | Date | Author | Change Description |
+|---|---|---|---|
+| 1.0 | 2026-06-08 | (initial draft) | Initial survey of 15 standards; per-document analysis; comparison matrices; conclusions and recommendations |
+
+---
+
+*End of CSC-ANA-001 External C Coding Standards Survey and Analysis v1.0*

--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -751,26 +751,26 @@ class Checker:
             # Double pointer (**) → local part must start with pp_
             # The stars are captured directly in RE_VAR_DECL (group 3).
             #
-            # For function parameters the naming convention allows a parameter
-            # prefix (e.g. "p_") to precede the type prefix (e.g. "ptr_"),
-            # giving "p_ptr_name".  Accept the type prefix when it appears
-            # either directly at the start of the local part OR immediately
-            # after the configured parameter prefix.  This is independent of
-            # whether variable.parameter.p_prefix is enabled — it reflects the
-            # physical naming convention used by the project.
+            # The naming convention allows a parameter prefix (e.g. "p_") to
+            # precede the type prefix (e.g. "ptr_"), giving "p_ptr_name".
+            # Accept the type prefix when it appears either directly at the
+            # start of the local part OR immediately after the configured
+            # parameter prefix. This applies regardless of scope — a project
+            # may apply the same "p_ptr_name" convention to struct members,
+            # locals, and globals, not just function parameters — and is
+            # independent of whether variable.parameter.p_prefix is enabled,
+            # since it reflects the physical naming convention used by the
+            # project rather than the parameter-prefix rule itself.
             local_raw = self._strip_any_prefix(name)
 
             if stars == "**":
                 if pp_cfg.get("enabled", True):
                     pp_pfx = pp_cfg.get("prefix", "pp_")
                     pp_sev = pp_cfg.get("severity", "warning")
-                    if scope == "parameter":
-                        pp_ok = local_raw.startswith(pp_pfx) or (
-                            local_raw.startswith(_pp_param_pfx) and
-                            local_raw[len(_pp_param_pfx):].startswith(pp_pfx)
-                        )
-                    else:
-                        pp_ok = local_raw.startswith(pp_pfx)
+                    pp_ok = local_raw.startswith(pp_pfx) or (
+                        local_raw.startswith(_pp_param_pfx) and
+                        local_raw[len(_pp_param_pfx):].startswith(pp_pfx)
+                    )
                     if not pp_ok:
                         self._v(m.start(), pp_sev, "variable.pp_prefix",
                                 f"Double-pointer variable '{name}' local part "
@@ -779,13 +779,10 @@ class Checker:
                 if ptr_cfg.get("enabled", True):
                     p_pfx = ptr_cfg.get("prefix", "p_")
                     p_sev = ptr_cfg.get("severity", "warning")
-                    if scope == "parameter":
-                        ptr_ok = local_raw.startswith(p_pfx) or (
-                            local_raw.startswith(_pp_param_pfx) and
-                            local_raw[len(_pp_param_pfx):].startswith(p_pfx)
-                        )
-                    else:
-                        ptr_ok = local_raw.startswith(p_pfx)
+                    ptr_ok = local_raw.startswith(p_pfx) or (
+                        local_raw.startswith(_pp_param_pfx) and
+                        local_raw[len(_pp_param_pfx):].startswith(p_pfx)
+                    )
                     if not ptr_ok:
                         self._v(m.start(), p_sev, "variable.pointer_prefix",
                                 f"Pointer variable '{name}' local part should "

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -282,5 +282,101 @@ class TestVariableMinLength(unittest.TestCase):
         self.assertIn("BARR-C", ml[0].message)
 
 
+class TestPointerPrefixCombinedNonParameterScopes(unittest.TestCase):
+    """Regression for GitHub issue #245.
+
+    The 'p_ptr_name' leniency (parameter prefix 'p_' followed by the
+    configured pointer-type prefix, e.g. 'ptr_') was previously only applied
+    when scope == "parameter". Globals, statics, locals, and struct members
+    using the identical naming convention were incorrectly flagged even
+    though their local part, after stripping the leading 'p_', clearly
+    starts with the configured pointer prefix.
+
+    Reported false positives:
+        api_radio_transport.h: Pointer variable 'p_ptr_offset' ...
+        api_vibration.h:       Pointer variable 'p_ptr_packet_buffer' ...
+    Neither was a function parameter.
+    """
+
+    @staticmethod
+    def _cfg(ptr_pfx="ptr_", pp_pfx="pp_", param_pfx="p_"):
+        return cfg_only(variables={
+            "enabled": True, "severity": "error",
+            "case": "lower_snake", "min_length": 2, "max_length": 60,
+            "allow_single_char_loop_vars": True,
+            "allow_loop_vars_short": True,
+            "allowed_abbreviations": [],
+            "global": {"severity": "error", "case": "lower_snake",
+                       "require_module_prefix": False,
+                       "g_prefix": {"enabled": False}},
+            "static": {"severity": "error", "case": "lower_snake",
+                       "require_module_prefix": False,
+                       "s_prefix": {"enabled": False}},
+            "local":     {"severity": "error", "case": "lower_snake",
+                          "require_module_prefix": False},
+            "parameter": {"severity": "warning", "case": "lower_snake",
+                          "require_module_prefix": False,
+                          # Rule itself need not be enabled — only its
+                          # configured prefix value is used for stripping.
+                          "p_prefix": {"enabled": False,
+                                       "severity": "warning",
+                                       "prefix": param_pfx}},
+            "pointer_prefix": {"enabled": True, "severity": "warning",
+                               "prefix": ptr_pfx},
+            "pp_prefix":      {"enabled": True, "severity": "warning",
+                               "prefix": pp_pfx},
+            "bool_prefix":    {"enabled": False},
+            "no_numeric_in_name": {"enabled": False, "exempt_patterns": []},
+            "prefix_order": {"enabled": False},
+            "handle_prefix": {"enabled": False, "handle_types": []},
+        })
+
+    def test_global_p_ptr_name_passes(self):
+        cfg = self._cfg()
+        src = "uint8_t *p_ptr_offset;\n"
+        self.assertFalse(has(src, cfg, "variable.pointer_prefix"))
+
+    def test_local_p_ptr_name_passes(self):
+        cfg = self._cfg()
+        src = "void f(void){ uint8_t *p_ptr_offset = 0; (void)p_ptr_offset; }\n"
+        self.assertFalse(has(src, cfg, "variable.pointer_prefix"))
+
+    def test_struct_member_p_ptr_name_passes(self):
+        cfg = self._cfg()
+        src = "typedef struct { uint8_t *p_ptr_packet_buffer; } api_x_t;\n"
+        self.assertFalse(has(src, cfg, "variable.pointer_prefix"))
+
+    def test_static_p_ptr_name_passes(self):
+        cfg = self._cfg()
+        src = "static uint8_t *p_ptr_offset;\n"
+        self.assertFalse(has(src, cfg, "variable.pointer_prefix"))
+
+    def test_global_pp_ptr_name_passes(self):
+        """Double pointer: pp_pfx leniency must also apply outside parameters."""
+        cfg = self._cfg()
+        src = "uint8_t **p_pp_table;\n"
+        self.assertFalse(has(src, cfg, "variable.pp_prefix"))
+
+    def test_global_missing_type_prefix_still_flags(self):
+        """Sanity check: the leniency must not become a blanket bypass —
+        a global pointer missing the type prefix entirely must still warn."""
+        cfg = self._cfg()
+        src = "uint8_t *p_offset;\n"
+        self.assertTrue(has(src, cfg, "variable.pointer_prefix"))
+
+    def test_global_bare_type_prefix_still_passes(self):
+        """A global pointer using the bare type prefix (no param prefix
+        lead-in) must still pass directly."""
+        cfg = self._cfg()
+        src = "uint8_t *ptr_offset;\n"
+        self.assertFalse(has(src, cfg, "variable.pointer_prefix"))
+
+    def test_parameter_scope_still_passes_after_fix(self):
+        """Existing parameter-scope behaviour must be unaffected."""
+        cfg = self._cfg()
+        src = "void f(uint8_t *p_ptr_buf){ (void)p_ptr_buf; }\n"
+        self.assertFalse(has(src, cfg, "variable.pointer_prefix"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Fixes #245 (and the duplicate #246): `variable.pointer_prefix` / `variable.pp_prefix` incorrectly flagged pointer names following the "parameter prefix + pointer-type prefix" convention (e.g. `p_ptr_offset` when `pointer_prefix.prefix: "ptr_"`) unless the variable was classified as a function parameter.
- The "strip the parameter prefix, then check for the pointer-type prefix" leniency in `_check_variables()` (`src/cstylecheck/checker.py`) was gated on `scope == "parameter"`. Globals, statics, locals, and struct members using the identical naming pattern had no equivalent leniency and were flagged.
- Removed the `scope == "parameter"` gate so the leniency check applies uniformly to all scopes for both the single-pointer (`variable.pointer_prefix`) and double-pointer (`variable.pp_prefix`) checks.

## Verification
- Confirmed the bug reproduces pre-fix for global, local, and struct-member declarations of `uint8_t *p_ptr_offset;` with `pointer_prefix.prefix: "ptr_"` (by reverting the change locally and re-running), and that the fix resolves all three.
- Added `TestPointerPrefixCombinedNonParameterScopes` to `tests/test_variables.py` covering: global, local, static, and struct-member pointers using the combined prefix; double-pointer (`pp_`) leniency outside parameter scope; a sanity check that a pointer missing the type prefix entirely is still flagged (the leniency isn't a blanket bypass); and that existing parameter-scope behavior is unaffected.
- Full suite: `python3 -m unittest discover -s tests` — 1116 tests, all passing.

## Test plan
- [x] `python3 -m unittest discover -s tests` passes (1116 tests)
- [x] New regression tests fail on the pre-fix code and pass on the fix

https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_