### PR TITLE
Sync develop → main (ASPICE audit CSC-AUD-006 fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **`naming.no_single_char_identifiers` rule** — flags single-character variable names
   outside a configurable exempt list (e.g. `i`, `j`, `k`) (disabled by default)
   (issue [#231](https://github.com/dermot-murphy/CStyleCheck/issues/231)).
-- **102 new tests** (1143 total) covering all 11 new rules, including edge cases for
+- **102 new tests** (1152 total) covering all 11 new rules, including edge cases for
   multi-line macros, nested braces, comment exclusion, and regex-based exemptions.
+- Draft companion documents `embedded_c_style_guide.md`, `embedded_c_coding_standard.md`,
+  and `external_standards_analysis.md` — pending rule population, linked from the README.
+
+### Fixed
+
+- Parameter and pointer naming-prefix checks no longer require both prefixes
+  simultaneously when only one is configured, fixing false positives on otherwise
+  compliant declarations
+  (issues [#245](https://github.com/dermot-murphy/CStyleCheck/issues/245),
+  [#246](https://github.com/dermot-murphy/CStyleCheck/issues/246)).
+- Fixed a catastrophic-backtracking (ReDoS) regular expression in
+  `misc.null_statement_comment` that could hang indefinitely on an unclosed
+  `if`/`while`/`for` condition spanning a long line
+  (issues [#248](https://github.com/dermot-murphy/CStyleCheck/issues/248),
+  [#249](https://github.com/dermot-murphy/CStyleCheck/issues/249)).
+- Fixed broken GitHub Wiki links: malformed triple-hyphen slugs for headings containing
+  backticks/parentheses, and a non-functional "Rules and Configuration Reference" link
+  that previously prompted "Create a new page" instead of opening the Rules page
+  (issue [#251](https://github.com/dermot-murphy/CStyleCheck/issues/251)).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Implements **Barr-C:2018** and MISRA-C complementary rules across **64 rule IDs*
 📖 **[Rules and Configuration Reference](Rules-and-Configuration.md)** — full
 documentation for all 64 rules with YAML configuration and annotated C examples.
 
+Draft companion documents (pending rule population, not yet authoritative):
+[Embedded C Style Guide](embedded_c_style_guide.md) ·
+[Embedded C Coding Standard](embedded_c_coding_standard.md) ·
+[External C Coding Standards — Survey and Analysis](external_standards_analysis.md)
+
 ---
 
 ## Repository layout
@@ -64,7 +69,7 @@ tests/
     test_dictionaries.py    #  32 tests: dict file loading and CLI flags
     test_misc_improvements.py #  77 tests: unsigned_suffix, loop vars, numerics
     test_defines.py         #  16 tests: constant.* / macro.*
-    test_variables.py       #  35 tests: all variable.* rules
+    test_variables.py       #  43 tests: all variable.* rules
     test_functions.py       #  14 tests: function.*
     test_typedefs.py        #   8 tests: typedef.*
     test_enums.py           #  11 tests: enum.*
@@ -96,7 +101,7 @@ tests/
     test_function_length.py #  11 tests: misc.function_length
     test_function_doc_header.py # 12 tests: misc.function_doc_header
     test_assert_density.py  #   8 tests: misc.assert_density
-    test_null_statement_comment.py # 9 tests: misc.null_statement_comment
+    test_null_statement_comment.py # 10 tests: misc.null_statement_comment
     test_declaration_spacing.py #  8 tests: misc.declaration_spacing
     test_file_length.py     #   8 tests: misc.file_length
     test_reserved_header_name.py # 10 tests: misc.reserved_header_name
@@ -104,11 +109,14 @@ tests/
     test_macro_multistatement_wrapper.py # 9 tests: macro.multistatement_wrapper
     test_identifier_length.py #  10 tests: naming.identifier_length
     test_no_single_char_identifiers.py # 8 tests: naming.no_single_char_identifiers
+    test_config_loading.py  #  13 tests: rules.yml / config loading edge cases
+    test_preprocessor.py    #  76 tests: comment/string stripping, token extraction
+    test_update_config.py   #  27 tests: per-directory and config merge updates
 Dockerfile/
     Dockerfile               # multi-platform Docker image
     .dockerignore
 .github/workflows/
-    cstylecheck_tests.yml      # runs the test suite on every commit (1143 tests)
+    cstylecheck_tests.yml      # runs the test suite on every commit (1152 tests)
     rules.yml    # runs linter + trend page on C source commits
     docker_publish.yml       # builds and pushes image to GHCR and Docker Hub
     wiki_publish.yml         # publishes GitHub Wiki from README + ASPICE docs
@@ -441,7 +449,7 @@ suppressed rule, delete its entries from the baseline and commit.
 #### Package refactor
 
 The monolithic `cstylecheck.py` (~3 200 lines) has been split into a proper Python package
-(`src/cstylecheck/`) with 10 focused sub-modules. The CLI entry point `cstylecheck` and all
+(`src/cstylecheck/`) with 12 focused sub-modules. The CLI entry point `cstylecheck` and all
 existing command-line flags are fully backward-compatible — nothing changes for users.
 
 #### Three new lint rules
@@ -461,6 +469,21 @@ prefixes, per-file exclusions, GitHub annotations, case-pattern helpers, and thr
 #### Coverage gate: 85% combined (statement + branch)
 
 Subprocess coverage now captures the CLI entry point in CI; `--cov-fail-under=85` enforced.
+
+### New in v1.3.0 (2026-06-05)
+
+- **Inline suppression comments** — `// cstylecheck: disable=rule.id` (same-line),
+  `disable-next-line=`, and paired `disable=`/`enable=` block directives.
+- **Auto-fix mode** (`--fix`, `--dry-run`, `--safe-only`) — applies safe mechanical fixes
+  such as `misc.unsigned_suffix` and `misc.lowercase_l_suffix` in place.
+- **Config wizard and presets** (`--init`, `--preset barr-c|minimal|misra`) — interactive
+  `.cstylecheck.yml` generation, or a pre-built preset written non-interactively.
+- **Per-directory config** (`--per-dir-config`) — deep-merges the nearest `.cstylecheck.yml`
+  found walking up from each source file, honouring `root: true`.
+- **HTML report output** (`--output-format html`) — self-contained report with summary
+  cards and per-file violation tables.
+
+#### Test suite: 1152 tests across 49 modules
 
 ---
 

--- a/docs/aspice/CStyleCheck_ACQ4_Supplier_Monitoring_Plan.md
+++ b/docs/aspice/CStyleCheck_ACQ4_Supplier_Monitoring_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-ACQ4-001 | **Version** | 1.1 |
-| **Project** | CStyleCheck | **Date** | 2026-05-28 |
+| **Document ID** | CSC-ACQ4-001 | **Version** | 1.2 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | ACQ.4 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.2 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.1 | 2026-05-28 | Claude | Reviewed and updated for v1.1.0 release; revision history maintained per ASPICE GP 2.2.4 |
 | 1.0 | 2026-04-12 | Claude | Initial release |
 
@@ -43,10 +44,10 @@ There are no contracted Tier-1 software suppliers or subcontractors.
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-MAN3-001 | Project Management Plan | 1.0 |
-| CSC-MAN5-001 | Risk Management Plan | 1.0 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.1 |
-| CSC-SUP9-001 | Problem Resolution Management Plan | 1.0 |
+| CSC-MAN3-001 | Project Management Plan | 1.6 |
+| CSC-MAN5-001 | Risk Management Plan | 1.3 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP9-001 | Problem Resolution Management Plan | 1.2 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_DEV001_AI_Authorship_Deviation.md
+++ b/docs/aspice/CStyleCheck_DEV001_AI_Authorship_Deviation.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-DEV-001 | **Version** | 1.1 |
-| **Project** | CStyleCheck | **Date** | 2026-05-28 |
+| **Document ID** | CSC-DEV-001 | **Version** | 1.2 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Approved | **Classification** | Internal |
 | **Author** | Dermot Murphy | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | PA 2.1, GP 2.1.6 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.2 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.0 | 2026-05-28 | Dermot Murphy | Initial deviation record — closes issue #52 |
 
 ---
@@ -131,7 +132,7 @@ This deviation is accepted on the basis that Dermot Murphy is the sole accountab
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-PA2-001 | Process Capability Records | 1.1 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.1 |
-| CSC-SUP9-001 | Problem Resolution Management Plan | 1.0 |
+| CSC-PA2-001 | Process Capability Records | 1.9 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP9-001 | Problem Resolution Management Plan | 1.2 |
 | GitHub Issue #52 | AI listed as Author across all 18 ASPICE work products | — |

--- a/docs/aspice/CStyleCheck_DEV002_Independent_Review_Deviation.md
+++ b/docs/aspice/CStyleCheck_DEV002_Independent_Review_Deviation.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-DEV-002 | **Version** | 1.0 |
-| **Project** | CStyleCheck | **Date** | 2026-05-28 |
+| **Document ID** | CSC-DEV-002 | **Version** | 1.1 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Approved | **Classification** | Internal |
 | **Author** | Dermot Murphy | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | PA 2.2, GP 2.2.3 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.1 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.0 | 2026-05-28 | Dermot Murphy | Initial deviation record — closes issue #61 |
 
 ---
@@ -150,9 +151,9 @@ This deviation is accepted on the basis that CStyleCheck is a single-person proj
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-DEV-001 | Process Deviation — AI-Assisted Authorship | 1.1 |
-| CSC-PA2-001 | Process Capability Records | 1.1 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.1 |
-| CSC-SUP9-001 | Problem Resolution Management Plan | 1.0 |
-| CSC-SUP10-001 | Change Request Plan | 1.0 |
+| CSC-DEV-001 | Process Deviation — AI-Assisted Authorship | 1.2 |
+| CSC-PA2-001 | Process Capability Records | 1.9 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP9-001 | Problem Resolution Management Plan | 1.2 |
+| CSC-SUP10-001 | Change Request Plan | 1.2 |
 | GitHub Issue #61 | Designate independent reviewer (not approver) for SWE1, SWE4, SWE6 work products | — |

--- a/docs/aspice/CStyleCheck_MAN3_Project_Management_Plan.md
+++ b/docs/aspice/CStyleCheck_MAN3_Project_Management_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-MAN3-001 | **Version** | 1.5 |
-| **Project** | CStyleCheck | **Date** | 2026-06-04 |
+| **Document ID** | CSC-MAN3-001 | **Version** | 1.6 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | MAN.3 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.6 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.5 | 2026-06-04 | Claude | Deep accuracy audit: fix §3 Purpose version text v1.0.0→v1.2.0, update SWE1-001 version in §3.2 (1.3→1.5) — resolves issue #163 |
 | 1.4 | 2026-06-04 | Claude | Automated accuracy audit: fix §3.1 version, §4.1 rule count 48→53 and package reference, update test count and module count, update referenced doc versions, update WBS-10 status — resolves issue #163 |
 | 1.3 | 2026-05-28 | Dermot Murphy | §6 WBS-10 to WBS-16: update status with concrete facts (839 tests, release dates, blocked items) — closes issue #154 |
@@ -49,11 +50,11 @@ This Project Management Plan (PMP) defines the project scope, lifecycle, work br
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SYS2-001 | System Requirements Specification | 1.4 |
-| CSC-SWE1-001 | Software Requirements Specification | 1.5 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.4 |
-| CSC-MAN5-001 | Risk Management Plan | 1.2 |
-| CSC-SUP1-001 | Quality Assurance Plan | 1.2 |
+| CSC-SYS2-001 | System Requirements Specification | 1.6 |
+| CSC-SWE1-001 | Software Requirements Specification | 1.9 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-MAN5-001 | Risk Management Plan | 1.3 |
+| CSC-SUP1-001 | Quality Assurance Plan | 1.4 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_MAN5_Risk_Management_Plan.md
+++ b/docs/aspice/CStyleCheck_MAN5_Risk_Management_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-MAN5-001 | **Version** | 1.2 |
-| **Project** | CStyleCheck | **Date** | 2026-05-28 |
+| **Document ID** | CSC-MAN5-001 | **Version** | 1.3 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | MAN.5 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.3 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.2 | 2026-05-28 | Dermot Murphy | RISK-003: add Dependabot; update owner and review date. RISK-005: add CONTRIBUTING.md and AI-reproducibility mitigations; update owner and review date — closes issue #155 |
 | 1.1 | 2026-05-28 | Claude | Reviewed and updated for v1.1.0 release; revision history maintained per ASPICE GP 2.2.4 |
 | 1.0 | 2026-04-12 | Claude | Initial release |
@@ -34,9 +35,9 @@ This Risk Management Plan defines the risk identification, analysis, treatment, 
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-MAN3-001 | Project Management Plan | 1.0 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.1 |
-| CSC-SUP10-001 | Change Request Management Plan | 1.0 |
+| CSC-MAN3-001 | Project Management Plan | 1.6 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP10-001 | Change Request Management Plan | 1.2 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_PA2_Capability_Records.md
+++ b/docs/aspice/CStyleCheck_PA2_Capability_Records.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-PA2-001 | **Version** | 1.8 |
-| **Project** | CStyleCheck | **Date** | 2026-06-04 |
+| **Document ID** | CSC-PA2-001 | **Version** | 1.9 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | PA 2.1, PA 2.2 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-18 | Claude | ASPICE audit #254 — update §4.1/§5.4/§6 SWE.4 test count 965→1152; mark CI-017 released at v1.3.0 |
 | 1.8 | 2026-06-04 | Claude | Deep accuracy audit: fix §4.1 SWE.3 unit count (46→90), SUP.8 CI count (27→34), §6 SWE.3 (89→90) and SUP.8 (29→34); update §5.4 document version table — resolves issue #163 |
 | 1.7 | 2026-06-04 | Claude | Automated accuracy audit: update §4.1 SWE.4 test count ≥500→965, §5.2 SWE.4 839→965, §5.4 CI-017 839→965 and SUP9/10/ACQ4 versions, §6 SWE.4 839→965 — resolves issue #163 |
 | 1.6 | 2026-05-29 | Claude | §5.4: mark all work products Released at v1.2.0 tag; update SVD to 1.2, PA2 to 1.6, AUD-001 to Released |
@@ -56,7 +57,7 @@ For each assessed process, performance objectives are defined in the table below
 | SWE.1 | 70 software requirements defined, reviewed, approved; 100% traceable to SYS.2 | CSC-SWE1-001 §4.15 verification criteria | ✅ Defined |
 | SWE.2 | Architecture reviewed; all SWE.1 requirements mapped to components; interfaces defined | CSC-SWE2-001 §10 traceability | ✅ Defined |
 | SWE.3 | All 90 units designed; algorithmic specification complete; resource usage documented | CSC-SWE3-001 §4 unit catalogue | ✅ Defined |
-| SWE.4 | ≥ 85% combined statement + branch coverage (CI gate); ≥ 90% statement / ≥ 85% branch (long-term target); all 965 unit tests PASS on Python 3.10/11/12 | CSC-SWE4-001 §4.2 coverage criteria | ✅ Defined |
+| SWE.4 | ≥ 85% combined statement + branch coverage (CI gate); ≥ 90% statement / ≥ 85% branch (long-term target); all 1152 unit tests PASS on Python 3.10/11/12 | CSC-SWE4-001 §4.2 coverage criteria | ✅ Defined |
 | SWE.5 | All 13 SIT integration test cases PASS; all 10 SWA interfaces covered | CSC-SWE5-001 §3.3 verification criteria | ✅ Defined |
 | SWE.6 | All 12 SWQ qualification test cases PASS; 100% SW requirements coverage; release gate met | CSC-SWE6-001 §3.3 qualification criteria | ✅ Defined |
 | MAN.3 | All WBS work packages completed; milestones achieved within schedule | CSC-MAN3-001 §8 schedule | ✅ Defined |
@@ -206,7 +207,7 @@ All work products are reviewed before approval according to the following schedu
 | CSC-AUD-003 | ASPICE Internal Audit — Accuracy (2026-06-04) | 1.0 | Released | issue #163 audit |
 | CSC-AUD-004 | ASPICE Internal Audit — Deep Accuracy (2026-06-04) | 1.0 | Released | issue #163 deep audit |
 | CI-001 | `src/cstylecheck/` package | 1.2.0 | Released | v1.2.0 tag |
-| CI-017 | Test suite (965 tests) | 1.2.0 | Released | v1.2.0 tag |
+| CI-017 | Test suite (1152 tests) | 1.3.0 | Released | v1.3.0+ |
 
 ---
 
@@ -223,7 +224,7 @@ The table below summarises all assessed processes and their CL2 PA achievement e
 | SWE.1 | 70+ SW requirements defined | Objectives: §4.1; strategy: §4.2 | CSC-SWE1-001 reviewed; in CM | **L** | #148, #149 |
 | SWE.2 | 7 components, 10 interfaces defined | Objectives: §4.1 | CSC-SWE2-001 reviewed; in CM | **L** | #146 |
 | SWE.3 | 90 units with algorithmic specs | Objectives: §4.1 | CSC-SWE3-001 reviewed; in CM | **L** | #147, #148 |
-| SWE.4 | 965 unit tests; self-check CI; 85% cov. | Objectives: §4.1; coverage targets | CSC-SWE4-001 reviewed; CI evidence | **L** | — |
+| SWE.4 | 1152 unit tests; self-check CI; 85% cov. | Objectives: §4.1; coverage targets | CSC-SWE4-001 reviewed; CI evidence | **L** | — |
 | SWE.5 | 13 SIT tests covering all interfaces | Objectives: §4.1 | CSC-SWE5-001 reviewed; in CM | **P** ⚠️ | #152 |
 | SWE.6 | 12 SWQ tests; 100% SW-REQ coverage | Objectives: §4.1; release gate | CSC-SWE6-001 reviewed; CI evidence | **L** | #151, #152 |
 | MAN.3 | WBS, schedule, monitoring defined | Objectives: §4.1; §4.3 monitoring | CSC-MAN3-001 reviewed; in CM | **L** | #154 |

--- a/docs/aspice/CStyleCheck_STD_001_Industry_Standards_Comparison.md
+++ b/docs/aspice/CStyleCheck_STD_001_Industry_Standards_Comparison.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-STD-001 | **Version** | 1.1 |
-| **Project** | CStyleCheck | **Date** | 2026-06-06 |
+| **Document ID** | CSC-STD-001 | **Version** | 1.2 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.1 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.2 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.1 | 2026-06-06 | Claude | Add `misc.file_length` (max lines per file) as unique opportunity #12; create change-request issues for all 12 opportunities |
 | 1.0 | 2026-06-06 | Claude | Initial document — full survey of 11 industry standards with coverage matrix; closes issue #217 |
 
@@ -40,9 +41,9 @@ The findings are presented in a unified coverage matrix and a prioritised list o
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.6 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.8 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.8 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.10 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SUP10_Change_Request_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP10_Change_Request_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP10-001 | **Version** | 1.1 |
-| **Project** | CStyleCheck | **Date** | 2026-05-28 |
+| **Document ID** | CSC-SUP10-001 | **Version** | 1.2 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.10 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.2 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.1 | 2026-05-28 | Claude | Reviewed and updated for v1.1.0 release; revision history maintained per ASPICE GP 2.2.4 |
 | 1.0 | 2026-04-12 | Claude | Initial release |
 
@@ -35,9 +36,9 @@ A **change request (CR)** covers any planned modification to a baselined work pr
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SUP8-001 | Configuration Management Plan | 1.1 |
-| CSC-SUP9-001 | Problem Resolution Management Plan | 1.0 |
-| CSC-MAN3-001 | Project Management Plan | 1.0 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP9-001 | Problem Resolution Management Plan | 1.2 |
+| CSC-MAN3-001 | Project Management Plan | 1.6 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP1-001 | **Version** | 1.3 |
-| **Project** | CStyleCheck | **Date** | 2026-06-04 |
+| **Document ID** | CSC-SUP1-001 | **Version** | 1.4 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.1 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.4 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.3 | 2026-06-04 | Claude | Deep accuracy audit: fix §3 Purpose version text, update §3.1 referenced doc versions (all 5 stale), update QO-006 and §5.4 to v1.2.0, clarify §7 version language — resolves issue #163 |
 | 1.2 | 2026-05-28 | Dermot Murphy | §4 QO-003/QO-004: document 85% combined CI gate as enforced threshold; 90% statement as aspirational target; align §5.4 checklist — closes issue #151 |
 | 1.1 | 2026-05-28 | Claude | Reviewed and updated for v1.1.0 release; revision history maintained per ASPICE GP 2.2.4 |
@@ -37,11 +38,11 @@ QA activities for CStyleCheck verify that project processes are followed as plan
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-MAN3-001 | Project Management Plan | 1.5 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.6 |
-| CSC-SUP9-001 | Problem Resolution Management Plan | 1.1 |
-| CSC-SUP10-001 | Change Request Management Plan | 1.1 |
-| CSC-SWE4-001 | Unit Verification Specification | 1.6 |
+| CSC-MAN3-001 | Project Management Plan | 1.6 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP9-001 | Problem Resolution Management Plan | 1.2 |
+| CSC-SUP10-001 | Change Request Management Plan | 1.2 |
+| CSC-SWE4-001 | Unit Verification Specification | 1.11 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SUP8_CM_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP8_CM_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP8-001 | **Version** | 1.6 |
-| **Project** | CStyleCheck | **Date** | 2026-06-04 |
+| **Document ID** | CSC-SUP8-001 | **Version** | 1.7 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.8 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.7 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.6 | 2026-06-04 | Claude | Deep accuracy audit: fix CI-024 workflow filename (rules.yml→cstylecheck_rules.yml), fix §7.5 reference, update SWE1-001 version in §3.3 — resolves issue #163 |
 | 1.5 | 2026-06-04 | Claude | Automated accuracy audit: fix §3.1 version text v1.0.0→v1.2.0, update referenced doc versions — resolves issue #163 |
 | 1.4 | 2026-05-28 | Dermot Murphy | Add CI-034 (wiki_publish.yml) to CI inventory — closes issue #150 |
@@ -54,9 +55,9 @@ This plan applies to all configuration items produced by the CStyleCheck project
 | Document ID | Title | Version |
 |---|---|---|
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
-| CSC-SUP9-001 | CStyleCheck Problem Resolution Management Plan | 1.1 |
-| CSC-SUP10-001 | CStyleCheck Change Request Management Plan | 1.1 |
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.5 |
+| CSC-SUP9-001 | CStyleCheck Problem Resolution Management Plan | 1.2 |
+| CSC-SUP10-001 | CStyleCheck Change Request Management Plan | 1.2 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SUP9_Problem_Resolution_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP9_Problem_Resolution_Plan.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP9-001 | **Version** | 1.1 |
-| **Project** | CStyleCheck | **Date** | 2026-05-28 |
+| **Document ID** | CSC-SUP9-001 | **Version** | 1.2 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.9 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.2 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.1 | 2026-05-28 | Claude | Reviewed and updated for v1.1.0 release; revision history maintained per ASPICE GP 2.2.4 |
 | 1.0 | 2026-04-12 | Claude | Initial release |
 
@@ -35,10 +36,10 @@ A **problem** is any unintended behaviour, defect, failure, or non-conformance d
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-MAN3-001 | Project Management Plan | 1.0 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.1 |
-| CSC-SUP10-001 | Change Request Management Plan | 1.0 |
-| CSC-SUP1-001 | Quality Assurance Plan | 1.0 |
+| CSC-MAN3-001 | Project Management Plan | 1.6 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP10-001 | Change Request Management Plan | 1.2 |
+| CSC-SUP1-001 | Quality Assurance Plan | 1.4 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.8 |
-| **Project** | CStyleCheck | **Date** | 2026-06-08 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.9 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.8 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-18 | Claude | ASPICE audit #254 — fix internally inconsistent test counts: §3/§5.4/§8.2/§9 now all read 1152 tests / 49 modules (previously a mix of 1143 and stale 1041) |
 | 1.8 | 2026-06-08 | Claude | ASPICE audit #238 — update SWE1/SWE3/SWE4 version refs; correct rule count 53→64; update test count 1041→1143, 38→49 modules |
 | 1.7 | 2026-06-05 | Claude | v1.3.0 release — update all version identifiers, release summary, change log, upgrade notes |
 | 1.6 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
@@ -41,15 +42,15 @@ This document satisfies the release-identification and configuration-status-acco
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.8 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.7 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.9 |
-| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.9 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.4 |
-| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.5 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.6 |
-| CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.3 |
-| CSC-MAN3-001 | CStyleCheck Project Management Plan | 1.5 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.8 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.10 |
+| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.11 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.5 |
+| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.6 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.4 |
+| CSC-MAN3-001 | CStyleCheck Project Management Plan | 1.6 |
 
 ---
 
@@ -125,7 +126,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 ### 5.4 Test Suite
 
-**Total: 1143 tests across 49 modules** — all passing.
+**Total: 1152 tests across 49 modules** — all passing.
 
 | Item | Test Count | Description |
 |---|---|---|
@@ -135,7 +136,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 | `tests/test_dictionaries.py` | 32 | dict file loading and CLI flags |
 | `tests/test_misc_improvements.py` | 77 | unsigned_suffix, loop vars, numerics |
 | `tests/test_defines.py` | 16 | constant.* / macro.* |
-| `tests/test_variables.py` | 35 | all variable.* rules |
+| `tests/test_variables.py` | 43 | all variable.* rules |
 | `tests/test_functions.py` | 14 | function.* |
 | `tests/test_typedefs.py` | 8 | typedef.* |
 | `tests/test_enums.py` | 11 | enum.* |
@@ -170,7 +171,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 | `tests/test_function_length.py` | 11 | `misc.function_length` rule |
 | `tests/test_function_doc_header.py` | 12 | `misc.function_doc_header` rule |
 | `tests/test_assert_density.py` | 8 | `misc.assert_density` rule |
-| `tests/test_null_statement_comment.py` | 9 | `misc.null_statement_comment` rule |
+| `tests/test_null_statement_comment.py` | 10 | `misc.null_statement_comment` rule |
 | `tests/test_declaration_spacing.py` | 8 | `misc.declaration_spacing` rule |
 | `tests/test_file_length.py` | 8 | `misc.file_length` rule |
 | `tests/test_reserved_header_name.py` | 10 | `misc.reserved_header_name` rule |
@@ -178,31 +179,31 @@ Platforms: `linux/amd64`, `linux/arm64`.
 | `tests/test_macro_multistatement_wrapper.py` | 9 | `macro.multistatement_wrapper` rule |
 | `tests/test_identifier_length.py` | 10 | `naming.identifier_length` rule |
 | `tests/test_no_single_char_identifiers.py` | 8 | `naming.no_single_char_identifiers` rule |
-| **Total** | **1143** | |
+| **Total** | **1152** | |
 
 ### 5.5 Documentation
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SVD-001 | Software Version Description (this document) | 1.7 |
-| CSC-SWE1-001 | Software Requirements Specification | 1.6 |
-| CSC-SWE2-001 | Software Architecture Design | 1.5 |
-| CSC-SWE3-001 | Software Detailed Design | 1.6 |
-| CSC-SWE4-001 | Software Unit Verification Specification | 1.6 |
-| CSC-SWE5-001 | Software Integration Test Specification | 1.3 |
-| CSC-SWE6-001 | Software Qualification Test Specification | 1.4 |
-| CSC-SYS2-001 | System Requirements Specification | 1.5 |
-| CSC-SYS3-001 | System Architecture Design | 1.4 |
-| CSC-SYS4-001 | System Integration Test Specification | 1.3 |
-| CSC-SYS5-001 | System Verification Specification | 1.4 |
-| CSC-MAN3-001 | Project Management Plan | 1.5 |
-| CSC-MAN5-001 | Risk Management Plan | 1.2 |
-| CSC-SUP1-001 | Quality Assurance Plan | 1.3 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.6 |
-| CSC-SUP9-001 | Problem Resolution Plan | 1.1 |
-| CSC-SUP10-001 | Change Request Plan | 1.1 |
-| CSC-ACQ4-001 | Supplier Monitoring Plan | 1.1 |
-| CSC-PA2-001 | Capability Level 2 Records | 1.8 |
+| CSC-SVD-001 | Software Version Description (this document) | 1.9 |
+| CSC-SWE1-001 | Software Requirements Specification | 1.9 |
+| CSC-SWE2-001 | Software Architecture Design | 1.8 |
+| CSC-SWE3-001 | Software Detailed Design | 1.10 |
+| CSC-SWE4-001 | Software Unit Verification Specification | 1.11 |
+| CSC-SWE5-001 | Software Integration Test Specification | 1.5 |
+| CSC-SWE6-001 | Software Qualification Test Specification | 1.6 |
+| CSC-SYS2-001 | System Requirements Specification | 1.6 |
+| CSC-SYS3-001 | System Architecture Design | 1.5 |
+| CSC-SYS4-001 | System Integration Test Specification | 1.4 |
+| CSC-SYS5-001 | System Verification Specification | 1.6 |
+| CSC-MAN3-001 | Project Management Plan | 1.6 |
+| CSC-MAN5-001 | Risk Management Plan | 1.3 |
+| CSC-SUP1-001 | Quality Assurance Plan | 1.4 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP9-001 | Problem Resolution Plan | 1.2 |
+| CSC-SUP10-001 | Change Request Plan | 1.2 |
+| CSC-ACQ4-001 | Supplier Monitoring Plan | 1.2 |
+| CSC-PA2-001 | Capability Level 2 Records | 1.9 |
 | CSC-DEV001 | AI Authorship Deviation Record | 1.0 |
 | CSC-DEV002 | Independent Review Deviation Record | 1.0 |
 
@@ -268,7 +269,7 @@ All of the following CI checks passed on the `develop` branch before tag creatio
 
 ### 8.2 Qualification Test Status
 
-All 1041 tests pass with no failures. Test counts per module are documented in §5.4.
+All 1152 tests pass with no failures. Test counts per module are documented in §5.4.
 
 ### 8.3 Docker Build
 
@@ -328,7 +329,7 @@ The `src/cstylecheck.py` entry point shim is unchanged. All 53 rule IDs, existin
 | Integration Tests | CSC-SWE5-001 | 1.4 | Released |
 | Qualification Tests | CSC-SWE6-001 | 1.5 | Released |
 | Source Code | `src/cstylecheck/` (package) | 1.3.0 | Released |
-| Test Suite | `tests/` (1041 tests) | 1.3.0 | Released |
+| Test Suite | `tests/` (1152 tests) | 1.3.0 | Released |
 | CI Automation | `.github/workflows/` + `scripts/ci/` | 1.3.0 | Released |
 | Docker Image | `Dockerfile/Dockerfile` | 1.3.0 | Released |
 | Change Log | `CHANGELOG.md` | 1.3.0 | Released |

--- a/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
+++ b/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE1-001 | **Version** | 1.8 |
-| **Project** | CStyleCheck | **Date** | 2026-06-08 |
+| **Document ID** | CSC-SWE1-001 | **Version** | 1.9 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.1 |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.8 | 2026-06-08 | Claude | Add SWE1-078 to SWE1-088 for 11 new rules (issues #221–#232); update RTM |
 | 1.7 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.6 | 2026-06-04 | Claude | Add SWE1-072 to SWE1-076 for five new features (inline suppression, --fix, --init/--preset, per-dir config, HTML output) — issues #188 #189 #190 #193 #192 |
@@ -46,10 +47,10 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.1 — Software Requir
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.5 |
-| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.4 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.7 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.5 |
+| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.6 |
+| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.8 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 | Barr-C:2018 | Barr Group Embedded C Coding Standard | 2018 |
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
 

--- a/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
+++ b/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE2-001 | **Version** | 1.7 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SWE2-001 | **Version** | 1.8 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.2 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.8 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.7 | 2026-06-08 | Claude | ASPICE audit #238 — add COMP-05h (naming rules); extend §10 RTM with SWE1-078–088 |
 | 1.6 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.5 | 2026-06-04 | Claude | Add COMP-08 (Fixer), COMP-09 (Config Wizard), COMP-10 (Per-dir Config); add `parse_inline_suppressions` to COMP-04; add `_violations_to_html` to COMP-07; update §8.1 sequence; update §10 RTM — issues #188 #189 #190 #193 #192 |
@@ -41,10 +42,10 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.2 — Software Archit
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.4 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.8 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.5 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
+| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.10 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE3-001 | **Version** | 1.9 |
-| **Project** | CStyleCheck | **Date** | 2026-06-08 |
+| **Document ID** | CSC-SWE3-001 | **Version** | 1.10 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.3 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.10 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.9 | 2026-06-08 | Claude | Add UNIT-102 to UNIT-112 for 11 new rules (issues #221–#232); update §8 traceability |
 | 1.8 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.6 | 2026-06-04 | Claude | Add UNIT-95 to UNIT-101 for five new features (inline suppression, fixer, wizard, per-dir config, HTML output); update §4.1 package structure; update §8 traceability — issues #188 #189 #190 #193 #192 |
@@ -40,9 +41,9 @@ This document defines the detailed design of each software unit in **CStyleCheck
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.8 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.7 |
-| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.8 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.8 |
+| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.11 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
+++ b/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE4-001 | **Version** | 1.10 |
-| **Project** | CStyleCheck | **Date** | 2026-06-08 |
+| **Document ID** | CSC-SWE4-001 | **Version** | 1.11 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.4 |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.11 | 2026-06-18 | Claude | ASPICE audit #254 — update §6 test total 1143→1152 (49 modules) |
 | 1.10 | 2026-06-08 | Claude | ASPICE audit #238 — correct CSC-SWE3 version reference 1.8→1.9 in §3.1 |
 | 1.9 | 2026-06-08 | Claude | Add 11 new test modules (102 tests) for issues #221–#232; update §6 totals; update §7 traceability |
 | 1.8 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
@@ -45,10 +46,10 @@ Unit verification covers both dynamic testing (pytest test suite) and static ver
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.9 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.4 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.4 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.10 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.5 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 
 ---
 
@@ -119,7 +120,7 @@ Tests are organised by test module. Each module maps to one or more COMP-05 sub-
 
 ---
 
-### 5.1 Variable Rules — `test_variables.py` (35 tests)
+### 5.1 Variable Rules — `test_variables.py` (43 tests)
 
 | TC-ID | Test Name | Rule Verified | Pass Condition |
 |---|---|---|---|
@@ -353,7 +354,7 @@ Each test class verifies: positive detection, negative non-detection, disabled-r
 
 | Test Module | Tests | Pass | Fail | Coverage Contribution |
 |---|---|---|---|---|
-| `test_variables.py` | 35 | 35 | 0 | `_check_variables` |
+| `test_variables.py` | 43 | 43 | 0 | `_check_variables` |
 | `test_functions.py` | 14 | 14 | 0 | `_check_functions` |
 | `test_defines.py` | 16 | 16 | 0 | `_check_defines` |
 | `test_typedefs.py` | 8 | 8 | 0 | `_check_typedefs` |
@@ -394,7 +395,7 @@ Each test class verifies: positive detection, negative non-detection, disabled-r
 | `test_function_length.py` | 11 | 11 | 0 | COMP-01 (`_check_function_length`) |
 | `test_function_doc_header.py` | 12 | 12 | 0 | COMP-01 (`_check_function_doc_header`) |
 | `test_assert_density.py` | 8 | 8 | 0 | COMP-01 (`_check_assert_density`) |
-| `test_null_statement_comment.py` | 9 | 9 | 0 | COMP-01 (`_check_null_statement_comment`) |
+| `test_null_statement_comment.py` | 10 | 10 | 0 | COMP-01 (`_check_null_statement_comment`) |
 | `test_declaration_spacing.py` | 8 | 8 | 0 | COMP-01 (`_check_declaration_spacing`) |
 | `test_file_length.py` | 8 | 8 | 0 | COMP-01 (`_check_file_length`) |
 | `test_reserved_header_name.py` | 10 | 10 | 0 | COMP-01 (`_check_reserved_header_name`) |
@@ -402,7 +403,7 @@ Each test class verifies: positive detection, negative non-detection, disabled-r
 | `test_macro_multistatement_wrapper.py` | 9 | 9 | 0 | COMP-01 (`_check_macro_multistatement_wrapper`) |
 | `test_identifier_length.py` | 10 | 10 | 0 | COMP-01 (`_check_identifier_length`) |
 | `test_no_single_char_identifiers.py` | 8 | 8 | 0 | COMP-01 (`_check_no_single_char_identifiers`) |
-| **Total** | **1143** | **1143** | **0** | All rules covered — 49 modules |
+| **Total** | **1152** | **1152** | **0** | All rules covered — 49 modules |
 
 **Statement Coverage (v1.1.0 CI — unit tests excl. subprocess):** 86% (1,694 statements, 243 missed)
 **Statement Coverage (v1.2.0 CI — 1041 tests incl. subprocess):** 89.8% (1,694 statements, 172 missed)

--- a/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
+++ b/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE5-001 | **Version** | 1.4 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SWE5-001 | **Version** | 1.5 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.5 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.5 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.4 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.3 | 2026-06-04 | Claude | Automated accuracy audit: update referenced doc versions §3.1, test count 839→965 in overall result — resolves issue #163 |
 | 1.2 | 2026-05-28 | Dermot Murphy | Populate all SIT-001 to SIT-013 execution results (PASS); commit 93178cd, 2026-05-28 — closes issue #152 |
@@ -40,10 +41,10 @@ The primary integration test suite is `tests/test_cli.py`, which invokes `cstyle
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.5 |
-| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.8 |
-| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.4 |
-| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.3 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.8 |
+| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.11 |
+| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.6 |
+| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.4 |
 
 ### 3.2 Test Environment
 

--- a/docs/aspice/CStyleCheck_SWE6_Qualification_Test.md
+++ b/docs/aspice/CStyleCheck_SWE6_Qualification_Test.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE6-001 | **Version** | 1.5 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SWE6-001 | **Version** | 1.6 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.6 |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.6 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.5 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.4 | 2026-06-04 | Claude | Automated accuracy audit: fix version text v1.0.0→v1.2.x, rule count 48→53, update referenced doc versions, resolve §3.2 placeholders — resolves issue #163 |
 | 1.3 | 2026-05-28 | Dermot Murphy | Complete §8 release gate checklist for v1.1.0; populate §8 open issues — closes issue #53 |
@@ -41,10 +42,10 @@ Qualification tests (SWE.6) differ from integration tests (SWE.5) in that they v
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.7 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.4 |
-| CSC-SYS5-001 | CStyleCheck System Verification Report | 1.5 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.4 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 1.9 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.5 |
+| CSC-SYS5-001 | CStyleCheck System Verification Report | 1.6 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 
 ### 3.2 Software Configuration Under Test
 

--- a/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
+++ b/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS2-001 | **Version** | 1.5 |
-| **Project** | CStyleCheck | **Date** | 2026-06-04 |
+| **Document ID** | CSC-SYS2-001 | **Version** | 1.6 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SYS.2 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.6 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.5 | 2026-06-04 | Claude | Add SYS-F-041 to SYS-F-045 for five new features (inline suppression, --fix, --init/--preset, per-dir config, HTML output); update §6 RTM — issues #188 #189 #190 #193 #192 |
 | 1.4 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.2 "three modes" text (listed 4 modes), update §3.3 referenced doc versions — resolves issue #163 |
 | 1.3 | 2026-06-04 | Claude | Automated accuracy audit: fix §3.1 and SYS-F-011 rule count 48→53; update referenced doc versions — resolves issue #163 |
@@ -54,8 +55,8 @@ The system is deployed in four integration modes:
 |---|---|---|
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
 | Barr-C:2018 | Barr Group Embedded C Coding Standard | 2018 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.6 |
-| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.3 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
 
 ### 3.4 Glossary
 

--- a/docs/aspice/CStyleCheck_SYS3_System_Architecture.md
+++ b/docs/aspice/CStyleCheck_SYS3_System_Architecture.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS3-001 | **Version** | 1.4 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SYS3-001 | **Version** | 1.5 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SYS.3 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.5 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.4 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.3 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.1 version text, update §3.2 referenced doc versions — resolves issue #163 |
 | 1.2 | 2026-05-28 | Claude | Update §5/§6/§8 to reflect package refactor (issue #144): replace single `cstylecheck.py` references with package sub-modules — closes issue #146 |
@@ -39,9 +40,9 @@ This System Architecture Description defines the top-level structural and behavi
 | Document ID | Title | Version |
 |---|---|---|
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
-| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.5 |
-| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.3 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.5 |
+| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.6 |
+| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.4 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SYS4_Integration_Test_Spec.md
+++ b/docs/aspice/CStyleCheck_SYS4_Integration_Test_Spec.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS4-001 | **Version** | 1.3 |
-| **Project** | CStyleCheck | **Date** | 2026-06-04 |
+| **Document ID** | CSC-SYS4-001 | **Version** | 1.4 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SYS.4 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.4 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.3 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.1 version text, update §3.3 referenced doc versions — resolves issue #163 |
 | 1.2 | 2026-05-28 | Dermot Murphy | Populate all SITC-001 to SITC-014 execution results (PASS); commit 93178cd, 2026-05-28 — closes issue #152 |
 | 1.1 | 2026-05-28 | Claude | Reviewed and updated for v1.1.0 release; revision history maintained per ASPICE GP 2.2.4 |
@@ -49,9 +50,9 @@ SWE.4/SWE.5 unit and component-level tests are documented in the software test s
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.4 |
-| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.3 |
-| CSC-SYS5-001 | CStyleCheck System Verification Report | 1.4 |
+| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.6 |
+| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
+| CSC-SYS5-001 | CStyleCheck System Verification Report | 1.6 |
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
 
 ### 3.4 Test Environment

--- a/docs/aspice/CStyleCheck_SYS5_System_Verification.md
+++ b/docs/aspice/CStyleCheck_SYS5_System_Verification.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS5-001 | **Version** | 1.5 |
-| **Project** | CStyleCheck | **Date** | 2026-06-05 |
+| **Document ID** | CSC-SYS5-001 | **Version** | 1.6 |
+| **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SYS.5 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.6 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.5 | 2026-06-05 | Claude | CSC-AUD-005 corrective action — fix factual errors identified in audit |
 | 1.4 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.1 version text, update §3.2 referenced doc versions, fix VTC-003 header and §6 rule count — resolves issue #163 |
 | 1.3 | 2026-05-28 | Dermot Murphy | Populate all SYS-VTC execution result tables; fill §3.3 configuration; update overall verdict to commit 93178cd, 839 tests PASS — closes issue #152 |
@@ -41,11 +42,11 @@ System verification (SYS.5) differs from system integration testing (SYS.4) in t
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.5 |
-| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.4 |
-| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.3 |
+| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.6 |
+| CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
+| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.4 |
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.5 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 
 ### 3.3 System Configuration Under Test
 

--- a/embedded_c_coding_standard.md
+++ b/embedded_c_coding_standard.md
@@ -4,7 +4,7 @@
 
 | Field | Value |
 |---|---|
-| Document ID | CSC-STD-001 |
+| Document ID | CSC-STD-002 |
 | Title | Embedded C Coding Standard |
 | Version | 1.0 (DRAFT) |
 | Status | Draft — Pending Rule Population |


### PR DESCRIPTION
Syncs PR #255 (ASPICE audit CSC-AUD-006 corrective action — stale test counts, doc-ID collision, cross-reference version drift) from `develop` into `main`.

Closes #254.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_