### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [1.4.0] — 2026-06-18
+
 ### Added
 
 - **`macro.trailing_semicolon` rule** — detects `#define` macros whose expansion ends

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Contributions are very welcome.
 ![Logo](logo/cstylecheck.jpg)
 
 Embedded C Style Compliance Checker for GitHub Actions / pre-commit hooks.
-Implements **Barr-C:2018** and MISRA-C complementary rules across **64 rule IDs**.
+Implements **Barr-C:2018** and MISRA-C complementary rules across **75 rule IDs**.
 
 [![Tests](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/cstylecheck_tests.yml/badge.svg)](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/cstylecheck_tests.yml)
 [![Naming Convention](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dermot-murphy/CStyleCheck/gh-pages/cstylecheck/badge.json)](https://dermot-murphy.github.io/CStyleCheck/cstylecheck/)
 [![Docker](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/docker_publish.yml/badge.svg)](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/docker_publish.yml)
 
 📖 **[Rules and Configuration Reference](Rules-and-Configuration.md)** — full
-documentation for all 64 rules with YAML configuration and annotated C examples.
+documentation for all 75 rules with YAML configuration and annotated C examples.
 
 Draft companion documents (pending rule population, not yet authoritative):
 [Embedded C Style Guide](embedded_c_style_guide.md) ·
@@ -31,7 +31,7 @@ Draft companion documents (pending rule population, not yet authoritative):
 ```
 .pre-commit-hooks.yml   # pre-commit hook definition (id: cstylecheck)
 pyproject.toml           # pip / pipx / pre-commit packaging metadata
-Rules-and-Configuration.md  # wiki: all 64 rules with config and examples
+Rules-and-Configuration.md  # wiki: all 75 rules with config and examples
 src/
     cstylecheck.py          # thin CLI shim (backward-compatible entry point)
     cstylecheck/            # checker package (12 sub-modules)
@@ -41,7 +41,7 @@ src/
         models.py           # Violation, CheckResult, shared constants
         preprocessor.py     # comment/string stripping, token extraction
         utils.py            # case matching, module name helpers
-        checker.py          # main Checker class — all 64 rule implementations
+        checker.py          # main Checker class — all 75 rule implementations
         sign_checker.py     # cross-file sign-compatibility and declared_not_defined
         baseline.py         # baseline load/write
         output.py           # text / JSON / SARIF / HTML formatters, Tee, summary
@@ -484,6 +484,37 @@ Subprocess coverage now captures the CLI entry point in CI; `--cov-fail-under=85
   cards and per-file violation tables.
 
 #### Test suite: 1152 tests across 49 modules
+
+---
+
+### New in v1.4.0 (2026-06-18)
+
+- **`macro.trailing_semicolon`** — flags `#define` macros whose expansion ends with a
+  semicolon, preventing double-semicolon and dangling-else bugs at the call site.
+- **`macro.multistatement_wrapper`** — enforces that function-like macros containing
+  multiple statements are wrapped in `do { ... } while (0)`.
+- **`misc.function_length`** — configurable maximum function body line count, with
+  `count_comments: false` to exclude blank and comment-only lines.
+- **`misc.function_doc_header`** — requires a Doxygen-style `@brief`/`@param`/`@return`
+  block comment before each non-static function definition (disabled by default).
+- **`misc.assert_density`** — enforces a minimum number of `assert()` calls per qualifying
+  function, with per-function exemption via regex patterns (disabled by default).
+- **`misc.null_statement_comment`** — requires a comment whenever a null statement is used.
+- **`misc.declaration_spacing`** — enforces a blank line between variable declarations and
+  the first executable statement in a function body (disabled by default).
+- **`misc.file_length`** — configurable maximum total lines per source file.
+- **`misc.reserved_header_name`** — flags source files and `#include "..."` directives that
+  shadow a standard C or POSIX library header name.
+- **`naming.identifier_length`** — uniform minimum/maximum identifier-length check across
+  all identifier categories (disabled by default).
+- **`naming.no_single_char_identifiers`** — flags single-character variable names outside a
+  configurable exempt list (disabled by default).
+
+11 new rules, bringing the total to **75 rule IDs**. 102 new tests added (1152 total).
+
+Bug fixes: parameter/pointer naming-prefix false positives (#245, #246), a
+catastrophic-backtracking regex hang in `misc.null_statement_comment` (#248, #249), and
+broken GitHub Wiki links (#251).
 
 ---
 

--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.9 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.10 |
 | **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.10 | 2026-06-18 | Claude | v1.4.0 release — update all version identifiers, release summary, change log, upgrade notes |
 | 1.9 | 2026-06-18 | Claude | ASPICE audit #254 — fix internally inconsistent test counts: §3/§5.4/§8.2/§9 now all read 1152 tests / 49 modules (previously a mix of 1143 and stale 1041) |
 | 1.8 | 2026-06-08 | Claude | ASPICE audit #238 — update SWE1/SWE3/SWE4 version refs; correct rule count 53→64; update test count 1041→1143, 38→49 modules |
 | 1.7 | 2026-06-05 | Claude | v1.3.0 release — update all version identifiers, release summary, change log, upgrade notes |
@@ -34,7 +35,7 @@
 
 ## 3. Purpose & Scope
 
-This **Software Version Description (SVD)** formally describes the **CStyleCheck v1.3.0** software release. It identifies the software items delivered, the baseline against which changes are recorded, and the configuration status of all controlled work products.
+This **Software Version Description (SVD)** formally describes the **CStyleCheck v1.4.0** software release. It identifies the software items delivered, the baseline against which changes are recorded, and the configuration status of all controlled work products.
 
 This document satisfies the release-identification and configuration-status-accounting requirements of **Automotive SPICE® PAM v4.0, SUP.8 — Configuration Management**.
 
@@ -61,19 +62,27 @@ This document satisfies the release-identification and configuration-status-acco
 | Field | Value |
 |---|---|
 | **Product Name** | CStyleCheck |
-| **Version** | 1.3.0 |
-| **Release Date** | 2026-06-05 |
+| **Version** | 1.4.0 |
+| **Release Date** | 2026-06-18 |
 | **Release Type** | Minor Release |
-| **Git Tag** | `v1.3.0` |
+| **Git Tag** | `v1.4.0` |
 | **Branch** | `main` |
-| **Previous Release** | v1.2.1 (2026-05-29) |
+| **Previous Release** | v1.3.0 (2026-06-05) |
 | **Repository** | https://github.com/dermot-murphy/CStyleCheck |
 
 ### 4.2 Release Classification
 
-This is a **minor release** under Semantic Versioning. It is **backward-compatible** with v1.2.1: all existing `rules.yml` configurations, CLI flags, and pre-commit hook integrations continue to work without modification.
+This is a **minor release** under Semantic Versioning. It is **backward-compatible** with v1.3.0: all existing `rules.yml` configurations, CLI flags, and pre-commit hook integrations continue to work without modification.
 
-New capabilities (inline suppression, `--fix`, `--init`/`--preset`, per-directory config, HTML report, and 11 new rules from issues #221–#232) are entirely additive. The CLI entry point, all 64 rule IDs, and all existing output formats are backward-compatible with v1.2.1.
+New capabilities are 11 new rules from issues #221–#232 (`macro.trailing_semicolon`,
+`macro.multistatement_wrapper`, `misc.function_length`, `misc.function_doc_header`,
+`misc.assert_density`, `misc.null_statement_comment`, `misc.declaration_spacing`,
+`misc.file_length`, `misc.reserved_header_name`, `naming.identifier_length`,
+`naming.no_single_char_identifiers`), bringing the total from 64 to **75 rule IDs**. All
+new rules are entirely additive; several are disabled by default. This release also
+includes three bug fixes (issues #245/#246, #248/#249, #251) — see §6.2. The CLI entry
+point, all pre-existing rule IDs, and all existing output formats remain
+backward-compatible with v1.3.0.
 
 ---
 
@@ -90,14 +99,14 @@ New capabilities (inline suppression, `--fix`, `--init`/`--preset`, per-director
 | `src/cstylecheck/models.py` | Violation, CheckResult, shared constants | `src/cstylecheck/models.py` |
 | `src/cstylecheck/preprocessor.py` | Comment/string stripping, token extraction | `src/cstylecheck/preprocessor.py` |
 | `src/cstylecheck/utils.py` | Case matching helpers, module-name derivation | `src/cstylecheck/utils.py` |
-| `src/cstylecheck/checker.py` | Main Checker class — all 64 rule implementations | `src/cstylecheck/checker.py` |
+| `src/cstylecheck/checker.py` | Main Checker class — all 75 rule implementations | `src/cstylecheck/checker.py` |
 | `src/cstylecheck/sign_checker.py` | Cross-file sign-compatibility and declared_not_defined | `src/cstylecheck/sign_checker.py` |
 | `src/cstylecheck/baseline.py` | Baseline load / write | `src/cstylecheck/baseline.py` |
 | `src/cstylecheck/output.py` | Text / JSON / SARIF / HTML formatters, Tee, summary table | `src/cstylecheck/output.py` |
 | `src/cstylecheck/fixer.py` | Auto-fix engine: apply_fixes, unified_diff (`--fix`, `--dry-run`, `--safe-only`) | `src/cstylecheck/fixer.py` |
 | `src/cstylecheck/wizard.py` | Config wizard and preset writer (`--init`, `--preset`) | `src/cstylecheck/wizard.py` |
 | `src/rules.yml` | Rule configuration for the CStyleCheck project | `src/rules.yml` |
-| `src/_version.py` | Version string: `1.3.0` (generated by CI: `git describe --tags`) | `src/_version.py` |
+| `src/_version.py` | Version string: `1.4.0` (generated by CI: `git describe --tags`) | `src/_version.py` |
 | `src/aliases.txt` | Module alias map | `src/aliases.txt` |
 | `src/exclusions.yml` | Per-file rule suppressions | `src/exclusions.yml` |
 | `src/options.txt` | Project defaults for `--options-file` | `src/options.txt` |
@@ -111,8 +120,8 @@ New capabilities (inline suppression, `--fix`, `--init`/`--preset`, per-director
 
 | Registry | Image | Tags |
 |---|---|---|
-| Docker Hub | `dermotmurphy/cstylecheck` | `1.3.0`, `1.3`, `1`, `latest` |
-| GitHub Container Registry | `ghcr.io/dermot-murphy/cstylecheck` | `1.3.0`, `1.3`, `1`, `latest` |
+| Docker Hub | `dermotmurphy/cstylecheck` | `1.4.0`, `1.4`, `1`, `latest` |
+| GitHub Container Registry | `ghcr.io/dermot-murphy/cstylecheck` | `1.4.0`, `1.4`, `1`, `latest` |
 
 Platforms: `linux/amd64`, `linux/arm64`.
 
@@ -209,31 +218,39 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 ---
 
-## 6. Change Summary (v1.2.1 → v1.3.0)
+## 6. Change Summary (v1.3.0 → v1.4.0)
 
 ### 6.1 New Features
 
 | ID | Description | Issue |
 |---|---|---|
-| F-001 | Inline suppression comments (`preprocessor.parse_inline_suppressions`) — suppress violations per-line, next-line, or block via `// cstylecheck: disable=rule.id` directives; case-insensitive; comma-separated rule lists | [#188](https://github.com/dermot-murphy/CStyleCheck/issues/188) |
-| F-002 | `--fix` auto-fix mode (`fixer.py`) — apply safe mechanical in-place fixes; `--dry-run` shows unified diff; `--safe-only` restricts to zero-risk fixes; currently fixable: `misc.unsigned_suffix` and `misc.lowercase_l_suffix` | [#189](https://github.com/dermot-murphy/CStyleCheck/issues/189) |
-| F-003 | `--init` config wizard and `--preset` (`wizard.py`) — interactive Q&A writing `.cstylecheck.yml`; pre-built presets `barr-c`, `minimal`, `misra`; `--init-output FILE`; `--overwrite` | [#190](https://github.com/dermot-murphy/CStyleCheck/issues/190) |
-| F-004 | Per-directory config (`config.resolve_per_dir_config`) — `--per-dir-config` enables upward dir-walk from each source file; deep-merge of found `.cstylecheck.yml`; nearest config wins; `root: true` stops search; results cached per directory | [#193](https://github.com/dermot-murphy/CStyleCheck/issues/193) |
-| F-005 | HTML report (`output._violations_to_html`) — `--output-format html` produces self-contained HTML with inline CSS, summary cards, and per-file violation tables; written to `--log FILE` if provided, else stdout | [#192](https://github.com/dermot-murphy/CStyleCheck/issues/192) |
+| F-006 | `macro.trailing_semicolon` — flags `#define` macros whose expansion ends with a semicolon, preventing double-semicolon and dangling-else bugs at the call site | [#228](https://github.com/dermot-murphy/CStyleCheck/issues/228) |
+| F-007 | `macro.multistatement_wrapper` — enforces that function-like macros containing multiple statements are wrapped in `do { ... } while (0)` for safe use in `if`/`else` branches | [#229](https://github.com/dermot-murphy/CStyleCheck/issues/229) |
+| F-008 | `misc.function_length` — configurable maximum function body line count; supports `count_comments: false` to exclude blank and comment-only lines | [#221](https://github.com/dermot-murphy/CStyleCheck/issues/221) |
+| F-009 | `misc.function_doc_header` — requires a Doxygen-style `@brief`/`@param`/`@return` block comment before each non-static function definition (disabled by default) | [#222](https://github.com/dermot-murphy/CStyleCheck/issues/222) |
+| F-010 | `misc.assert_density` — enforces a minimum number of `assert()` calls per qualifying function; supports per-function exemption via regex patterns (disabled by default) | [#225](https://github.com/dermot-murphy/CStyleCheck/issues/225) |
+| F-011 | `misc.null_statement_comment` — requires a comment whenever a null statement (`while (x) ;`, standalone `;`) is used | [#227](https://github.com/dermot-murphy/CStyleCheck/issues/227) |
+| F-012 | `misc.declaration_spacing` — enforces a blank line between variable declarations and the first executable statement in a function body (disabled by default) | [#224](https://github.com/dermot-murphy/CStyleCheck/issues/224) |
+| F-013 | `misc.file_length` — configurable maximum total lines per source file; supports excluding blank and/or comment-only lines from the count | [#232](https://github.com/dermot-murphy/CStyleCheck/issues/232) |
+| F-014 | `misc.reserved_header_name` — flags source files and `#include "..."` directives that use a name identical to a standard C or POSIX library header | [#230](https://github.com/dermot-murphy/CStyleCheck/issues/230) |
+| F-015 | `naming.identifier_length` — uniform minimum/maximum identifier-length check across all identifier categories with per-name exemptions (disabled by default) | [#223](https://github.com/dermot-murphy/CStyleCheck/issues/223) |
+| F-016 | `naming.no_single_char_identifiers` — flags single-character variable names outside a configurable exempt list (disabled by default) | [#231](https://github.com/dermot-murphy/CStyleCheck/issues/231) |
 
 ### 6.2 Bug Fixes
 
-No functional bug fixes in this release.
+| ID | Description | Issue |
+|---|---|---|
+| B-001 | Parameter and pointer naming-prefix checks no longer require both prefixes simultaneously when only one is configured, fixing false positives on otherwise compliant declarations | [#245](https://github.com/dermot-murphy/CStyleCheck/issues/245), [#246](https://github.com/dermot-murphy/CStyleCheck/issues/246) |
+| B-002 | Fixed a catastrophic-backtracking (ReDoS) regular expression in `misc.null_statement_comment` that could hang indefinitely on an unclosed `if`/`while`/`for` condition spanning a long line | [#248](https://github.com/dermot-murphy/CStyleCheck/issues/248), [#249](https://github.com/dermot-murphy/CStyleCheck/issues/249) |
+| B-003 | Fixed broken GitHub Wiki links: malformed triple-hyphen slugs for headings containing backticks/parentheses, and a non-functional "Rules and Configuration Reference" link | [#251](https://github.com/dermot-murphy/CStyleCheck/issues/251) |
 
 ### 6.3 Documentation Updates
 
 | ID | Description | Issue |
 |---|---|---|
-| D-001 | CSC-AUD-005 corrective action: 32 ASPICE factual errors resolved across SWE1–SWE6, SYS3, SVD, SYS5 | [#209](https://github.com/dermot-murphy/CStyleCheck/issues/209) |
-| D-002 | SWE.2, SWE.3, SWE.4 updated: `fixer.py`/`wizard.py` correctly documented; `apply_fixes`, `unified_diff`, `run_preset` signatures corrected; 12 sub-modules | — |
-| D-003 | SWE.1 RTM corrected: SWE1-072–077 test file references updated to five new test modules | — |
-| D-004 | SYS.3 updated: SS-07/08/09 subsystems added; SYS-F-041–045 forward traceability added | — |
-| D-005 | SWE.5 / SWE.6 updated: SIT-014–018 integration test cases added; qualification scope extended to SWE1-077 | — |
+| D-006 | ASPICE audit CSC-AUD-006 corrective action: fixed pervasive stale test counts (1152/49 modules), a Document-ID collision (`CSC-STD-001`), systemic cross-reference version-citation drift across all 22 `docs/aspice/*.md` work products, three orphaned top-level docs, and `CHANGELOG.md` gaps | [#254](https://github.com/dermot-murphy/CStyleCheck/issues/254) |
+| D-007 | Fixed Wiki sidebar/README links: malformed triple-hyphen slugs and the non-functional "Rules and Configuration Reference" link | [#251](https://github.com/dermot-murphy/CStyleCheck/issues/251) |
+| D-008 | 102 new tests (1152 total) covering all 11 new rules, including edge cases for multi-line macros, nested braces, comment exclusion, and regex-based exemptions | — |
 
 ---
 
@@ -247,7 +264,7 @@ The following issues are open at the time of this release and deferred to a futu
 | [#160](https://github.com/dermot-murphy/CStyleCheck/issues/160) | Pre-commit hook: warn gracefully when no C files are staged | Low |
 | [#161](https://github.com/dermot-murphy/CStyleCheck/issues/161) | `misc.copyright_header` regex anchoring edge cases on Windows line endings | Low |
 
-> No open issues map to known functional defects in the 53 active rules. All issue numbers above are illustrative; see GitHub for the live issue tracker.
+> No open issues map to known functional defects in the 75 active rules. All issue numbers above are illustrative; see GitHub for the live issue tracker.
 
 ---
 
@@ -273,7 +290,7 @@ All 1152 tests pass with no failures. Test counts per module are documented in �
 
 ### 8.3 Docker Build
 
-The Docker image is built for `linux/amd64` and `linux/arm64` and published to Docker Hub and GHCR automatically on creation of the `v1.3.0` tag via `docker_publish.yml`.
+The Docker image is built for `linux/amd64` and `linux/arm64` and published to Docker Hub and GHCR automatically on creation of the `v1.4.0` tag via `docker_publish.yml`.
 
 ### 8.4 GitHub Pages / Wiki
 
@@ -283,7 +300,7 @@ The GitHub Wiki is rebuilt automatically on any push to `main` that touches `REA
 
 ## 9. Installation and Upgrade Notes
 
-### 9.1 Upgrade from v1.2.1
+### 9.1 Upgrade from v1.3.0
 
 No breaking changes. Upgrade steps:
 
@@ -292,25 +309,31 @@ No breaking changes. Upgrade steps:
 pip install --upgrade cstylecheck
 
 # Docker
-docker pull dermotmurphy/cstylecheck:1.3.0
+docker pull dermotmurphy/cstylecheck:1.4.0
 
 # pre-commit (update rev in .pre-commit-config.yaml)
-rev: v1.3.0
+rev: v1.4.0
 ```
 
 ### 9.2 New Features — Optional Activation
 
-New features in v1.3.0 that require explicit opt-in:
+New rules in v1.4.0 that require explicit opt-in (`enabled: true` under their key in
+`rules.yml`) because they are disabled by default:
 
-- **Inline suppression**: no config change required — add `// cstylecheck: disable=rule.id` comments in source.
-- **Auto-fix**: pass `--fix` (and optionally `--dry-run`, `--safe-only`) on the CLI.
-- **Config wizard / presets**: run `cstylecheck --init` or `cstylecheck --preset barr-c|minimal|misra`.
-- **Per-directory config**: pass `--per-dir-config` on the CLI; place `.cstylecheck.yml` files in subdirectories.
-- **HTML report**: pass `--output-format html` (optionally with `--log FILE`) on the CLI.
+- **`misc.function_doc_header`**, **`misc.assert_density`**, **`misc.declaration_spacing`**,
+  **`naming.identifier_length`**, **`naming.no_single_char_identifiers`**.
+
+The remaining six new rules (`macro.trailing_semicolon`, `macro.multistatement_wrapper`,
+`misc.function_length`, `misc.null_statement_comment`, `misc.file_length`,
+`misc.reserved_header_name`) are enabled by default; no config change is required to
+benefit from them.
 
 ### 9.3 Backward Compatibility
 
-The `src/cstylecheck.py` entry point shim is unchanged. All 53 rule IDs, existing `rules.yml` configurations, and pre-commit hook definitions are unchanged. Users who import the checker programmatically via `import cstylecheck` continue to work without modification.
+The `src/cstylecheck.py` entry point shim is unchanged. All pre-existing rule IDs,
+existing `rules.yml` configurations, and pre-commit hook definitions are unchanged. The
+11 new rules added in this release bring the total to 75 rule IDs. Users who import the
+checker programmatically via `import cstylecheck` continue to work without modification.
 
 ---
 
@@ -318,21 +341,21 @@ The `src/cstylecheck.py` entry point shim is unchanged. All 53 rule IDs, existin
 
 | Work Product | Document | Version | Status |
 |---|---|---|---|
-| System Requirements | CSC-SYS2-001 | 1.5 | Released |
-| System Architecture | CSC-SYS3-001 | 1.4 | Released |
-| System Integration Tests | CSC-SYS4-001 | 1.3 | Released |
-| System Verification | CSC-SYS5-001 | 1.5 | Released |
-| Software Requirements | CSC-SWE1-001 | 1.7 | Released |
-| Software Architecture | CSC-SWE2-001 | 1.6 | Released |
-| Detailed Design | CSC-SWE3-001 | 1.8 | Released |
-| Unit Verification | CSC-SWE4-001 | 1.8 | Released |
-| Integration Tests | CSC-SWE5-001 | 1.4 | Released |
-| Qualification Tests | CSC-SWE6-001 | 1.5 | Released |
-| Source Code | `src/cstylecheck/` (package) | 1.3.0 | Released |
-| Test Suite | `tests/` (1152 tests) | 1.3.0 | Released |
-| CI Automation | `.github/workflows/` + `scripts/ci/` | 1.3.0 | Released |
-| Docker Image | `Dockerfile/Dockerfile` | 1.3.0 | Released |
-| Change Log | `CHANGELOG.md` | 1.3.0 | Released |
+| System Requirements | CSC-SYS2-001 | 1.6 | Released |
+| System Architecture | CSC-SYS3-001 | 1.5 | Released |
+| System Integration Tests | CSC-SYS4-001 | 1.4 | Released |
+| System Verification | CSC-SYS5-001 | 1.6 | Released |
+| Software Requirements | CSC-SWE1-001 | 1.9 | Released |
+| Software Architecture | CSC-SWE2-001 | 1.8 | Released |
+| Detailed Design | CSC-SWE3-001 | 1.10 | Released |
+| Unit Verification | CSC-SWE4-001 | 1.11 | Released |
+| Integration Tests | CSC-SWE5-001 | 1.5 | Released |
+| Qualification Tests | CSC-SWE6-001 | 1.6 | Released |
+| Source Code | `src/cstylecheck/` (package) | 1.4.0 | Released |
+| Test Suite | `tests/` (1152 tests) | 1.4.0 | Released |
+| CI Automation | `.github/workflows/` + `scripts/ci/` | 1.4.0 | Released |
+| Docker Image | `Dockerfile/Dockerfile` | 1.4.0 | Released |
+| Change Log | `CHANGELOG.md` | 1.4.0 | Released |
 
 ---
 
@@ -349,4 +372,4 @@ The `src/cstylecheck.py` entry point shim is unchanged. All 53 rule IDs, existin
 
 ---
 
-*End of Software Version Description — CStyleCheck v1.3.0*
+*End of Software Version Description — CStyleCheck v1.4.0*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "cstylecheck"
-version         = "1.3.0"
+version         = "1.4.0"
 description     = "Embedded C Style Compliance Checker (Barr-C / MISRA-C complementary)"
 readme          = "README.md"
 license         = { text = "MIT" }


### PR DESCRIPTION
## Summary

Prepares the **v1.4.0** minor release (SemVer minor bump — the `[Unreleased]` section contained 11 new backward-compatible rules plus 3 bug fixes, no breaking changes).

- **`CHANGELOG.md`** — renamed `[Unreleased]` to `## [1.4.0] — 2026-06-18`, added a fresh empty `[Unreleased]` section above it.
- **`pyproject.toml`** — bumped static `version` field `1.3.0` → `1.4.0`.
- **`README.md`** — added a `### New in v1.4.0` section (11 new rules + 3 bug fixes), updated rule-ID count `64` → `75` in all 4 occurrences.
- **`docs/aspice/CStyleCheck_SVD_Software_Version_Description.md`** (CSC-SVD-001, ASPICE SUP.8 work product) — bumped own version 1.9 → 1.10 with revision-history row; updated §3 Purpose, §4.1 Release Summary (version/date/tag/previous-release), §4.2 Release Classification, §5.1/§5.2 (version strings, Docker tags), §6 Change Summary (new Features/Bug Fixes/Documentation tables for v1.3.0 → v1.4.0), §8.3, §9.1–9.3 (upgrade notes, rule count), §10 Traceability table (synced to current doc versions), and the footer.

## Notes

- 75 = 64 (prior baseline, consistently cited across README/SVD pre-this-change) + 11 new rules added in this release. No new rules were removed/renamed, so this is additive.
- Full test suite re-run locally: **1152 passed**, confirming the test-count citations are accurate.
- No tag has been pushed yet — that's the next step after this PR merges and is synced to `main`, since pushing a `v1.4.0` tag triggers the real Docker Hub/GHCR publish via `docker_publish.yml`. Will wait for your go-ahead on that step too.

## Test plan

- [x] `pytest tests/` — 1152 passed
- [ ] Review CHANGELOG/README/SVD wording
- [ ] Merge to `develop`, then sync `develop` → `main`
- [ ] Tag `v1.4.0` and push (triggers Docker publish) — pending separate confirmation


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_