### PR TITLE
fix(checker): eliminate ReDoS in null_statement_comment regex

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -2570,7 +2570,7 @@ class Checker:
         # [^()\n] prevents matching across newlines.
         # Allows one level of nested parens (e.g. while(fn());).
         _RE_INLINE_NULL = re.compile(
-            r'\b(?:while|for|if)[ \t]*\((?:[^()\n]*|\([^()\n]*\))*\)[ \t]*;',
+            r'\b(?:while|for|if)[ \t]*\((?:[^()\n]|\([^()\n]*\))*\)[ \t]*;',
         )
         for m in _RE_INLINE_NULL.finditer(self.clean):
             self._v(m.start(), sev, "misc.null_statement_comment",

--- a/tests/test_null_statement_comment.py
+++ b/tests/test_null_statement_comment.py
@@ -1,5 +1,6 @@
 """test_null_statement_comment.py — tests for misc.null_statement_comment (issue #228)."""
 import sys, os; sys.path.insert(0, os.path.dirname(__file__))
+import time
 import unittest
 from harness import cfg_only, has, clean, count
 
@@ -51,3 +52,17 @@ class TestNullStatementComment(unittest.TestCase):
             "}\n"
         )
         self.assertEqual(count(src, NS_CFG, "misc.null_statement_comment"), 2)
+
+    def test_no_catastrophic_backtracking_on_unclosed_condition(self):
+        # Regression test: the inline-null regex used a nested-quantifier
+        # alternation (?:[^()\n]*|\(...\))* which caused exponential
+        # backtracking when a line opened "if (" / "while (" / "for (" with
+        # a long run of plain characters and no matching ");" on that line.
+        long_line = "if (" + "a" * 5000 + "\n"
+        src = "void foo(void) {\n" + long_line + "}\n"
+        start = time.time()
+        has(src, NS_CFG, "misc.null_statement_comment")
+        elapsed = time.time() - start
+        self.assertLess(elapsed, 2.0,
+                         f"null_statement_comment check took {elapsed:.2f}s; "
+                         f"likely catastrophic regex backtracking")


### PR DESCRIPTION
## Summary

Fixes #248. `misc.null_statement_comment` (JSF Rule 192, added for #228) used a catastrophic-backtracking regex that could hang the checker indefinitely on real source files.

```python
# before — nested quantifier, exponential backtracking
r'\b(?:while|for|if)[ \t]*\((?:[^()\n]*|\([^()\n]*\))*\)[ \t]*;'

# after — each alternative advances exactly one unit per repetition
r'\b(?:while|for|if)[ \t]*\((?:[^()\n]|\([^()\n]*\))*\)[ \t]*;'
```

Reproduced the hang locally (`if (` + 40 plain chars with no closing `);` on the line took 5+ seconds and scales exponentially; with the fix it resolves in <1ms). All existing positive/negative match cases for the rule behave identically before and after.

## Changes

- `src/cstylecheck/checker.py`: drop the redundant inner `*` in `_RE_INLINE_NULL`.
- `tests/test_null_statement_comment.py`: add a regression test asserting the check completes well under 2s on a previously-pathological 5000-character unclosed condition line.

## Test plan

- [x] New regression test (`test_no_catastrophic_backtracking_on_unclosed_condition`) passes.
- [x] All 9 pre-existing `null_statement_comment` tests still pass (semantics unchanged).
- [x] Full suite: 1152 passed, 2 subtests passed, no regressions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_