### PR TITLE
Sync develop → main (ASPICE CL2 re-assessment, CSC-AUD-007)

### DIFF
--- a/docs/aspice/CStyleCheck_PA2_Capability_Records.md
+++ b/docs/aspice/CStyleCheck_PA2_Capability_Records.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-PA2-001 | **Version** | 1.9 |
+| **Document ID** | CSC-PA2-001 | **Version** | 1.10 |
 | **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.10 | 2026-06-18 | Claude | CSC-AUD-007 — §6 was stale since 2026-05-28 (predated issue #152 closure and superseding audit CSC-AUD-002); resync §6 ratings/verdict to current `main` (v1.4.0); CL2 confirmed ACHIEVED; add §5.4 rows for CSC-AUD-002/CSC-AUD-007 |
 | 1.9 | 2026-06-18 | Claude | ASPICE audit #254 — update §4.1/§5.4/§6 SWE.4 test count 965→1152; mark CI-017 released at v1.3.0 |
 | 1.8 | 2026-06-04 | Claude | Deep accuracy audit: fix §4.1 SWE.3 unit count (46→90), SUP.8 CI count (27→34), §6 SWE.3 (89→90) and SUP.8 (29→34); update §5.4 document version table — resolves issue #163 |
 | 1.7 | 2026-06-04 | Claude | Automated accuracy audit: update §4.1 SWE.4 test count ≥500→965, §5.2 SWE.4 839→965, §5.4 CI-017 839→965 and SUP9/10/ACQ4 versions, §6 SWE.4 839→965 — resolves issue #163 |
@@ -204,8 +205,10 @@ All work products are reviewed before approval according to the following schedu
 | CSC-DEV-002 | Independent Review Deviation Record | 1.0 | Released | v1.1.0 tag |
 | CSC-SVD-001 | Software Version Description | 1.4 | Released | issue #163 deep audit |
 | CSC-AUD-001 | ASPICE Internal Audit Report | 1.0 | Released | v1.2.0 tag |
+| CSC-AUD-002 | ASPICE Internal Audit — CL2 Re-assessment (2026-05-29) | 1.0 | Released | v1.2.1 tag |
 | CSC-AUD-003 | ASPICE Internal Audit — Accuracy (2026-06-04) | 1.0 | Released | issue #163 audit |
 | CSC-AUD-004 | ASPICE Internal Audit — Deep Accuracy (2026-06-04) | 1.0 | Released | issue #163 deep audit |
+| CSC-AUD-007 | ASPICE Internal Audit — CL2 Re-assessment (2026-06-18) | 1.0 | Released | v1.4.0 tag |
 | CI-001 | `src/cstylecheck/` package | 1.2.0 | Released | v1.2.0 tag |
 | CI-017 | Test suite (1152 tests) | 1.3.0 | Released | v1.3.0+ |
 
@@ -213,33 +216,35 @@ All work products are reviewed before approval according to the following schedu
 
 ## 6. ASPICE CL2 Coverage Summary
 
-The table below summarises all assessed processes and their CL2 PA achievement evidence.
+*Resynced 2026-06-18 (CSC-AUD-007) — the verdict below was stale between 2026-05-28 and 2026-06-18: it predated both the closure of issue #152 (2026-05-28) and the superseding re-assessment CSC-AUD-002 (2026-05-29), and five intervening document revisions (1.5–1.9) never refreshed it. See CSC-AUD-007 for the full resync rationale.*
+
+The table below summarises all assessed processes and their CL2 PA achievement evidence, current as of v1.4.0.
 
 | Process | PA 1.1 (Performed) | PA 2.1 (Perf. Mgmt) | PA 2.2 (WP Mgmt) | Assessment Verdict | Open Issue(s) |
 |---|---|---|---|---|---|
-| SYS.2 | SYS REQ-IDs defined and traceable | Objectives: §4.1; strategy: §4.2 | CSC-SYS2-001 reviewed; in CM | **L** | #153 |
-| SYS.3 | Architecture with subsystems and interfaces | Objectives: §4.1; monitoring: §4.3 | CSC-SYS3-001 reviewed; in CM | **L** | #146 |
-| SYS.4 | 14 SITC test cases defined | Objectives: §4.1 | CSC-SYS4-001 reviewed; in CM | **P** ⚠️ | #152 |
-| SYS.5 | 13 SYS-VTC test cases defined | Objectives: §4.1 | CSC-SYS5-001 reviewed; in CM | **P** ⚠️ | #152, #153 |
-| SWE.1 | 70+ SW requirements defined | Objectives: §4.1; strategy: §4.2 | CSC-SWE1-001 reviewed; in CM | **L** | #148, #149 |
-| SWE.2 | 7 components, 10 interfaces defined | Objectives: §4.1 | CSC-SWE2-001 reviewed; in CM | **L** | #146 |
-| SWE.3 | 90 units with algorithmic specs | Objectives: §4.1 | CSC-SWE3-001 reviewed; in CM | **L** | #147, #148 |
-| SWE.4 | 1152 unit tests; self-check CI; 85% cov. | Objectives: §4.1; coverage targets | CSC-SWE4-001 reviewed; CI evidence | **L** | — |
-| SWE.5 | 13 SIT tests covering all interfaces | Objectives: §4.1 | CSC-SWE5-001 reviewed; in CM | **P** ⚠️ | #152 |
-| SWE.6 | 12 SWQ tests; 100% SW-REQ coverage | Objectives: §4.1; release gate | CSC-SWE6-001 reviewed; CI evidence | **L** | #151, #152 |
-| MAN.3 | WBS, schedule, monitoring defined | Objectives: §4.1; §4.3 monitoring | CSC-MAN3-001 reviewed; in CM | **L** | #154 |
-| MAN.5 | 8 risks identified and treated | Objectives: §4.1; risk monitoring | CSC-MAN5-001 reviewed; in CM | **L** | #155 |
-| SUP.1 | QA gates and checklist defined | Objectives: §4.1; CI evidence | CSC-SUP1-001 reviewed; in CM | **L** | #151 |
-| SUP.8 | 34 CIs; Git Flow; dual-registry | Objectives: §4.1; CM monitoring | CSC-SUP8-001 reviewed; in CM | **L** | #150 |
-| SUP.9 | Problem process with SLAs and register | Objectives: §4.1; Issue metrics | CSC-SUP9-001 reviewed; in CM | **L** | DEV-002 |
-| SUP.10 | CR process with impact levels and approval | Objectives: §4.1; CR metrics | CSC-SUP10-001 reviewed; in CM | **L** | DEV-002 |
-| ACQ.4 | 5 suppliers monitored with criteria | Objectives: §4.1; monitoring schedule | CSC-ACQ4-001 reviewed; in CM | **L** | #155 |
+| SYS.2 | SYS REQ-IDs defined and traceable | Objectives: §4.1; strategy: §4.2 | CSC-SYS2-001 reviewed; in CM | **L** | — |
+| SYS.3 | Architecture with subsystems and interfaces | Objectives: §4.1; monitoring: §4.3 | CSC-SYS3-001 reviewed; in CM | **F** | — |
+| SYS.4 | 14 SITC test cases defined and executed | Objectives: §4.1 | CSC-SYS4-001 reviewed; in CM | **L** | AUD7-F-001, #261 |
+| SYS.5 | 13 SYS-VTC test cases defined and executed | Objectives: §4.1 | CSC-SYS5-001 reviewed; in CM | **L** | AUD7-F-001, #261 |
+| SWE.1 | 88 SW requirements defined | Objectives: §4.1; strategy: §4.2 | CSC-SWE1-001 reviewed; in CM | **F** | — |
+| SWE.2 | 10 components, 10 interfaces defined | Objectives: §4.1 | CSC-SWE2-001 reviewed; in CM | **F** | — |
+| SWE.3 | 112 units with algorithmic specs | Objectives: §4.1 | CSC-SWE3-001 reviewed; in CM | **F** | — |
+| SWE.4 | 1152 unit tests; self-check CI; 85% cov. | Objectives: §4.1; coverage targets | CSC-SWE4-001 reviewed; CI evidence | **F** | — |
+| SWE.5 | 18 SIT tests; new v1.3/v1.4 rules not yet covered | Objectives: §4.1 | CSC-SWE5-001 reviewed; in CM | **L** ⚠️ | AUD7-F-001, #261 |
+| SWE.6 | 12 SWQ tests; rule-coverage test stale at 53/75 rules | Objectives: §4.1; release gate | CSC-SWE6-001 reviewed; CI evidence | **L** ⚠️ | AUD7-F-001, #261 |
+| MAN.3 | WBS, schedule, monitoring defined | Objectives: §4.1; §4.3 monitoring | CSC-MAN3-001 reviewed; in CM | **F** | — |
+| MAN.5 | 8 risks identified and treated | Objectives: §4.1; risk monitoring | CSC-MAN5-001 reviewed; in CM | **L** | — |
+| SUP.1 | QA gates and checklist defined | Objectives: §4.1; CI evidence | CSC-SUP1-001 reviewed; in CM | **L** | — |
+| SUP.8 | 34 CIs; Git Flow; dual-registry | Objectives: §4.1; CM monitoring | CSC-SUP8-001 reviewed; in CM | **F** | — |
+| SUP.9 | Problem process with SLAs and register | Objectives: §4.1; Issue metrics | CSC-SUP9-001 reviewed; in CM | **F** | DEV-002 |
+| SUP.10 | CR process with impact levels and approval | Objectives: §4.1; CR metrics | CSC-SUP10-001 reviewed; in CM | **F** | DEV-002 |
+| ACQ.4 | 5 suppliers monitored with criteria | Objectives: §4.1; monitoring schedule | CSC-ACQ4-001 reviewed; in CM | **L** | — |
 
 > **📋 Rating scale:** N = Not achieved (0–15%), P = Partially achieved (15–50%), L = Largely achieved (50–85%), F = Fully achieved (85–100%). All processes must achieve **L or F** at PA 2.1 and PA 2.2 for CL2 to be awarded.
 >
-> **⚠️ CL2 Verdict: NOT YET ACHIEVED — Largely Achieved overall.** Three processes (SYS.4, SYS.5, SWE.5) are rated **P** due to absent test execution evidence (issue #152). Closing issue #152 is the critical path to CL2 award. All other processes achieve **L**. Full assessment detail and path-to-CL2 action list: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-05-28.md` (CSC-AUD-001).
+> **✅ CL2 Verdict: ACHIEVED.** All 17 processes rate **L or F** (11 F, 6 L, 0 P/N). One corrective action remains open — **AUD7-F-001**: the 11 rules added in v1.3.0/v1.4.0 (issues #221–#232) have requirements/design/unit-test coverage (SWE.1/SWE.3/SWE.4) but no integration-, system-, or qualification-level test cases yet (SWE.5/SYS.4/SYS.5/SWE.6); `SYS-VTC-003`/`SWQ-003` still cite "53 rule IDs" instead of 75. This downgrades SWE.5 and SWE.6 from F to L but does not affect the CL2 award. Targeted for the v1.5.0 cycle. Full detail: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007).
 >
-> **Ratings assigned by internal audit CSC-AUD-001, 2026-05-28.**
+> **Ratings assigned by internal audit CSC-AUD-007, 2026-06-18 (supersedes CSC-AUD-001 2026-05-28 and CSC-AUD-002 2026-05-29 for this table).**
 
 ---
 

--- a/docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md
+++ b/docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md
@@ -1,0 +1,115 @@
+# CStyleCheck ASPICE Internal Audit — CSC-AUD-007
+
+| Field | Value |
+|---|---|
+| **Audit ID** | CSC-AUD-007 |
+| **Date** | 2026-06-18 |
+| **Branch** | `main` (v1.4.0, commit tag `v1.4.0`) |
+| **Auditor** | AI-assisted internal audit (Claude, per CSC-DEV-001) |
+| **Scope** | CL2 re-assessment of all 17 processes against the current `main` baseline; resolution check on `CSC-PA2-001` §6 staleness |
+| **Overall Status** | **CL2 Achieved, with one open corrective action** |
+| **Test count (actual)** | 1152 / 49 modules |
+| **Rule count (actual)** | 75 |
+
+---
+
+## 1. Purpose and Trigger
+
+`CSC-PA2-001` §6 ("ASPICE CL2 Coverage Summary") still carried the verdict **"CL2 NOT YET ACHIEVED"**, citing three processes (SYS.4, SYS.5, SWE.5) rated **P** due to open issue #152. This is stale:
+
+- Issue #152 was closed 2026-05-28, with execution evidence populated into CSC-SYS4-001, CSC-SYS5-001, and CSC-SWE5-001.
+- A second internal audit, **CSC-AUD-002** (2026-05-29), already re-rated those three processes (P→L, P→L, P→F) and concluded the v1.2.1 release met CL2 requirements (all 17 processes L or F).
+- Five subsequent revisions of `CSC-PA2-001` (1.5 through 1.9) updated test counts and baseline tables but never synchronised §6 with CSC-AUD-002's findings — an oversight, not a real regression.
+
+Rather than mechanically copy CSC-AUD-002's v1.2.1 ratings forward, this audit re-assesses the **current** `main` baseline (v1.4.0), since three releases (v1.3.0, v1.4.0, and an unreleased package refactor) and four accuracy audits (CSC-AUD-003 through CSC-AUD-006) have landed since CSC-AUD-002.
+
+---
+
+## 2. Carried-Forward Findings (No Regression)
+
+All ten issues referenced in the stale §6 table are closed: #146, #147, #148, #149, #150, #151, #152, #153, #154, #155. No evidence of regression was found for SYS.2, SWE.1, SWE.2, SWE.3, SWE.4, MAN.3, MAN.5, SUP.1, SUP.8, SUP.9, SUP.10, ACQ.4 — these carry forward their CSC-AUD-002 ratings unchanged (SYS.2 L, SWE.1 F, SWE.2 F, SWE.3 F, SWE.4 F, MAN.3 F, MAN.5 L, SUP.1 L, SUP.8 F, SUP.9 F, SUP.10 F, ACQ.4 L).
+
+CSC-AUD-006 (tracked as issue #254, closed 2026-06-18) already corrected the test/module-count drift (965→1152, 33→49 modules) that would otherwise have affected SWE.4 and CSC-SVD-001 evidence currency.
+
+---
+
+## 3. New Finding — AUD7-F-001: v1.3.0/v1.4.0 rules have no integration/system/qualification test coverage
+
+**Severity: High** | **Affects: SWE.5, SYS.4, SYS.5, SWE.6**
+
+The 11 rules added across v1.3.0/v1.4.0 (issues #221–#232, SWE1-078 to SWE1-088) are fully covered at the requirements (SWE.1), design (SWE.3), and unit-test (SWE.4) levels — each has a dedicated `_check_*` method, a UNIT-XXX design entry, and a `test_*.py` unit test module. However:
+
+- **SWE.5** (`CSC-SWE5-001`): no SIT-XXX test case references any of the 11 new rules. SIT-001 to SIT-018 cover only pre-v1.3.0 functionality.
+- **SYS.4** (`CSC-SYS4-001`): no SITC-XXX test case references any of the 11 new rules. SITC-001 to SITC-014 are unchanged since before v1.3.0.
+- **SYS.5** (`CSC-SYS5-001`): `SYS-VTC-003` ("Full Rule Coverage") still says **"53 Rule IDs"** — its objective, RTM entries (§ "SYS-F-011 to F-024 → Covered"), and `SYS-F-020` itself (the umbrella system requirement SWE1-078–088 trace to) were never updated to mention the 11 new checks. `SYS-F-020`'s own text still only describes the pre-v1.3.0 misc rules (line length, indentation, magic numbers, unsigned suffix, yoda conditions, block comment spacing).
+- **SWE.6** (`CSC-SWE6-001`): `SWQ-003` ("All Rule IDs Detected") likewise still says **"53 Rule IDs"** and its rule-category breakdown table omits the `macro.*` and the 6 new `misc.*`/`naming.*` rules entirely.
+
+**Impact:** the documented integration/system/qualification verification work products do not demonstrate that 11 of the product's 75 rules — roughly 15% of total functionality — were verified above the unit level for the current release. This is a genuine, currently-open gap, not a stale-documentation artefact like the §6 table issue.
+
+**Disposition:** SWE.5 and SWE.6 downgrade from **F** (CSC-AUD-002) to **L** — base practices are performed and work products exist and are controlled, but evidence of complete verification scope is not yet objective. SYS.4 and SYS.5 remain **L** (unchanged — they already carried this caveat implicitly; CSC-AUD-002 did not anticipate the rule additions that came after it).
+
+This does **not** block CL2 — L is a passing rating — but it is the top corrective-action item for the v1.5.0 cycle. Tracked as a new issue (see §6).
+
+---
+
+## 4. Updated CL2 Coverage Summary (supersedes CSC-AUD-001 data in CSC-PA2-001 §6)
+
+| Process | CSC-AUD-001 (2026-05-28) | CSC-AUD-002 (2026-05-29) | **CSC-AUD-007 (2026-06-18, current)** | Open Issue(s) |
+|---|---|---|---|---|
+| SYS.2 | L | L | **L** | — |
+| SYS.3 | L | F | **F** | — |
+| SYS.4 | P | L | **L** | AUD7-F-001, #261 |
+| SYS.5 | P | L | **L** | AUD7-F-001, #261 |
+| SWE.1 | F | F | **F** | — |
+| SWE.2 | L | F | **F** | — |
+| SWE.3 | L | F | **F** | — |
+| SWE.4 | L | F | **F** | — |
+| SWE.5 | P | F | **L** ↓ | AUD7-F-001, #261 |
+| SWE.6 | F | F | **L** ↓ | AUD7-F-001, #261 |
+| MAN.3 | L | F | **F** | — |
+| MAN.5 | L | L | **L** | — |
+| SUP.1 | L | L | **L** | — |
+| SUP.8 | L | F | **F** | — |
+| SUP.9 | F | F | **F** | — |
+| SUP.10 | F | F | **F** | — |
+| ACQ.4 | L | L | **L** | — |
+
+> **📋 Rating scale:** N = Not achieved (0–15%), P = Partially achieved (15–50%), L = Largely achieved (50–85%), F = Fully achieved (85–100%). All processes must achieve **L or F** at PA 2.1 and PA 2.2 for CL2 to be awarded.
+
+### 4.1 Overall CL2 Verdict
+
+**✅ ASPICE CL2 IS ACHIEVED at v1.4.0.** All 17 processes rate **L or F** (11 F, 6 L, 0 P/N). The `CSC-PA2-001` §6 table's "NOT YET ACHIEVED" verdict was stale — it predated both the closure of issue #152 (2026-05-28) and the superseding re-assessment CSC-AUD-002 (2026-05-29) by several weeks, and was never refreshed across five subsequent document revisions.
+
+One corrective action remains open (AUD7-F-001/#261: extend SWE.5/SYS.4/SYS.5/SWE.6 verification scope to the 11 rules added in v1.3.0/v1.4.0), tracked for the v1.5.0 cycle. It does not affect the CL2 award since the affected processes still rate L.
+
+---
+
+## 5. Conclusion
+
+CL2 was actually achieved on 2026-05-29 (CSC-AUD-002, at v1.2.1) and remains achieved at v1.4.0, modulo one newly-identified verification-scope gap (AUD7-F-001) that downgrades SWE.5 and SWE.6 from F to L without affecting the overall award. The root cause of the "NOT YET ACHIEVED" message the project saw was a documentation-sync defect in `CSC-PA2-001` §6, not an actual capability gap — corrected by this audit.
+
+---
+
+## 6. Actions Required
+
+| Action | Finding | Owner | Target Version |
+|---|---|---|---|
+| Sync `CSC-PA2-001` §6 to this audit's ratings and verdict | (this audit) | Claude | v1.4.0 (immediate, this PR) |
+| Add `CSC-AUD-002` and `CSC-AUD-007` rows to `CSC-PA2-001` §5.4 baseline table | (this audit) | Claude | v1.4.0 (immediate, this PR) |
+| Add SIT/SITC/SYS-VTC/SWQ test cases for the 11 rules from #221–#232; update `SYS-F-020` and rule-count text (53→75) in `SYS-VTC-003`/`SWQ-003` | AUD7-F-001, #261 | Dermot Murphy | v1.5.0 |
+
+---
+
+## 7. Sign-off
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Auditor | Claude (AI-assisted) | 2026-06-18 | *per CSC-DEV-001* |
+| Audit Owner / Reviewer | Dermot Murphy | — | *pending manual review* |
+
+> **Note:** This audit was conducted by an AI tool (Claude) acting in the auditor role as documented in CSC-DEV-001. The solo-developer independent-review constraint is formally acknowledged in CSC-DEV-002. The Audit Owner signature above constitutes the required management review approval for this ASPICE-internal document.
+
+---
+
+*Document: CSC-AUD-007 · Version 1.0 · 2026-06-18*
+*Location: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md`*


### PR DESCRIPTION
## Summary

Routine develop → main sync (no version bump, no tag) bringing in PR #262:

- New internal audit `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007)
- `CSC-PA2-001` §6 resynced — CL2 verdict corrected from stale "NOT YET ACHIEVED" to **ACHIEVED**, with one tracked follow-up (issue #261) for v1.5.0

## Why

Merging this to `main` will trigger `wiki_publish.yml` (push to `main` touching `docs/aspice/**.md`), publishing the corrected ASPICE documentation to the GitHub Wiki without requiring a version release.

## Test plan

- [x] Doc-only change, fast-forward merge from `develop`, no conflicts
- [x] No code/test impact


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_