### PR TITLE
Sync develop → main (wiki link fixes for #251)

### DIFF
--- a/.github/workflows/wiki_publish.yml
+++ b/.github/workflows/wiki_publish.yml
@@ -4,7 +4,7 @@
 # =============================================================================
 #
 # Triggers:
-#   - Push to main when README.md or docs/aspice/ changes
+#   - Push to main when README.md, Rules-and-Configuration.md, or docs/aspice/ changes
 #   - Manual trigger (workflow_dispatch)
 #
 # What it does:
@@ -54,6 +54,7 @@ on:
       - main
     paths:
       - "README.md"
+      - "Rules-and-Configuration.md"
       - "docs/aspice/**.md"
       - ".github/workflows/wiki_publish.yml"
   workflow_dispatch:
@@ -139,7 +140,6 @@ jobs:
               "Structured output":                    "Structured-output",
               "Baseline suppression":                 "Baseline-suppression",
               "New in this release":                  "New-in-this-release",
-              "Rule IDs (48 total)":                  "Rule-IDs",
               "Dictionary files":                     "Dictionary-files",
               "pre-commit":                           "Pre-commit",
               "Docker":                               "Docker",
@@ -148,11 +148,42 @@ jobs:
               "GitHub Actions (CI workflow)":         "CI-Workflows",
           }
 
+          # README_SLUG_MAP is keyed on the literal heading text, so any heading
+          # that embeds a changing count (e.g. "Rule IDs (N total)") would need
+          # its map entry updated every time the count changes — easy to miss
+          # (it was, going from 48 to 64). Match on a stable prefix instead.
+          README_SLUG_PREFIX_MAP = {
+              "Rule IDs": "Rule-IDs",
+          }
+
+          # Top-level repo docs (outside README.md / docs/aspice/) that are
+          # published to the wiki as their own page. Maps the relative link
+          # target used in README.md to the wiki page slug.
+          TOP_LEVEL_DOC_MAP = {
+              "Rules-and-Configuration.md": "Rules-and-Configuration",
+          }
+
+          def rewrite_local_doc_links(text):
+              """Rewrite links to top-level repo docs into wiki [[Text|Slug]] links.
+              Plain markdown links like [Text](Rules-and-Configuration.md) resolve to
+              a non-existent page once published to the wiki's flat namespace."""
+              def _fix(m):
+                  link_text, target = m.group(1), m.group(2)
+                  if target in TOP_LEVEL_DOC_MAP:
+                      return f'[[{link_text}|{TOP_LEVEL_DOC_MAP[target]}]]'
+                  return m.group(0)
+              return re.sub(r'\[([^\]]+)\]\(([^)]+)\)', _fix, text)
+
           def readme_slug(h):
               if h in README_SLUG_MAP:
                   return README_SLUG_MAP[h]
+              for prefix, slug in README_SLUG_PREFIX_MAP.items():
+                  if h.startswith(prefix):
+                      return slug
               s = re.sub(r'[^\w\s-]', '', h)
-              return re.sub(r'\s+', '-', s.strip())
+              s = re.sub(r'\s+', '-', s.strip())
+              s = re.sub(r'-+', '-', s).strip('-')
+              return s
 
           def aspice_slug(filename):
               stem = filename[:-3] if filename.endswith('.md') else filename
@@ -214,7 +245,7 @@ jobs:
               + "---\n\n## Contents\n\n"
               + "\n".join(home_toc) + "\n"
           )
-          write("wiki/Home.md", rewrite_images(home_md))
+          write("wiki/Home.md", rewrite_images(rewrite_local_doc_links(home_md)))
 
           # One page per README section
           for idx, heading in enumerate(ordered):
@@ -224,10 +255,21 @@ jobs:
               prev_s     = readme_slug(ordered[idx - 1]) if idx > 0 else "Home"
               next_label = ordered[idx + 1] if idx < len(ordered) - 1 else None
               next_s     = readme_slug(ordered[idx + 1]) if idx < len(ordered) - 1 else None
-              write(f"wiki/{s}.md",
-                    rewrite_images(body.rstrip() + nav_footer(prev_label, prev_s, next_label, next_s)))
+              page = rewrite_local_doc_links(body.rstrip()) + nav_footer(prev_label, prev_s, next_label, next_s)
+              write(f"wiki/{s}.md", rewrite_images(page))
 
           print(f"Wrote {len(ordered)} README section pages.")
+
+          # Top-level repo docs published as their own wiki page (e.g. the
+          # full Rules-and-Configuration reference linked from the README intro).
+          for rel_path, slug in TOP_LEVEL_DOC_MAP.items():
+              src = Path(rel_path)
+              if not src.is_file():
+                  print(f"  WARNING: {rel_path} not found - skipping its wiki page.")
+                  continue
+              raw = src.read_text(encoding="utf-8")
+              write(f"wiki/{slug}.md", rewrite_images(raw.rstrip() + nav_footer()))
+          print(f"Wrote {len(TOP_LEVEL_DOC_MAP)} top-level doc page(s).")
 
           # ASPICE pages - all flat in wiki root with ASPICE- prefix
           aspice_src   = Path("docs/aspice")
@@ -336,6 +378,7 @@ jobs:
               "",
               "**User Guide**",
               "",
+              "- [[Rules and Configuration Reference|Rules-and-Configuration]]",
           ]
           for h in ordered:
               sidebar.append(f"- [[{h}|{readme_slug(h)}]]")

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ uint32_t val = 100;  // cstylecheck: disable=misc.unsigned_suffix,misc.magic_num
 
 ---
 
-## Auto-fix mode (`--fix`)
+## Auto-fix mode
 
 CStyleCheck can apply safe, mechanical fixes in-place.  All currently fixable
 violations are zero-risk character substitutions.
@@ -341,7 +341,7 @@ qualify, so the flag is a forward-compatibility guard.
 
 ---
 
-## Config wizard (`--init` / `--preset`)
+## Config wizard
 
 Generate a starter `.cstylecheck.yml` without writing YAML by hand.
 
@@ -374,7 +374,7 @@ python src/cstylecheck.py --preset misra      # MISRA-oriented rule set
 
 ---
 
-## Per-directory config (`--per-dir-config`)
+## Per-directory config
 
 Enable hierarchical configuration where subdirectories can override the root
 `rules.yml` settings.


### PR DESCRIPTION
## Summary
- Syncs `develop` into `main` to bring PR #252's wiki-link fixes live.
- Fixes broken `[[...]]` wiki links (triple-hyphen slugs from headings with backticks/parens) reported on the User Guide link list and in the README.
- Fixes the "Rules and Configuration Reference" link on the README/wiki, which previously led to "Create a new page" instead of the actual Rules page; publishes `Rules-and-Configuration.md` to the wiki and adds it to the sidebar.
- Hardens the slug generator (`README_SLUG_PREFIX_MAP`) against future drift (e.g. "Rule IDs (N total)" headings).

Closes #251 (once merged and the wiki workflow rebuilds on push to `main`).

## Test plan
- [x] Dry-run of the extracted wiki-generation script against real repo content confirmed correct slugs and a working Rules-and-Configuration cross-link.
- [x] Full test suite passing on `develop` prior to this sync.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_