### PR TITLE
README: add "Recommendations for source code" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,45 @@ uint32_t val = 100;  // cstylecheck: disable=misc.unsigned_suffix,misc.magic_num
 
 ---
 
+## Recommendations for source code
+
+These recommendations help you write C source that produces accurate, low-noise
+results from CStyleCheck.
+
+### Prefer `typedef` over `#define` for type aliases
+
+Object-like `#define`s are syntactically indistinguishable from constant
+definitions, so CStyleCheck checks them against the `constant.case` rule
+(upper-snake by default). A `_t`- or `_T`-suffixed macro will therefore be
+flagged even though it is logically a type alias, not a constant:
+
+```c
+/* Avoid — CStyleCheck cannot tell this #define introduces a type rather
+ * than a constant value, so it is checked against constant.case (upper_snake)
+ * and will be flagged: */
+#define api_nvm_error_t   uint8_t
+
+/* Prefer — typedef is unambiguous; it is checked against typedef.case and
+ * typedef.suffix instead, and is the standard C99+ idiom for type aliasing: */
+typedef uint8_t api_nvm_error_t;
+```
+
+Reserve `#define`-based type aliasing for legacy/pre-C99 or assembler-shared
+headers where `typedef` is unavoidable. If you must use it, add an exemption
+pattern to suppress the false positive:
+
+```yaml
+# rules.yml
+constants:
+  exempt_patterns:
+    - '.*_t$'   # suppress constant.case for _t-suffixed #define type aliases
+```
+
+See issue [#244](https://github.com/dermot-murphy/CStyleCheck/issues/244) for
+the original discussion.
+
+---
+
 ## Auto-fix mode
 
 CStyleCheck can apply safe, mechanical fixes in-place.  All currently fixable


### PR DESCRIPTION
## Summary

Adds a new `## Recommendations for source code` section to `README.md`, placed after `## Inline suppression comments` and before `## Auto-fix mode`.

The section is seeded with the `typedef` vs `#define` recommendation that came out of issue #244: explains why `_t`-suffixed `#define` type aliases trigger `constant.case`, shows the preferred `typedef` pattern, and documents the `constants.exempt_patterns` workaround for unavoidable legacy use.

Per the `wiki_publish.yml` README-section parser, this new `##` section will automatically appear as its own **"Recommendations for source code"** page on the GitHub Wiki on the next push to `main` — no workflow changes needed.

## Test plan

- [ ] Verify section renders correctly in the GitHub PR diff preview
- [ ] Verify placement: after `## Inline suppression comments`, before `## Auto-fix mode`
- [ ] Confirm C code blocks display correctly (both `#define` and `typedef` examples)
- [ ] Confirm YAML code block for `exempt_patterns` workaround renders correctly
- [ ] After merge to `main`: confirm Wiki gains a new "Recommendations for source code" page

Closes #271.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_