### PR TITLE
Fix CL2 count typo, add Wiki Deviations/Audits sections, flag stale reports

### DIFF
--- a/.github/workflows/wiki_publish.yml
+++ b/.github/workflows/wiki_publish.yml
@@ -188,6 +188,9 @@ jobs:
           def aspice_slug(filename):
               stem = filename[:-3] if filename.endswith('.md') else filename
               stem = re.sub(r'^CStyleCheck_', '', stem)
+              # Audit report filenames already start with "ASPICE_" - strip it
+              # too, otherwise the slug doubles up as "ASPICE-ASPICE-...".
+              stem = re.sub(r'^ASPICE_', '', stem)
               stem = stem.replace('_', '-')
               return 'ASPICE-' + stem
 
@@ -271,12 +274,19 @@ jobs:
               write(f"wiki/{slug}.md", rewrite_images(raw.rstrip() + nav_footer()))
           print(f"Wrote {len(TOP_LEVEL_DOC_MAP)} top-level doc page(s).")
 
-          # ASPICE pages - all flat in wiki root with ASPICE- prefix
-          aspice_src   = Path("docs/aspice")
-          aspice_files = []
-
-          if aspice_src.is_dir():
-              for src in sorted(aspice_src.glob("*.md")):
+          # ASPICE pages - all flat in wiki root with ASPICE- prefix.
+          # docs/aspice/ holds the 21 work products + supporting reports;
+          # docs/aspice/audits/ holds the dated, immutable internal audit
+          # reports - both are published the same way, just classified
+          # into different Wiki sidebar sections (see classify() below).
+          def publish_aspice_dir(src_dir):
+              """Convert every *.md in src_dir to a flat wiki page. Returns
+              the list of filenames written."""
+              files = []
+              if not src_dir.is_dir():
+                  print(f"{src_dir} not found - skipping its pages.")
+                  return files
+              for src in sorted(src_dir.glob("*.md")):
                   raw = src.read_text(encoding="utf-8")
                   # Strip YAML front-matter
                   raw = re.sub(r'^---\s*\n.*?\n---\s*\n', '', raw, flags=re.DOTALL)
@@ -292,22 +302,34 @@ jobs:
                   footer = "\n\n---\n\n*[[ASPICE Documentation Index|ASPICE-Index]]*\n"
                   page_slug = aspice_slug(src.name)
                   write(f"wiki/{page_slug}.md", raw.rstrip() + footer)
-                  aspice_files.append(src.name)
-              print(f"Wrote {len(aspice_files)} ASPICE pages.")
-          else:
-              print("docs/aspice/ not found - skipping ASPICE pages.")
+                  files.append(src.name)
+              return files
+
+          aspice_src   = Path("docs/aspice")
+          aspice_files = publish_aspice_dir(aspice_src)
+          print(f"Wrote {len(aspice_files)} ASPICE pages.")
+
+          audit_files  = publish_aspice_dir(aspice_src / "audits")
+          print(f"Wrote {len(audit_files)} ASPICE audit pages.")
+
+          doc_paths = {f: aspice_src / f for f in aspice_files}
+          doc_paths.update({f: aspice_src / "audits" / f for f in audit_files})
 
           # ASPICE-Index.md
           now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
           def classify(fn):
+              # Match "_<CODE><digit>" rather than a bare substring - otherwise
+              # e.g. "_ACQ4_Supplier_..." misclassifies as Support (_SUP is a
+              # substring of _SUPplier).
               u = fn.upper()
-              if '_SYS' in u:  return "System Engineering (SYS)"
-              if '_SWE' in u:  return "Software Engineering (SWE)"
-              if '_MAN' in u:  return "Management (MAN)"
-              if '_SUP' in u:  return "Support Processes (SUP)"
-              if '_ACQ' in u:  return "Acquisition (ACQ)"
-              if '_PA'  in u:  return "Capability Level 2 (PA 2.1 / PA 2.2)"
+              if re.search(r'_SYS\d', u): return "System Engineering (SYS)"
+              if re.search(r'_SWE\d', u): return "Software Engineering (SWE)"
+              if re.search(r'_MAN\d', u): return "Management (MAN)"
+              if re.search(r'_SUP\d', u): return "Support Processes (SUP)"
+              if re.search(r'_ACQ\d', u): return "Acquisition (ACQ)"
+              if re.search(r'_PA\d',  u): return "Capability Level 2 (PA 2.1 / PA 2.2)"
+              if re.search(r'_DEV\d', u): return "Deviations (DEV)"
               return "Other"
 
           group_order = [
@@ -317,11 +339,16 @@ jobs:
               "Support Processes (SUP)",
               "Acquisition (ACQ)",
               "Capability Level 2 (PA 2.1 / PA 2.2)",
+              "Deviations (DEV)",
+              "Internal Audits (AUD)",
               "Other",
           ]
           groups = {g: [] for g in group_order}
           for f in aspice_files:
               groups[classify(f)].append(f)
+          # Audit reports are classified by directory, not filename pattern -
+          # their names don't follow the "_XXX" process-code convention.
+          groups["Internal Audits (AUD)"] = audit_files
 
           idx_lines = [
               "# ASPICE CL2 Documentation",
@@ -343,23 +370,28 @@ jobs:
                   idx_lines.append(f"- [[{aspice_display(f)}|{aspice_slug(f)}]]")
               idx_lines.append("")
 
-          if aspice_files:
+          all_aspice_files = aspice_files + audit_files
+          if all_aspice_files:
               idx_lines += ["---", "", "## Document ID Reference", "",
                             "| Document ID | Process | Page |",
                             "|---|---|---|"]
-              for f in aspice_files:
+              for f in all_aspice_files:
                   doc_id = process = ""
-                  src = aspice_src / f
-                  if src.exists():
+                  src = doc_paths.get(f)
+                  if src and src.exists():
                       for line in src.read_text(encoding="utf-8").splitlines():
                           if not doc_id:
+                              # Work products use "Document ID"; audit
+                              # reports use "Audit ID" instead.
                               m = re.search(
-                                  r'\|\s*\*\*Document ID\*\*\s*\|\s*(\S+)\s*\|', line)
+                                  r'\|\s*\*\*(?:Document|Audit) ID\*\*\s*\|\s*(\S+)\s*\|', line)
                               if m:
                                   doc_id = m.group(1)
                           if not process:
+                              # Work products use "Related Process"; audit
+                              # reports use "Scope" instead.
                               p = re.search(
-                                  r'\|\s*\*\*Related Process\*\*\s*\|\s*([^\|]+?)\s*\|', line)
+                                  r'\|\s*\*\*(?:Related Process|Scope)\*\*\s*\|\s*([^\|]+?)\s*\|', line)
                               if p:
                                   process = p.group(1).strip()
                           if doc_id and process:
@@ -456,7 +488,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           README_SECTIONS=$(grep -c "^## " README.md || echo "0")
-          ASPICE_COUNT=$(find docs/aspice -maxdepth 1 -name "*.md" 2>/dev/null \
+          ASPICE_COUNT=$(find docs/aspice -name "*.md" 2>/dev/null \
                          | wc -l | tr -d ' ')
 
           {

--- a/docs/aspice/CStyleCheck_Analysis_Report.md
+++ b/docs/aspice/CStyleCheck_Analysis_Report.md
@@ -3,6 +3,8 @@
 *Automotive SPICE® V4 · MISRA C · CI/CD · Code Quality | Generated 2026-04-17*
 *Updated 2026-05-28 — post-v1.2 internal audit CSC-AUD-001 status addendum appended (§7)*
 
+> **⚠️ Historical snapshot — not maintained past v1.2.1.** This report and its §7 addendum reflect the codebase as of 2026-05-28 (v1.2.1). Three releases (v1.3.0, v1.4.0) and five further internal audits (CSC-AUD-002 through CSC-AUD-007) have landed since. For the current ASPICE CL2 status, see `CSC-PA2-001` §6 and the latest audit: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007).
+
 | Metric | Count |
 |---|---|
 | Files analysed | 87 (initial) / 102 (post-refactor) |

--- a/docs/aspice/CStyleCheck_PA2_Capability_Records.md
+++ b/docs/aspice/CStyleCheck_PA2_Capability_Records.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-PA2-001 | **Version** | 1.10 |
+| **Document ID** | CSC-PA2-001 | **Version** | 1.11 |
 | **Project** | CStyleCheck | **Date** | 2026-06-18 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.11 | 2026-06-18 | Claude | Fix §6 verdict summary arithmetic (11 F, 6 L → 9 F, 8 L; table itself was already correct); bump CSC-AUD-007 §5.4 entry to v1.1 (matching erratum); reorganise Wiki publishing into Deviations/Audits sections — see issue tracker |
 | 1.10 | 2026-06-18 | Claude | CSC-AUD-007 — §6 was stale since 2026-05-28 (predated issue #152 closure and superseding audit CSC-AUD-002); resync §6 ratings/verdict to current `main` (v1.4.0); CL2 confirmed ACHIEVED; add §5.4 rows for CSC-AUD-002/CSC-AUD-007 |
 | 1.9 | 2026-06-18 | Claude | ASPICE audit #254 — update §4.1/§5.4/§6 SWE.4 test count 965→1152; mark CI-017 released at v1.3.0 |
 | 1.8 | 2026-06-04 | Claude | Deep accuracy audit: fix §4.1 SWE.3 unit count (46→90), SUP.8 CI count (27→34), §6 SWE.3 (89→90) and SUP.8 (29→34); update §5.4 document version table — resolves issue #163 |
@@ -208,7 +209,7 @@ All work products are reviewed before approval according to the following schedu
 | CSC-AUD-002 | ASPICE Internal Audit — CL2 Re-assessment (2026-05-29) | 1.0 | Released | v1.2.1 tag |
 | CSC-AUD-003 | ASPICE Internal Audit — Accuracy (2026-06-04) | 1.0 | Released | issue #163 audit |
 | CSC-AUD-004 | ASPICE Internal Audit — Deep Accuracy (2026-06-04) | 1.0 | Released | issue #163 deep audit |
-| CSC-AUD-007 | ASPICE Internal Audit — CL2 Re-assessment (2026-06-18) | 1.0 | Released | v1.4.0 tag |
+| CSC-AUD-007 | ASPICE Internal Audit — CL2 Re-assessment (2026-06-18) | 1.1 | Released | v1.4.0 tag |
 | CI-001 | `src/cstylecheck/` package | 1.2.0 | Released | v1.2.0 tag |
 | CI-017 | Test suite (1152 tests) | 1.3.0 | Released | v1.3.0+ |
 
@@ -242,7 +243,7 @@ The table below summarises all assessed processes and their CL2 PA achievement e
 
 > **📋 Rating scale:** N = Not achieved (0–15%), P = Partially achieved (15–50%), L = Largely achieved (50–85%), F = Fully achieved (85–100%). All processes must achieve **L or F** at PA 2.1 and PA 2.2 for CL2 to be awarded.
 >
-> **✅ CL2 Verdict: ACHIEVED.** All 17 processes rate **L or F** (11 F, 6 L, 0 P/N). One corrective action remains open — **AUD7-F-001**: the 11 rules added in v1.3.0/v1.4.0 (issues #221–#232) have requirements/design/unit-test coverage (SWE.1/SWE.3/SWE.4) but no integration-, system-, or qualification-level test cases yet (SWE.5/SYS.4/SYS.5/SWE.6); `SYS-VTC-003`/`SWQ-003` still cite "53 rule IDs" instead of 75. This downgrades SWE.5 and SWE.6 from F to L but does not affect the CL2 award. Targeted for the v1.5.0 cycle. Full detail: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007).
+> **✅ CL2 Verdict: ACHIEVED.** All 17 processes rate **L or F** (9 F, 8 L, 0 P/N). One corrective action remains open — **AUD7-F-001**: the 11 rules added in v1.3.0/v1.4.0 (issues #221–#232) have requirements/design/unit-test coverage (SWE.1/SWE.3/SWE.4) but no integration-, system-, or qualification-level test cases yet (SWE.5/SYS.4/SYS.5/SWE.6); `SYS-VTC-003`/`SWQ-003` still cite "53 rule IDs" instead of 75. This downgrades SWE.5 and SWE.6 from F to L but does not affect the CL2 award. Targeted for the v1.5.0 cycle. Full detail: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007).
 >
 > **Ratings assigned by internal audit CSC-AUD-007, 2026-06-18 (supersedes CSC-AUD-001 2026-05-28 and CSC-AUD-002 2026-05-29 for this table).**
 

--- a/docs/aspice/CStyleCheck_Review_Record_v1.2.md
+++ b/docs/aspice/CStyleCheck_Review_Record_v1.2.md
@@ -2,6 +2,8 @@
 
 *Produced using CSC-REVIEW-TEMPLATE-001 v1.0*
 
+> **⚠️ Historical snapshot — pinned to the v1.2.1 baseline, not re-run for later releases.** This record covers the 21 work products as reviewed on 2026-05-29. It is not updated each release; a new review record would need a new document ID/version. For the current document and CL2 status, see `CSC-PA2-001` §5.4/§6 and the latest audit, CSC-AUD-007 (`docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md`).
+
 ---
 
 ## 1. Review Identification

--- a/docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md
+++ b/docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md
@@ -78,7 +78,7 @@ This does **not** block CL2 — L is a passing rating — but it is the top corr
 
 ### 4.1 Overall CL2 Verdict
 
-**✅ ASPICE CL2 IS ACHIEVED at v1.4.0.** All 17 processes rate **L or F** (11 F, 6 L, 0 P/N). The `CSC-PA2-001` §6 table's "NOT YET ACHIEVED" verdict was stale — it predated both the closure of issue #152 (2026-05-28) and the superseding re-assessment CSC-AUD-002 (2026-05-29) by several weeks, and was never refreshed across five subsequent document revisions.
+**✅ ASPICE CL2 IS ACHIEVED at v1.4.0.** All 17 processes rate **L or F** (9 F, 8 L, 0 P/N). The `CSC-PA2-001` §6 table's "NOT YET ACHIEVED" verdict was stale — it predated both the closure of issue #152 (2026-05-28) and the superseding re-assessment CSC-AUD-002 (2026-05-29) by several weeks, and was never refreshed across five subsequent document revisions.
 
 One corrective action remains open (AUD7-F-001/#261: extend SWE.5/SYS.4/SYS.5/SWE.6 verification scope to the 11 rules added in v1.3.0/v1.4.0), tracked for the v1.5.0 cycle. It does not affect the CL2 award since the affected processes still rate L.
 
@@ -111,5 +111,7 @@ CL2 was actually achieved on 2026-05-29 (CSC-AUD-002, at v1.2.1) and remains ach
 
 ---
 
-*Document: CSC-AUD-007 · Version 1.0 · 2026-06-18*
+*Erratum (v1.1, 2026-06-18): §4.1 summary corrected from "11 F, 6 L" to "9 F, 8 L" to match the §4 table; the row-by-row ratings and the CL2 ACHIEVED verdict were already correct and are unaffected.*
+
+*Document: CSC-AUD-007 · Version 1.1 · 2026-06-18*
 *Location: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md`*


### PR DESCRIPTION
## Summary

Follow-up to CSC-AUD-007 (#262/#263), addressing items found while answering a question about the L-vs-F rating breakdown plus direct feedback on Wiki organization:

- **Count typo**: `CSC-PA2-001` §6 and `CSC-AUD-007` §4.1 said "11 F, 6 L" but the table itself has always shown 9 F / 8 L (17 total either way). Fixed the summary text in both docs; CSC-AUD-007 bumped to v1.1 with an erratum note (verdict/ratings unaffected).
- **Wiki: audit reports were never published.** `wiki_publish.yml` only globbed the top-level `docs/aspice/*.md`, so all 6 files in `docs/aspice/audits/` (including CSC-AUD-007 itself) were silently excluded from the Wiki. Refactored the publish step to also walk the `audits/` subdirectory.
- **Wiki: new "Deviations" and "Internal Audits" sidebar/index sections.** CSC-DEV-001/002 and the 6 audit reports were falling into a generic "Other" bucket. They now get their own dedicated sections, and the Document ID Reference table recognises `**Audit ID**`/`**Scope**` fields (audit reports use those instead of `**Document ID**`/`**Related Process**`).
- **Wiki: fixed a pre-existing classification bug.** `CStyleCheck_ACQ4_Supplier_Monitoring_Plan.md` was being filed under "Support Processes" because the substring check `'_SUP' in filename` matches inside `_SUPplier_`. Switched to a `_<CODE><digit>` regex match, verified by running the generator script against the real docs tree before/after.
- **Flagged two stale-looking reports** (`CStyleCheck_Analysis_Report.md`, `CStyleCheck_Review_Record_v1.2.md`) as historical snapshots pinned to v1.2.1 (2026-05-28/29), with a pointer to the current CSC-AUD-007 status, rather than rewriting their content (consistent with how the dated audit reports are already treated as immutable point-in-time artifacts).

## Test plan

- [x] Extracted and syntax-checked the embedded Python script from `wiki_publish.yml`
- [x] Ran the script against the real `docs/aspice/` tree in a scratch directory (before and after the classify() fix) and confirmed: audit pages are written with correct slugs (no doubled `ASPICE-ASPICE-` prefix), Deviations/Internal Audits sections appear in `_Sidebar.md` and `ASPICE-Index.md`, and ACQ.4 now correctly lands under Acquisition instead of Support Processes
- [ ] Merge and confirm `Publish Wiki` Action run succeeds (will need a follow-up develop→main sync, same as #263, since the workflow only triggers on push to `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_