### PR TITLE
Sync develop → main: fix variable.parameter.p_prefix false positive on call statements (#273)

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -169,6 +169,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # ── Extract the matching CHANGELOG.md section as release notes ──────────
       - name: Extract release notes from CHANGELOG.md

--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -93,7 +93,13 @@ RE_FUNCTION_DEF = re.compile(
     r"(?:(?:long[ \t]+long|long|short)[ \t]+)?"
     r"(?!(?:" + _CFKW + r")\b)"         # return type must NOT be a keyword
     r"\w+"                              # return type (one token)
-    r"[ \t]*\*?[ \t]*"
+    # A real declaration always has a visible separator (whitespace and/or
+    # pointer star) between the return type and the function name. A plain
+    # call statement (e.g. "foo (args) ;") is a single identifier with no
+    # such separator, so without this requirement \w+ can backtrack to peel
+    # off the call's trailing character as a fake "name" and misparse the
+    # call as a declaration (issue #273).
+    r"(?:[ \t]+\*{0,2}|\*{1,2})[ \t]*"
     r"([A-Za-z_]\w*)"                  # FUNCTION NAME — group 1
     r"[ \t]*\([^;{}]*\)"              # param list — [^;{}] matches newlines
     r"[ \t\n]*\{",                    # allow newline before opening brace
@@ -110,7 +116,9 @@ RE_FUNCTION_DECL = re.compile(
     r"(?:(?:long[ \t]+long|long|short)[ \t]+)?"
     r"(?!(?:" + _CFKW + r")\b)"
     r"\w+"                              # return type
-    r"[ \t]*\*?[ \t]*"
+    # See RE_FUNCTION_DEF above: require a real separator so a bare call
+    # statement's identifier can't be split into a fake type+name pair.
+    r"(?:[ \t]+\*{0,2}|\*{1,2})[ \t]*"
     r"([A-Za-z_]\w*)"                  # FUNCTION NAME — group 1
     r"[ \t]*\([^;{}]*\)"              # param list — [^;{}] matches newlines
     r"[ \t\n]*;",                     # ends with semicolon (declaration)

--- a/tests/test_parameter_prefix.py
+++ b/tests/test_parameter_prefix.py
@@ -508,5 +508,77 @@ class TestParamPrefixCombinedNoFalsePositive(unittest.TestCase):
             "p_p_buf should satisfy both p_prefix and pointer_prefix='p_'")
 
 
+# ===========================================================================
+# Regression: a function-CALL statement inside a function body must not be
+# misparsed as a declaration/definition (GitHub issue #273).
+#
+# RE_FUNCTION_DECL / RE_FUNCTION_DEF require a "return type" token followed
+# by a "name" token before "(args)". A call statement like "foo (args) ;" is
+# only a single identifier, but without a mandatory separator between the
+# two captured tokens, regex backtracking could peel off the call's last
+# character as a fake "name", turning the call into a fake declaration whose
+# "parameters" (the call's actual arguments) then got checked as if they
+# were real function parameters.
+# ===========================================================================
+
+class TestCallStatementNotMisparsedAsDeclaration(unittest.TestCase):
+
+    def test_zero_param_function_call_in_body_not_flagged(self):
+        """Reproduces app_normal.c:712 — call inside a (void) function."""
+        src = (
+            "void f (void)\n"
+            "{\n"
+            "    API_Radio_Field_ParameterPut (0U, (uint16_t) data.param.period) ;\n"
+            "}\n"
+        )
+        self.assertFalse(has(src, ON, RULE))
+
+    def test_call_with_correctly_prefixed_args_not_flagged(self):
+        """Reproduces api_ble.c:248 — call whose args are already 'p_'-prefixed."""
+        src = (
+            "void API_Ble_ProtocolInit (uint32_t p_fast_interval, "
+            "uint32_t p_fast_timeout)\n"
+            "{\n"
+            "    HAL_Ble_ProtocolInit (p_fast_interval, p_fast_timeout) ;\n"
+            "}\n"
+        )
+        self.assertFalse(has(src, ON, RULE))
+
+    def test_real_signature_with_genuine_violation_still_caught(self):
+        """The fix must not blind the rule to real, badly-named parameters."""
+        src = (
+            "void f (uint32_t timeout, uint8_t * buf)\n"
+            "{\n"
+            "    (void) timeout ;\n"
+            "}\n"
+        )
+        vs = [v for v in run(src, ON) if v.rule == RULE]
+        names = {v.message.split("'")[1] for v in vs}
+        self.assertEqual(names, {"timeout", "buf"})
+
+    def test_pointer_return_type_definition_still_detected(self):
+        """A real function returning a pointer (no space before name) still
+        has its parameters checked — only the separator-less call case
+        should be excluded."""
+        src = (
+            "uint8_t* f(uint32_t channel)\n"
+            "{\n"
+            "    return 0U ;\n"
+            "}\n"
+        )
+        self.assertTrue(has(src, ON, RULE))
+
+    def test_call_statement_in_header_declaration_context_not_flagged(self):
+        """A call-shaped line ending in ';' must not be treated as a
+        prototype either (covers the RE_FUNCTION_DECL path)."""
+        src = (
+            "void g (void)\n"
+            "{\n"
+            "    HAL_DoThing (some_value, other_value) ;\n"
+            "}\n"
+        )
+        self.assertFalse(has(src, ON, RULE))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Syncs `develop` into `main` to bring in the merged fix for #273 (PR #274):

- `src/cstylecheck/checker.py` — `RE_FUNCTION_DECL`/`RE_FUNCTION_DEF` now require a real separator between the captured return-type and name tokens, so a bare call statement (`foo (args) ;`) can no longer be backtracked into a fake declaration. This was producing `variable.parameter.p_prefix` false positives on call statements/arguments inside function bodies.
- `tests/test_parameter_prefix.py` — regression tests for the fix.
- `.github/workflows/docker_publish.yml` — `github-release` job's checkout step now sets `token: secrets.GITHUB_TOKEN`, matching the `build-and-push` job's checkout (fixes a pre-existing, unrelated CI gap found while triaging this PR's checks).

## Testing

`python3 -m pytest tests/` → 1157 passed on `develop` after merge.

## Next steps

Once merged, ASPICE docs (`docs/aspice/...`) will be updated to record this fix, and a new version will be released per the project's release process.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_