### PR TITLE
fix(aspice): resolve SYS.2 RTM traceability gap; advance SYS.2 L→F; 17F/0L

### DIFF
--- a/docs/aspice/CStyleCheck_PA2_Capability_Records.md
+++ b/docs/aspice/CStyleCheck_PA2_Capability_Records.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-PA2-001 | **Version** | 1.17 |
+| **Document ID** | CSC-PA2-001 | **Version** | 1.18 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.18 | 2026-06-26 | Claude | §6: advance SYS.2 L→F (RTM placeholders resolved; §3.3 SWE1-001 added; scope updated to v1.4.1); verdict 16F/1L→17F/0L; §5.4: SYS2 to 1.9, self to 1.18 — closes issue #292 |
 | 1.17 | 2026-06-26 | Claude | §6: advance SYS.4/SYS.5/SWE.5/SWE.6 L→F (SITC-015 + SIT-019 added; SYS-F-020 expanded; AUD7-F-001 fully resolved); verdict 12F/5L→16F/1L — closes issue #261 |
 | 1.16 | 2026-06-26 | Claude | §6: advance SUP.1 L→F (recurring review process established; CSC-REVIEW-002 produced); verdict 11F/6L→12F/5L; §5.4: update SUP1 to 1.5, add CSC-REVIEW-001/002 rows, self to 1.16 — closes issue #268 |
 | 1.15 | 2026-06-26 | Claude | §6: advance MAN.5 L→F and ACQ.4 L→F (RISK-003/005 treatments implemented; SUP-06 added); verdict 9F/8L→11F/6L; §5.4: update MAN5 to 1.4, ACQ4 to 1.3, self to 1.15 |
@@ -190,7 +191,7 @@ All work products are reviewed before approval according to the following schedu
 
 | Document ID | Work Product | Version | Baseline Status | CM Baseline |
 |---|---|---|---|---|
-| CSC-SYS2-001 | System Requirements Spec | 1.8 | Released | PR #261 (issue #261) |
+| CSC-SYS2-001 | System Requirements Spec | 1.9 | Released | PR (issue #292) |
 | CSC-SYS3-001 | System Architecture Description | 1.5 | Released | CSC-AUD-007 |
 | CSC-SYS4-001 | System Integration Test Spec | 1.5 | Released | PR #261 (issue #261) |
 | CSC-SYS5-001 | System Verification Report | 1.7 | Released | PR #280 (AUD7-F-001) |
@@ -207,7 +208,7 @@ All work products are reviewed before approval according to the following schedu
 | CSC-SUP9-001 | Problem Resolution Plan | 1.2 | Released | CSC-AUD-007 |
 | CSC-SUP10-001 | Change Request Plan | 1.2 | Released | CSC-AUD-007 |
 | CSC-ACQ4-001 | Supplier Monitoring Plan | 1.3 | Released | PR D (issue #269) |
-| CSC-PA2-001 | PA 2.1 / PA 2.2 Records | 1.17 | Released | PR (issue #261) |
+| CSC-PA2-001 | PA 2.1 / PA 2.2 Records | 1.18 | Released | PR (issue #292) |
 | CSC-REVIEW-001 | ASPICE Peer Review Record (v1.2.1 baseline) | 1.0 | Released | issue #169 |
 | CSC-REVIEW-002 | ASPICE Peer Review Record (v1.4.1 baseline) | 1.0 | Released | PR (issue #268) |
 | CSC-DEV-001 | AI Authorship Deviation Record | 1.1 | Released | v1.1.0 tag |
@@ -233,7 +234,7 @@ The table below summarises all assessed processes and their CL2 PA achievement e
 
 | Process | PA 1.1 (Performed) | PA 2.1 (Perf. Mgmt) | PA 2.2 (WP Mgmt) | Assessment Verdict | Open Issue(s) |
 |---|---|---|---|---|---|
-| SYS.2 | SYS REQ-IDs defined and traceable | Objectives: §4.1; strategy: §4.2 | CSC-SYS2-001 reviewed; in CM | **L** | — |
+| SYS.2 | 45 SYS REQ-IDs defined and traced to SWE.1 (§6 RTM); all placeholder IDs resolved | Objectives: §4.1; strategy: §4.2 | CSC-SYS2-001 v1.9 reviewed; in CM | **F** | — |
 | SYS.3 | Architecture with subsystems and interfaces | Objectives: §4.1; monitoring: §4.3 | CSC-SYS3-001 reviewed; in CM | **F** | — |
 | SYS.4 | 15 SITC test cases defined and executed; all 71 rules covered including 11 v1.4.0 rules (SITC-015) | Objectives: §4.1 | CSC-SYS4-001 reviewed; in CM | **F** | — |
 | SYS.5 | SYS-VTC test cases defined and executed; SYS-VTC-003 covers all 71 rule IDs | Objectives: §4.1 | CSC-SYS5-001 reviewed; in CM | **F** | — |
@@ -253,7 +254,7 @@ The table below summarises all assessed processes and their CL2 PA achievement e
 
 > **📋 Rating scale:** N = Not achieved (0–15%), P = Partially achieved (15–50%), L = Largely achieved (50–85%), F = Fully achieved (85–100%). All processes must achieve **L or F** at PA 2.1 and PA 2.2 for CL2 to be awarded.
 >
-> **✅ CL2 Verdict: ACHIEVED.** All 17 processes rate **L or F** (16 F, 1 L, 0 P/N). SYS.4, SYS.5, SWE.5, and SWE.6 advanced to F (2026-06-26): SITC-015 and SIT-019 added covering all 11 v1.4.0 rules; SYS-F-020 expanded to enumerate all misc and macro-safety rules; AUD7-F-001 fully resolved (issue #261). The sole remaining L is **SYS.2**: system requirements scope covers all 71 rules, but the requirements document version and cross-reference precision do not yet fully satisfy the F threshold. Targeted for the v1.5.0 cycle. Full detail: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007).
+> **✅ CL2 Verdict: ACHIEVED.** All 17 processes rate **F** (17 F, 0 L, 0 P/N). SYS.2 advanced to F (2026-06-26): CSC-SYS2-001 §6 RTM placeholder IDs replaced with actual SWE1-xxx IDs; CSC-SWE1-001 added to §3.3; scope updated to v1.4.1 (issue #292). All previously open ASPICE findings (AUD7-F-001, issues #261–#271) resolved. Full detail: `docs/aspice/audits/CStyleCheck_ASPICE_Internal_Audit_2026-06-18.md` (CSC-AUD-007).
 >
 > **Ratings assigned by internal audit CSC-AUD-007, 2026-06-18 (supersedes CSC-AUD-001 2026-05-28 and CSC-AUD-002 2026-05-29 for this table).**
 

--- a/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
+++ b/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS2-001 | **Version** | 1.8 |
+| **Document ID** | CSC-SYS2-001 | **Version** | 1.9 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-26 | Claude | §6 RTM: replace all `\<SWE.1-REQ-xxx\>` placeholders with actual SWE1-xxx IDs; add CSC-SWE1-001 to §3.3; update §3.1 scope to v1.4.1 — closes issue #292 |
 | 1.8 | 2026-06-26 | Claude | Update SYS-F-020 to include v1.4.0 misc and macro-safety rules — closes issue #261 |
 | 1.7 | 2026-06-25 | Claude | Correct rule count 53→71 in §3.1 purpose text and SYS-F-011 — closes issue #266 |
 | 1.6 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
@@ -36,7 +37,7 @@
 
 ### 3.1 Purpose
 
-This System Requirements Specification (SRS) defines the complete, structured set of system-level requirements for **CStyleCheck v1.2.x** — an embedded C naming-convention linter implementing Barr-C:2018 and MISRA-C complementary rules across 71 rule IDs.
+This System Requirements Specification (SRS) defines the complete, structured set of system-level requirements for **CStyleCheck v1.4.1** — an embedded C naming-convention linter implementing Barr-C:2018 and MISRA-C complementary rules across 71 rule IDs.
 
 This document satisfies the requirements of **Automotive SPICE® PAM v4.0, SYS.2 — System Requirements Analysis**.
 
@@ -59,6 +60,7 @@ The system is deployed in four integration modes:
 | Barr-C:2018 | Barr Group Embedded C Coding Standard | 2018 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Analysis | 1.9 |
 
 ### 3.4 Glossary
 
@@ -205,14 +207,14 @@ The following table summarises the stakeholder needs from which the system requi
 
 | REQ-ID | Category | Stakeholder Need | SYS.3 Architecture Element | SWE.1 SW Requirement |
 |---|---|---|---|---|
-| SYS-F-001 to SYS-F-010 | Input handling | STK-001, STK-002 | Input parser subsystem | \<SWE.1-REQ-001 to 010\> |
-| SYS-F-011 to SYS-F-026 | Rule engine | STK-001, STK-002 | Rule engine subsystem | \<SWE.1-REQ-011 to 026\> |
-| SYS-F-027 to SYS-F-033 | Output / reporting | STK-003, STK-005, STK-007 | Output formatter subsystem | \<SWE.1-REQ-027 to 033\> |
-| SYS-F-034 to SYS-F-036 | Baseline suppression | STK-004 | Baseline manager subsystem | \<SWE.1-REQ-034 to 036\> |
-| SYS-F-037 to SYS-F-040 | Exit codes | STK-003 | Main orchestrator | \<SWE.1-REQ-037 to 040\> |
-| SYS-NF-001 to SYS-NF-002 | Performance | STK-003 | Source cache | \<SWE.1-REQ-041 to 042\> |
-| SYS-NF-003 to SYS-NF-006 | Portability | STK-001, STK-006 | Build / packaging | \<SWE.1-REQ-043 to 046\> |
-| SYS-NF-007 to SYS-NF-009 | Configurability | STK-002 | Configuration loader | \<SWE.1-REQ-047 to 049\> |
+| SYS-F-001 to SYS-F-010 | Input handling | STK-001, STK-002 | SS-01 (CLI), SS-02 (Config Loader), SS-04 (Source Parser) | SWE1-001 to SWE1-016, SWE1-068 to SWE1-070 |
+| SYS-F-011 to SYS-F-026 | Rule engine | STK-001, STK-002 | SS-05 (Rule Engine) | SWE1-017 to SWE1-056, SWE1-MISRA-001 to SWE1-MISRA-003, SWE1-071, SWE1-078 to SWE1-088 |
+| SYS-F-027 to SYS-F-033 | Output / reporting | STK-003, STK-005, STK-007 | SS-06 (Output Formatter) | SWE1-057 to SWE1-064 |
+| SYS-F-034 to SYS-F-036 | Baseline suppression | STK-004 | SS-01 (CLI), SS-05 (Rule Engine) | SWE1-065 to SWE1-067 |
+| SYS-F-037 to SYS-F-040 | Exit codes | STK-003 | SS-01 (CLI / Entry Point) | SWE1-069 |
+| SYS-NF-001 to SYS-NF-002 | Performance | STK-003 | SS-04 (Source Cache) | SWE1-015 |
+| SYS-NF-003 to SYS-NF-006 | Portability | STK-001, STK-006 | Build / packaging (`pyproject.toml`, `Dockerfile`) | Verified at system level by CI matrix (SWE1-069 entry point exercised on Python 3.10 / 3.11 / 3.12) |
+| SYS-NF-007 to SYS-NF-009 | Configurability | STK-002 | SS-02 (Config Loader) | SWE1-001, SWE1-005, SWE1-068 |
 | SYS-NF-010 | Integration (pre-commit) | STK-001 | `.pre-commit-hooks.yml` | Deferred v2.0 |
 | SYS-NF-011 | Integration (GitHub Marketplace) | STK-005 | `action.yml` | Out of Scope v1.x |
 | SYS-NF-012 | Integration (step outputs) | STK-005 | `action.yml` | Deferred v2.0 |


### PR DESCRIPTION
## Summary

Closes **issue #292** — the last ASPICE L-rated process. All 17 processes now F.

- **CSC-SYS2-001 v1.8→v1.9**:
  - §3.1: update scope from `v1.2.x` to `v1.4.1`
  - §3.3: add `CSC-SWE1-001 v1.9` as referenced document (RTM traces to SWE1-xxx IDs so it must be cited)
  - §6 RTM: replace all 8 `\<SWE.1-REQ-xxx\>` placeholder rows with actual SWE1-xxx requirement IDs (the main ASPICE PA 2.2 traceability gap):
    - `SYS-F-001 to SYS-F-010` → `SWE1-001 to SWE1-016, SWE1-068 to SWE1-070`
    - `SYS-F-011 to SYS-F-026` → `SWE1-017 to SWE1-056, SWE1-MISRA-001–003, SWE1-071, SWE1-078 to SWE1-088`
    - `SYS-F-027 to SYS-F-033` → `SWE1-057 to SWE1-064`
    - `SYS-F-034 to SYS-F-036` → `SWE1-065 to SWE1-067`
    - `SYS-F-037 to SYS-F-040` → `SWE1-069`
    - `SYS-NF-001 to SYS-NF-002` → `SWE1-015`
    - `SYS-NF-003 to SYS-NF-006` → CI matrix / `SWE1-069`
    - `SYS-NF-007 to SYS-NF-009` → `SWE1-001, SWE1-005, SWE1-068`

- **CSC-PA2-001 v1.17→v1.18**: SYS.2 L→F; CL2 verdict **16F/1L → 17F/0L**; §5.4 versions updated

## Test plan

- [ ] Verify §6 RTM has no remaining `\<SWE.1-REQ` placeholder text
- [ ] Verify all SWE1 IDs cited in the RTM exist in CSC-SWE1-001 (spot-check SWE1-015, SWE1-069, SWE1-078)
- [ ] Verify §3.3 lists CSC-SWE1-001 v1.9
- [ ] Verify §3.1 says v1.4.1
- [ ] Verify PA2 §6 shows 17 F, 0 L
- [ ] Verify PA2 verdict text says 17F/0L

Closes #292

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_