### PR TITLE
docs(aspice): correct SYS-F-011 rule count 53→71; add AUD-005/AUD-006 rows to PA2 §5.4

### DIFF
--- a/docs/aspice/CStyleCheck_PA2_Capability_Records.md
+++ b/docs/aspice/CStyleCheck_PA2_Capability_Records.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-PA2-001 | **Version** | 1.13 |
+| **Document ID** | CSC-PA2-001 | **Version** | 1.14 |
 | **Project** | CStyleCheck | **Date** | 2026-06-25 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.14 | 2026-06-25 | Claude | §5.4: add missing CSC-AUD-005 and CSC-AUD-006 rows; update CSC-SYS2-001 to 1.7; update self to 1.14 — closes issues #266, #270 |
 | 1.13 | 2026-06-25 | Claude | Doc accuracy — update §5.4 baseline table: all document versions synced to v1.4.1 state (CSC-AUD-007 / PR #281); fix CI-001/CI-017 versions; update §5.4 preamble |
 | 1.12 | 2026-06-25 | Claude | AUD7-F-001 doc fix — update §6 SWE.6 capability summary; update CL2 verdict note to reflect SYS-VTC-003/SWQ-003 updated to 71 rule IDs; remaining test-scope gap still pending v1.5.0 |
 | 1.11 | 2026-06-18 | Claude | Fix §6 verdict summary arithmetic (11 F, 6 L → 9 F, 8 L; table itself was already correct); bump CSC-AUD-007 §5.4 entry to v1.1 (matching erratum); reorganise Wiki publishing into Deviations/Audits sections — see issue tracker |
@@ -186,7 +187,7 @@ All work products are reviewed before approval according to the following schedu
 
 | Document ID | Work Product | Version | Baseline Status | CM Baseline |
 |---|---|---|---|---|
-| CSC-SYS2-001 | System Requirements Spec | 1.6 | Released | CSC-AUD-007 |
+| CSC-SYS2-001 | System Requirements Spec | 1.7 | Released | PR #282 (issue #266) |
 | CSC-SYS3-001 | System Architecture Description | 1.5 | Released | CSC-AUD-007 |
 | CSC-SYS4-001 | System Integration Test Spec | 1.4 | Released | CSC-AUD-007 |
 | CSC-SYS5-001 | System Verification Report | 1.7 | Released | PR #280 (AUD7-F-001) |
@@ -203,7 +204,7 @@ All work products are reviewed before approval according to the following schedu
 | CSC-SUP9-001 | Problem Resolution Plan | 1.2 | Released | CSC-AUD-007 |
 | CSC-SUP10-001 | Change Request Plan | 1.2 | Released | CSC-AUD-007 |
 | CSC-ACQ4-001 | Supplier Monitoring Plan | 1.2 | Released | CSC-AUD-007 |
-| CSC-PA2-001 | PA 2.1 / PA 2.2 Records | 1.13 | Released | PR #281 (doc accuracy) |
+| CSC-PA2-001 | PA 2.1 / PA 2.2 Records | 1.14 | Released | PR #282 (issue #270) |
 | CSC-DEV-001 | AI Authorship Deviation Record | 1.1 | Released | v1.1.0 tag |
 | CSC-DEV-002 | Independent Review Deviation Record | 1.0 | Released | v1.1.0 tag |
 | CSC-SVD-001 | Software Version Description | 1.13 | Released | PR #281 (doc accuracy) |
@@ -211,6 +212,8 @@ All work products are reviewed before approval according to the following schedu
 | CSC-AUD-002 | ASPICE Internal Audit — CL2 Re-assessment (2026-05-29) | 1.0 | Released | v1.2.1 tag |
 | CSC-AUD-003 | ASPICE Internal Audit — Accuracy (2026-06-04) | 1.0 | Released | issue #163 audit |
 | CSC-AUD-004 | ASPICE Internal Audit — Deep Accuracy (2026-06-04) | 1.0 | Released | issue #163 deep audit |
+| CSC-AUD-005 | ASPICE Internal Audit — Post-release accuracy (2026-06-05) | 1.0 | Released | issue #163 / v1.3.0 |
+| CSC-AUD-006 | ASPICE Internal Audit — Test/module-count drift (2026-06-18) | — | Released (issue #254 only; no standalone report) | issue #254 |
 | CSC-AUD-007 | ASPICE Internal Audit — CL2 Re-assessment (2026-06-18) | 1.1 | Released | v1.4.0 tag |
 | CI-001 | `src/cstylecheck/` package | 1.4.1 | Released | v1.4.1 tag |
 | CI-017 | Test suite (1157 tests) | 1.4.1 | Released | v1.4.1 tag |

--- a/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
+++ b/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS2-001 | **Version** | 1.6 |
-| **Project** | CStyleCheck | **Date** | 2026-06-18 |
+| **Document ID** | CSC-SYS2-001 | **Version** | 1.7 |
+| **Project** | CStyleCheck | **Date** | 2026-06-25 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SYS.2 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.7 | 2026-06-25 | Claude | Correct rule count 53→71 in §3.1 purpose text and SYS-F-011 — closes issue #266 |
 | 1.6 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.5 | 2026-06-04 | Claude | Add SYS-F-041 to SYS-F-045 for five new features (inline suppression, --fix, --init/--preset, per-dir config, HTML output); update §6 RTM — issues #188 #189 #190 #193 #192 |
 | 1.4 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.2 "three modes" text (listed 4 modes), update §3.3 referenced doc versions — resolves issue #163 |
@@ -34,7 +35,7 @@
 
 ### 3.1 Purpose
 
-This System Requirements Specification (SRS) defines the complete, structured set of system-level requirements for **CStyleCheck v1.2.x** — an embedded C naming-convention linter implementing Barr-C:2018 and MISRA-C complementary rules across 53 rule IDs.
+This System Requirements Specification (SRS) defines the complete, structured set of system-level requirements for **CStyleCheck v1.2.x** — an embedded C naming-convention linter implementing Barr-C:2018 and MISRA-C complementary rules across 71 rule IDs.
 
 This document satisfies the requirements of **Automotive SPICE® PAM v4.0, SYS.2 — System Requirements Analysis**.
 
@@ -109,7 +110,7 @@ The following table summarises the stakeholder needs from which the system requi
 
 | REQ-ID | Requirement | Priority | Verification Method | Derived From |
 |---|---|---|---|---|
-| SYS-F-011 | The system shall enforce naming rules across 53 rule IDs covering: constants/macros, variables (by scope), functions, types (typedef/enum/struct), include guards, and miscellaneous rules | Mandatory | Test | STK-001, STK-002 |
+| SYS-F-011 | The system shall enforce naming rules across 71 rule IDs covering: constants/macros, variables (by scope), functions, types (typedef/enum/struct), include guards, and miscellaneous rules | Mandatory | Test | STK-001, STK-002 |
 | SYS-F-012 | The system shall enforce module-prefix requirements on global variables, file-scope static variables, public functions, macros, and constants | Mandatory | Test | STK-001 |
 | SYS-F-013 | The system shall enforce scope-aware variable rules: global (`g_` prefix), file-static (`s_` prefix), local, and parameter — each independently configurable | Mandatory | Test | STK-001 |
 | SYS-F-014 | The system shall enforce pointer-prefix rules: single pointer (`p_`), double pointer (`pp_`), boolean (`b_`), and handle variables (`h_`) | Mandatory | Test | STK-001 |


### PR DESCRIPTION
## Summary

Two quick documentation accuracy fixes.

### Changes

- **CSC-SYS2-001 v1.6→v1.7** (`CStyleCheck_SYS2_System_Requirements.md`)
  - §3.1 purpose text: "across 53 rule IDs" → "71 rule IDs"
  - SYS-F-011 requirement text: "across 53 rule IDs" → "71 rule IDs"
  - Closes issue #266

- **CSC-PA2-001 v1.13→v1.14** (`CStyleCheck_PA2_Capability_Records.md`)
  - §5.4 baseline table: add missing `CSC-AUD-005` row (v1.0, post-release accuracy audit 2026-06-05, reported in `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-05.md`)
  - §5.4 baseline table: add `CSC-AUD-006` row — this audit was documented via GitHub issue #254 only; no standalone report file exists. Row notes this explicitly rather than leaving it absent.
  - CSC-SYS2-001: 1.6→1.7; self-reference: 1.13→1.14
  - Closes issue #270

### Reviewer notes

- The issue #266 body said "53→75" but 71 is the confirmed rule count per source-code analysis (see PR #280).
- CSC-AUD-006 intentionally has no standalone `.md` report. The issue #270 acceptance criterion is satisfied by documenting this fact in the row rather than leaving the row absent.

## Test plan

- [ ] Verify no remaining "53 rule" text in CSC-SYS2-001
- [ ] Verify CSC-PA2-001 §5.4 now has rows for CSC-AUD-001 through CSC-AUD-007 (contiguous)
- [ ] Verify CSC-AUD-006 row clearly notes it is issue-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_