### PR TITLE
chore(release): bump version to v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,38 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.5.0] — 2026-06-26
+
+### Added
+
+- **`misc.non_ascii_source` rule** — flags characters outside the printable ASCII set
+  (code points outside 0x20–0x7E, plus TAB/LF/CR), implementing MISRA C:2012/2023 Rule 4.1.
+  Optional `exempt_string_literals: true` suppresses violations inside double-quoted string
+  literals (issue [#279](https://github.com/dermot-murphy/CStyleCheck/issues/279)).
+- **Per-file breakdown in `--summary` output** — the summary block now includes
+  "Files with errors / warnings / info / clean" counts. Invariant: all four buckets
+  sum to the total files-checked count
+  (issue [#278](https://github.com/dermot-murphy/CStyleCheck/issues/278)).
+
+### Changed
+
+- **`constant.case` typedef-alias exemption** — object-like `#define` names ending with
+  the configured `typedefs.suffix.suffix` (e.g. `_t`) are now exempt from `constant.case`
+  when `typedefs.suffix.enabled: true`. This eliminates the false positive on
+  `#define api_nvm_error_t uint8_t`-style type aliases
+  (issues [#272](https://github.com/dermot-murphy/CStyleCheck/issues/272),
+  [#244](https://github.com/dermot-murphy/CStyleCheck/issues/244)).
+
+### Fixed
+
+- **`variable.parameter.p_prefix` false positive on call statements** —
+  `RE_FUNCTION_DECL`/`RE_FUNCTION_DEF` now require a real (non-zero-width) separator
+  between the return-type token and the function-name token, preventing regex
+  backtracking from misparsing a plain call statement as a declaration/definition
+  (issue [#273](https://github.com/dermot-murphy/CStyleCheck/issues/273)).
+
+---
+
 ## [1.4.1] — 2026-06-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Subprocess coverage now captures the CLI entry point in CI; `--cov-fail-under=85
 - **HTML report output** (`--output-format html`) — self-contained report with summary
   cards and per-file violation tables.
 
-#### Test suite: 1152 tests across 49 modules (see v1.4.1 for current totals)
+#### Test suite: 1152 tests across 49 modules (see v1.5.0 for current totals)
 
 ---
 
@@ -559,7 +559,7 @@ broken GitHub Wiki links (#251).
 
 ---
 
-### New in v1.4.1 (2026-06-26)
+### New in v1.5.0 (2026-06-26)
 
 - **`misc.non_ascii_source`** — flags source files containing characters outside the basic
   ASCII character set (code points 0x00–0x7F excluding standard whitespace), implementing

--- a/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP1-001 | **Version** | 1.5 |
+| **Document ID** | CSC-SUP1-001 | **Version** | 1.6 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.6 | 2026-06-26 | Claude | Update §3 scope to v1.5.0 (minor release: F-017 misc.non_ascii_source, F-018 per-file summary, F-019 constant.case typedef exemption, B-004 RE_FUNCTION_DECL fix) |
 | 1.5 | 2026-06-26 | Claude | §5.4: add per-release peer-review record production as a release gate checklist item; update §3 scope to v1.4.1 — closes issue #268 |
 | 1.4 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.3 | 2026-06-04 | Claude | Deep accuracy audit: fix §3 Purpose version text, update §3.1 referenced doc versions (all 5 stale), update QO-006 and §5.4 to v1.2.0, clarify §7 version language — resolves issue #163 |
@@ -31,7 +32,7 @@
 
 ## 3. Purpose & Scope
 
-This Quality Assurance Plan defines the QA strategy, activities, criteria, and records for **CStyleCheck v1.4.1**. It satisfies **Automotive SPICE® PAM v4.0, SUP.1 — Quality Assurance**.
+This Quality Assurance Plan defines the QA strategy, activities, criteria, and records for **CStyleCheck v1.5.0**. It satisfies **Automotive SPICE® PAM v4.0, SUP.1 — Quality Assurance**.
 
 QA activities for CStyleCheck verify that project processes are followed as planned and that work products meet their defined quality criteria. Because CStyleCheck is itself a quality tool (a naming-convention linter), the project benefits from self-hosting its own quality checks.
 

--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.14 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.15 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.15 | 2026-06-26 | Claude | v1.5.0 release — update all version identifiers, release summary, change log, upgrade notes |
 | 1.14 | 2026-06-26 | Claude | Complete v1.4.1 content (PR #295) — add F-017/F-018/F-019; update rule count 71→72, test count 1157→1182, module count 49→50; sync §3.1/§5.4/§5.5/§6/§8 doc version refs; correct rule count throughout |
 | 1.13 | 2026-06-25 | Claude | Doc accuracy — sync §5.5 document version table to v1.4.1 baseline (CSC-SYS5-001/CSC-SWE6-001 → 1.7, CSC-PA2-001 → 1.13, self → 1.13) |
 | 1.12 | 2026-06-25 | Claude | Correct rule count 75→71 throughout (§4.2, §5.1, §8.2, §9): 71 is the confirmed count from source-code analysis |
@@ -39,7 +40,7 @@
 
 ## 3. Purpose & Scope
 
-This **Software Version Description (SVD)** formally describes the **CStyleCheck v1.4.1** software release. It identifies the software items delivered, the baseline against which changes are recorded, and the configuration status of all controlled work products.
+This **Software Version Description (SVD)** formally describes the **CStyleCheck v1.5.0** software release. It identifies the software items delivered, the baseline against which changes are recorded, and the configuration status of all controlled work products.
 
 This document satisfies the release-identification and configuration-status-accounting requirements of **Automotive SPICE® PAM v4.0, SUP.8 — Configuration Management**.
 
@@ -51,10 +52,10 @@ This document satisfies the release-identification and configuration-status-acco
 | CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.8 |
 | CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.11 |
 | CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.13 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.7 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.8 |
 | CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.9 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
-| CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.4 |
+| CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.6 |
 | CSC-MAN3-001 | CStyleCheck Project Management Plan | 1.6 |
 
 ---
@@ -66,27 +67,25 @@ This document satisfies the release-identification and configuration-status-acco
 | Field | Value |
 |---|---|
 | **Product Name** | CStyleCheck |
-| **Version** | 1.4.1 |
-| **Release Date** | 2026-06-18 |
-| **Release Type** | Patch Release |
-| **Git Tag** | `v1.4.1` |
+| **Version** | 1.5.0 |
+| **Release Date** | 2026-06-26 |
+| **Release Type** | Minor Release |
+| **Git Tag** | `v1.5.0` |
 | **Branch** | `main` |
-| **Previous Release** | v1.4.0 (2026-06-18) |
+| **Previous Release** | v1.4.1 (2026-06-18) |
 | **Repository** | https://github.com/dermot-murphy/CStyleCheck |
 
 ### 4.2 Release Classification
 
-This is a **patch/minor release** under Semantic Versioning. It is **backward-compatible**
-with v1.4.0: existing rule IDs, CLI flags, and `rules.yml` schema are unchanged. It adds
-one new rule, two new features, and one bug fix — see §6.
+This is a **minor release** under Semantic Versioning. It is **backward-compatible**
+with v1.4.x: all existing rule IDs, CLI flags, and `rules.yml` schema entries are
+unchanged. It adds one new rule, two new output features, and one bug fix — see §6.
 
-v1.4.0 added 11 new rules from issues #221–#232 (`macro.trailing_semicolon`,
-`macro.multistatement_wrapper`, `misc.function_length`, `misc.function_doc_header`,
-`misc.assert_density`, `misc.null_statement_comment`, `misc.declaration_spacing`,
-`misc.file_length`, `misc.reserved_header_name`, `naming.identifier_length`,
-`naming.no_single_char_identifiers`), bringing the total to **71 rule IDs**. v1.4.1 adds
-`misc.non_ascii_source` to reach **72 rule IDs** total. The CLI entry point and all
-existing output formats remain backward-compatible with v1.4.0.
+v1.4.1 (the previous release) contained only a bug fix for `variable.parameter.p_prefix`
+false positives (#273). v1.5.0 adds `misc.non_ascii_source` (MISRA Rule 4.1), per-file
+breakdown in `--summary` output, and `constant.case` typedef-alias exemption, reaching
+**72 rule IDs** total. The CLI entry point and all existing output formats remain
+backward-compatible with v1.4.x.
 
 ---
 
@@ -110,7 +109,7 @@ existing output formats remain backward-compatible with v1.4.0.
 | `src/cstylecheck/fixer.py` | Auto-fix engine: apply_fixes, unified_diff (`--fix`, `--dry-run`, `--safe-only`) | `src/cstylecheck/fixer.py` |
 | `src/cstylecheck/wizard.py` | Config wizard and preset writer (`--init`, `--preset`) | `src/cstylecheck/wizard.py` |
 | `src/rules.yml` | Rule configuration for the CStyleCheck project | `src/rules.yml` |
-| `src/_version.py` | Version string: `1.4.1` (generated by CI: `git describe --tags`) | `src/_version.py` |
+| `src/_version.py` | Version string: `1.5.0` (generated by CI: `git describe --tags`) | `src/_version.py` |
 | `src/aliases.txt` | Module alias map | `src/aliases.txt` |
 | `src/exclusions.yml` | Per-file rule suppressions | `src/exclusions.yml` |
 | `src/options.txt` | Project defaults for `--options-file` | `src/options.txt` |
@@ -124,8 +123,8 @@ existing output formats remain backward-compatible with v1.4.0.
 
 | Registry | Image | Tags |
 |---|---|---|
-| Docker Hub | `dermotmurphy/cstylecheck` | `1.4.1`, `1.4`, `1`, `latest` |
-| GitHub Container Registry | `ghcr.io/dermot-murphy/cstylecheck` | `1.4.1`, `1.4`, `1`, `latest` |
+| Docker Hub | `dermotmurphy/cstylecheck` | `1.5.0`, `1.5`, `1`, `latest` |
+| GitHub Container Registry | `ghcr.io/dermot-murphy/cstylecheck` | `1.5.0`, `1.5`, `1`, `latest` |
 
 Platforms: `linux/amd64`, `linux/arm64`.
 
@@ -199,20 +198,20 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SVD-001 | Software Version Description (this document) | 1.14 |
+| CSC-SVD-001 | Software Version Description (this document) | 1.15 |
 | CSC-SWE1-001 | Software Requirements Specification | 2.0 |
 | CSC-SWE2-001 | Software Architecture Design | 1.8 |
 | CSC-SWE3-001 | Software Detailed Design | 1.11 |
 | CSC-SWE4-001 | Software Unit Verification Specification | 1.13 |
-| CSC-SWE5-001 | Software Integration Test Specification | 1.7 |
+| CSC-SWE5-001 | Software Integration Test Specification | 1.8 |
 | CSC-SWE6-001 | Software Qualification Test Specification | 1.9 |
 | CSC-SYS2-001 | System Requirements Specification | 1.6 |
 | CSC-SYS3-001 | System Architecture Design | 1.5 |
-| CSC-SYS4-001 | System Integration Test Specification | 1.4 |
+| CSC-SYS4-001 | System Integration Test Specification | 1.6 |
 | CSC-SYS5-001 | System Verification Specification | 1.7 |
 | CSC-MAN3-001 | Project Management Plan | 1.6 |
 | CSC-MAN5-001 | Risk Management Plan | 1.3 |
-| CSC-SUP1-001 | Quality Assurance Plan | 1.4 |
+| CSC-SUP1-001 | Quality Assurance Plan | 1.6 |
 | CSC-SUP8-001 | Configuration Management Plan | 1.7 |
 | CSC-SUP9-001 | Problem Resolution Plan | 1.2 |
 | CSC-SUP10-001 | Change Request Plan | 1.2 |
@@ -223,7 +222,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 ---
 
-## 6. Change Summary (v1.3.0 → v1.4.1)
+## 6. Change Summary (v1.3.0 → v1.5.0)
 
 ### 6.1 New Features
 
@@ -260,7 +259,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 | D-007 | Fixed Wiki sidebar/README links: malformed triple-hyphen slugs and the non-functional "Rules and Configuration Reference" link | [#251](https://github.com/dermot-murphy/CStyleCheck/issues/251) |
 | D-008 | 102 new tests (1152 total) covering all 11 new rules, including edge cases for multi-line macros, nested braces, comment exclusion, and regex-based exemptions | — |
 
-### 6.4 v1.4.1 Changes (2026-06-18 → 2026-06-26)
+### 6.4 v1.5.0 New Features and Fixes (2026-06-26)
 
 | ID | Description | Issue |
 |---|---|---|
@@ -291,8 +290,8 @@ The following issues are open at the time of this release and deferred to a futu
 
 ### 8.1 CI Status at Release
 
-All of the following CI checks passed on the `fix/re-function-decl-call-misparse` branch
-before merge to `develop` and sync to `main`:
+All of the following CI checks passed on PRs #295 and #296 before merge to `develop`
+and sync to `main` via PR #297:
 
 | Check | Result |
 |---|---|
@@ -310,7 +309,7 @@ All 1182 tests pass with no failures. Test counts per module are documented in �
 
 ### 8.3 Docker Build
 
-The Docker image is built for `linux/amd64` and `linux/arm64` and published to Docker Hub and GHCR automatically on creation of the `v1.4.1` tag via `docker_publish.yml`.
+The Docker image is built for `linux/amd64` and `linux/arm64` and published to Docker Hub and GHCR automatically on creation of the `v1.5.0` tag via `docker_publish.yml`.
 
 ### 8.4 GitHub Pages / Wiki
 
@@ -320,46 +319,38 @@ The GitHub Wiki is rebuilt automatically on any push to `main` that touches `REA
 
 ## 9. Installation and Upgrade Notes
 
-### 9.1 Upgrade from v1.4.0
+### 9.1 Upgrade from v1.4.x
 
-No breaking changes. This is a bug-fix-only patch. Upgrade steps:
+No breaking changes. All existing configurations, pre-commit hooks, and CLI flags work
+without modification. Upgrade steps:
 
 ```bash
 # pip / pipx
 pip install --upgrade cstylecheck
 
 # Docker
-docker pull dermotmurphy/cstylecheck:1.4.1
+docker pull dermotmurphy/cstylecheck:1.5.0
 
 # pre-commit (update rev in .pre-commit-config.yaml)
-rev: v1.4.1
+rev: v1.5.0
 ```
-
-Users who have `variables.parameter.p_prefix.enabled: true` (or the equivalent
-`variable.pointer_prefix` enforcement) configured and were seeing spurious violations on
-plain function-call statements should re-run CStyleCheck after upgrading — those false
-positives are eliminated by this patch.
 
 ### 9.2 New Features — Optional Activation
 
-New rules in v1.4.0 that require explicit opt-in (`enabled: true` under their key in
-`rules.yml`) because they are disabled by default:
+New rule in v1.5.0 that requires explicit opt-in (`enabled: true` in `rules.yml`):
 
-- **`misc.function_doc_header`**, **`misc.assert_density`**, **`misc.declaration_spacing`**,
-  **`naming.identifier_length`**, **`naming.no_single_char_identifiers`**.
+- **`misc.non_ascii_source`** — disabled by default. Enable to flag non-ASCII characters
+  (MISRA C:2012/2023 Rule 4.1).
 
-The remaining six new rules (`macro.trailing_semicolon`, `macro.multistatement_wrapper`,
-`misc.function_length`, `misc.null_statement_comment`, `misc.file_length`,
-`misc.reserved_header_name`) are enabled by default; no config change is required to
-benefit from them.
+The per-file breakdown in `--summary` output and `constant.case` typedef-alias exemption
+activate automatically with existing `rules.yml` configuration (no changes needed).
 
 ### 9.3 Backward Compatibility
 
-The `src/cstylecheck.py` entry point shim is unchanged. All existing rule IDs,
-`rules.yml` configurations, and pre-commit hook definitions from v1.4.0 are
-backward-compatible in v1.4.1. One new rule ID (`misc.non_ascii_source`) and two
-features were added (72 rule IDs total). Users who import the checker programmatically
-via `import cstylecheck` continue to work without modification.
+The `src/cstylecheck.py` entry point shim is unchanged. All 71 rule IDs from v1.4.x are
+present and unchanged. One new rule ID (`misc.non_ascii_source`) was added (72 rule IDs
+total). Users who import the checker programmatically via `import cstylecheck` continue
+to work without modification.
 
 ---
 
@@ -369,19 +360,19 @@ via `import cstylecheck` continue to work without modification.
 |---|---|---|---|
 | System Requirements | CSC-SYS2-001 | 1.6 | Released |
 | System Architecture | CSC-SYS3-001 | 1.5 | Released |
-| System Integration Tests | CSC-SYS4-001 | 1.4 | Released |
+| System Integration Tests | CSC-SYS4-001 | 1.6 | Released |
 | System Verification | CSC-SYS5-001 | 1.6 | Released |
 | Software Requirements | CSC-SWE1-001 | 2.0 | Released |
 | Software Architecture | CSC-SWE2-001 | 1.8 | Released |
 | Detailed Design | CSC-SWE3-001 | 1.11 | Released |
 | Unit Verification | CSC-SWE4-001 | 1.13 | Released |
-| Integration Tests | CSC-SWE5-001 | 1.7 | Released |
+| Integration Tests | CSC-SWE5-001 | 1.8 | Released |
 | Qualification Tests | CSC-SWE6-001 | 1.9 | Released |
-| Source Code | `src/cstylecheck/` (package) | 1.4.1 | Released |
-| Test Suite | `tests/` (1182 tests) | 1.4.1 | Released |
-| CI Automation | `.github/workflows/` + `scripts/ci/` | 1.4.1 | Released |
-| Docker Image | `Dockerfile/Dockerfile` | 1.4.1 | Released |
-| Change Log | `CHANGELOG.md` | 1.4.1 | Released |
+| Source Code | `src/cstylecheck/` (package) | 1.5.0 | Released |
+| Test Suite | `tests/` (1182 tests) | 1.5.0 | Released |
+| CI Automation | `.github/workflows/` + `scripts/ci/` | 1.5.0 | Released |
+| Docker Image | `Dockerfile/Dockerfile` | 1.5.0 | Released |
+| Change Log | `CHANGELOG.md` | 1.5.0 | Released |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
+++ b/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE5-001 | **Version** | 1.7 |
+| **Document ID** | CSC-SWE5-001 | **Version** | 1.8 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.8 | 2026-06-26 | Claude | v1.5.0 release — update product version reference in §3 scope |
 | 1.7 | 2026-06-26 | Claude | Add SIT-020 for non_ascii_source (Rule 4.1), per-file summary breakdown, and typedef-alias constant.case exemption — issues #279 #278 #272 #244 |
 | 1.6 | 2026-06-26 | Claude | Add SIT-019 covering 11 v1.4.0 rules (macro safety, function quality, file constraints, naming); advance SWE.5 to F — closes issue #261 |
 | 1.5 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
@@ -33,7 +34,7 @@
 
 ## 3. Purpose & Scope
 
-This document defines the software integration test specification for **CStyleCheck v1.4.1**, verifying that the software components integrate correctly across the interfaces defined in CSC-SWE2-001. It satisfies **Automotive SPICE® PAM v4.0, SWE.5 — Software Integration and Integration Verification**.
+This document defines the software integration test specification for **CStyleCheck v1.5.0**, verifying that the software components integrate correctly across the interfaces defined in CSC-SWE2-001. It satisfies **Automotive SPICE® PAM v4.0, SWE.5 — Software Integration and Integration Verification**.
 
 Integration tests operate at a higher level than unit tests (SWE.4): they exercise data flows **across component boundaries** — primarily the path from COMP-01 (CLI) through COMP-04 (Parser) into COMP-05 (Rule Engine) and COMP-07 (Output Formatter) — rather than individual method logic.
 

--- a/docs/aspice/CStyleCheck_SYS4_Integration_Test_Spec.md
+++ b/docs/aspice/CStyleCheck_SYS4_Integration_Test_Spec.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS4-001 | **Version** | 1.5 |
+| **Document ID** | CSC-SYS4-001 | **Version** | 1.6 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.6 | 2026-06-26 | Claude | v1.5.0 release — update product version reference in §3.1 scope |
 | 1.5 | 2026-06-26 | Claude | Add SITC-015 covering 11 v1.4.0 rules (macro safety, function quality, file constraints, naming); advance SYS.4 to F — closes issue #261 |
 | 1.4 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.3 | 2026-06-04 | Claude | Deep accuracy audit: fix §3.1 version text, update §3.3 referenced doc versions — resolves issue #163 |
@@ -33,7 +34,7 @@
 
 ### 3.1 Purpose
 
-This System Integration Test Specification defines the integration test cases that verify the correct assembly, interface behaviour, and end-to-end operation of the **CStyleCheck v1.4.1** system across its six subsystems and five deployment modes. It satisfies **Automotive SPICE® PAM v4.0, SYS.4 — System Integration and Integration Verification**.
+This System Integration Test Specification defines the integration test cases that verify the correct assembly, interface behaviour, and end-to-end operation of the **CStyleCheck v1.5.0** system across its six subsystems and five deployment modes. It satisfies **Automotive SPICE® PAM v4.0, SYS.4 — System Integration and Integration Verification**.
 
 ### 3.2 Scope
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "cstylecheck"
-version         = "1.4.1"
+version         = "1.5.0"
 description     = "Embedded C Style Compliance Checker (Barr-C / MISRA-C complementary)"
 readme          = "README.md"
 license         = { text = "MIT" }


### PR DESCRIPTION
## Summary

- **`pyproject.toml`**: `1.4.1` → `1.5.0`
- **`CHANGELOG.md`**: add `[1.5.0]` section — F-017 `misc.non_ascii_source`, F-018 per-file `--summary` breakdown, F-019 `constant.case` typedef-alias exemption, B-004 `RE_FUNCTION_DECL` misparse fix
- **`README.md`**: update "New in v1.4.1" heading and cross-reference to v1.5.0
- **SVD** `v1.14 → v1.15`: full v1.5.0 release record; sync referenced-doc versions SWE5 1.7→1.8, SYS4 1.4→1.6, SUP1 1.4→1.6 throughout §3.1, §10, and traceability table
- **SWE5** `v1.7 → v1.8`: scope line updated to CStyleCheck v1.5.0
- **SYS4** `v1.5 → v1.6`: scope line updated to CStyleCheck v1.5.0
- **SUP1** `v1.5 → v1.6`: scope line updated to CStyleCheck v1.5.0

## Context

v1.4.1 tag already existed (bug-fix-only patch). The features introduced since that tag — `misc.non_ascii_source` (F-017), per-file summary (F-018), `constant.case` typedef exemption (F-019) — constitute a minor release requiring a MINOR version bump under SemVer.

## Test plan

- [ ] `pyproject.toml` version reads `1.5.0`
- [ ] CHANGELOG `[1.5.0]` section present with all four changes listed
- [ ] SVD §3.1, §10, and traceability table all show SWE5 1.8 / SYS4 1.6 / SUP1 1.6
- [ ] SWE5, SYS4, SUP1 scope lines reference CStyleCheck v1.5.0
- [ ] No other version strings left at 1.4.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_