### PR TITLE
Sync develop → main: ASPICE cross-ref cascade fix (v1.18 SVD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ Rule ID: `misc.eof_comment` · Default severity: `warning`
 
 ---
 
-## Rule IDs (64 total)
+## Rule IDs (72 total)
 
 | Category | Rule IDs |
 |---|---|

--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.17 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.18 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.18 | 2026-06-27 | Cascade cross-ref update: SWE1→2.3, SWE2→1.10, SWE3→1.14, SWE4→1.16, SWE5→1.10, SWE6→1.12, SYS4→1.9 | Dermot Murphy |
 | 1.17 | 2026-06-27 | Claude | ASPICE audit — update §3.1/§5.5/§10 doc version refs (SWE1 2.1→2.2, SWE3 1.12→1.13, SWE4 1.14→1.15, SWE6 1.10→1.11, SYS2 1.9→2.0, SYS4 1.7→1.8, SUP8 1.7→1.8); update approval dates — closes #315 #316 #317 #318 #319 #320 #321 #322 #323 |
 | 1.16 | 2026-06-26 | Claude | ASPICE audit corrections — update §3.1/§5.5/§10 doc version refs (SWE1 2.0→2.1, SWE2 1.8→1.9, SWE3 1.11→1.12, SWE4 1.13→1.14, SWE5 1.8→1.9, SWE6 1.9→1.10, SUP1 1.6→1.7, SYS2 1.6→1.9, SYS4 1.6→1.7); update test count 1182→1183 throughout — closes #302 #303 #304 #305 #306 #307 #308 #309 #310 #311 #312 |
 | 1.15 | 2026-06-26 | Claude | v1.5.0 release — update all version identifiers, release summary, change log, upgrade notes |
@@ -50,12 +51,12 @@ This document satisfies the release-identification and configuration-status-acco
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.2 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.9 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.13 |
-| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.15 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.9 |
-| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.11 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.10 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.14 |
+| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.16 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.10 |
+| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.12 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.8 |
 | CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.7 |
 | CSC-MAN3-001 | CStyleCheck Project Management Plan | 1.6 |
@@ -200,16 +201,16 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SVD-001 | Software Version Description (this document) | 1.17 |
-| CSC-SWE1-001 | Software Requirements Specification | 2.2 |
-| CSC-SWE2-001 | Software Architecture Design | 1.9 |
-| CSC-SWE3-001 | Software Detailed Design | 1.13 |
-| CSC-SWE4-001 | Software Unit Verification Specification | 1.15 |
-| CSC-SWE5-001 | Software Integration Test Specification | 1.9 |
-| CSC-SWE6-001 | Software Qualification Test Specification | 1.11 |
+| CSC-SVD-001 | Software Version Description (this document) | 1.18 |
+| CSC-SWE1-001 | Software Requirements Specification | 2.3 |
+| CSC-SWE2-001 | Software Architecture Design | 1.10 |
+| CSC-SWE3-001 | Software Detailed Design | 1.14 |
+| CSC-SWE4-001 | Software Unit Verification Specification | 1.16 |
+| CSC-SWE5-001 | Software Integration Test Specification | 1.10 |
+| CSC-SWE6-001 | Software Qualification Test Specification | 1.12 |
 | CSC-SYS2-001 | System Requirements Specification | 2.0 |
 | CSC-SYS3-001 | System Architecture Design | 1.5 |
-| CSC-SYS4-001 | System Integration Test Specification | 1.8 |
+| CSC-SYS4-001 | System Integration Test Specification | 1.9 |
 | CSC-SYS5-001 | System Verification Specification | 1.7 |
 | CSC-MAN3-001 | Project Management Plan | 1.6 |
 | CSC-MAN5-001 | Risk Management Plan | 1.3 |
@@ -349,8 +350,7 @@ activate automatically with existing `rules.yml` configuration (no changes neede
 
 ### 9.3 Backward Compatibility
 
-The `src/cstylecheck.py` entry point shim is unchanged. All 71 rule IDs from v1.4.x are
-present and unchanged. One new rule ID (`misc.non_ascii_source`) was added (72 rule IDs
+The `src/cstylecheck.py` entry point shim is unchanged. The 71 rule IDs present in v1.4.x are all retained and unchanged. One new rule ID (`misc.non_ascii_source`) was added (72 rule IDs
 total). Users who import the checker programmatically via `import cstylecheck` continue
 to work without modification.
 
@@ -362,14 +362,14 @@ to work without modification.
 |---|---|---|---|
 | System Requirements | CSC-SYS2-001 | 2.0 | Released |
 | System Architecture | CSC-SYS3-001 | 1.5 | Released |
-| System Integration Tests | CSC-SYS4-001 | 1.8 | Released |
+| System Integration Tests | CSC-SYS4-001 | 1.9 | Released |
 | System Verification | CSC-SYS5-001 | 1.7 | Released |
-| Software Requirements | CSC-SWE1-001 | 2.2 | Released |
-| Software Architecture | CSC-SWE2-001 | 1.9 | Released |
-| Detailed Design | CSC-SWE3-001 | 1.13 | Released |
-| Unit Verification | CSC-SWE4-001 | 1.15 | Released |
-| Integration Tests | CSC-SWE5-001 | 1.9 | Released |
-| Qualification Tests | CSC-SWE6-001 | 1.11 | Released |
+| Software Requirements | CSC-SWE1-001 | 2.3 | Released |
+| Software Architecture | CSC-SWE2-001 | 1.10 | Released |
+| Detailed Design | CSC-SWE3-001 | 1.14 | Released |
+| Unit Verification | CSC-SWE4-001 | 1.16 | Released |
+| Integration Tests | CSC-SWE5-001 | 1.10 | Released |
+| Qualification Tests | CSC-SWE6-001 | 1.12 | Released |
 | Source Code | `src/cstylecheck/` (package) | 1.5.0 | Released |
 | Test Suite | `tests/` (1183 tests) | 1.5.0 | Released |
 | CI Automation | `.github/workflows/` + `scripts/ci/` | 1.5.0 | Released |

--- a/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
+++ b/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE1-001 | **Version** | 2.2 |
+| **Document ID** | CSC-SWE1-001 | **Version** | 2.3 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 2.3 | 2026-06-27 | Fix §3.2 cross-ref: SYS2 1.9→2.0 | Dermot Murphy |
 | 2.2 | 2026-06-27 | Claude | ASPICE audit — fix §3.2 SWE2 ref 1.8→1.9 and SYS2 ref 1.6→1.9; update Review & Approval dates — closes #315 #323 |
 | 2.1 | 2026-06-26 | Claude | ASPICE audit — fix §3.1 scope text (v1.2.x → v1.5.0) — closes #305 |
 | 2.0 | 2026-06-26 | Claude | Add SWE1-089 (per-file summary #278), SWE1-MISRA-004 (non_ascii_source #279), SWE1-090 (typedef-alias constant.case exemption #272/#244); update RTM |
@@ -50,7 +51,7 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.1 — Software Requir
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.9 |
+| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 2.0 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
 | CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.9 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |

--- a/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
+++ b/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE2-001 | **Version** | 1.9 |
+| **Document ID** | CSC-SWE2-001 | **Version** | 1.10 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.10 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.1→2.3, SWE3 1.12→1.14 | Dermot Murphy |
 | 1.9 | 2026-06-26 | Claude | v1.9 — ASPICE audit corrections: fix §3 scope text (v1.2.x→v1.5.0); update §3.1 SWE1/SWE3 version refs; add v1.4.0/v1.5.0 methods to §8.1 run_all() sequence; add SWE1-MISRA-004/SWE1-089/SWE1-090 to §10 RTM — closes #307 |
 | 1.8 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.7 | 2026-06-08 | Claude | ASPICE audit #238 — add COMP-05h (naming rules); extend §10 RTM with SWE1-078–088 |
@@ -43,9 +44,9 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.2 — Software Archit
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.1 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.12 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.14 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 
 ---

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE3-001 | **Version** | 1.13 |
+| **Document ID** | CSC-SWE3-001 | **Version** | 1.14 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.14 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.1→2.3, SWE4 1.14→1.16 | Dermot Murphy |
 | 1.13 | 2026-06-27 | Claude | ASPICE audit — approve §9 Review & Approval (3 roles were Pending) — closes #316 #323 |
 | 1.12 | 2026-06-26 | Claude | ASPICE audit corrections: fix §3 scope text (v1.2.x→v1.5.0); update §3.1 SWE1/SWE4 version refs; correct UNIT-102–113 Component from COMP-01 to COMP-05f/COMP-05h; add _check_non_ascii_source to UNIT-22 run_all() order — closes #308 |
 | 1.11 | 2026-06-26 | Claude | Add UNIT-113 (_check_non_ascii_source), UNIT-114 (print_summary per-file breakdown), UNIT-115 (_check_defines typedef-alias exemption); update §8 traceability — issues #279 #278 #272 #244 |
@@ -44,9 +45,9 @@ This document defines the detailed design of each software unit in **CStyleCheck
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.1 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
 | CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.9 |
-| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.14 |
+| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.16 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
+++ b/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE4-001 | **Version** | 1.15 |
+| **Document ID** | CSC-SWE4-001 | **Version** | 1.16 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.16 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.1→2.3, SWE3 1.12→1.14 | Dermot Murphy |
 | 1.15 | 2026-06-27 | Claude | ASPICE audit — fix §4.2 test count 1041→1183; fix §6 COMP-01→COMP-05f/h for 11 modules; update coverage ref to v1.5.0; update Review & Approval dates — closes #317 #323 |
 | 1.14 | 2026-06-26 | Claude | ASPICE audit — fix §3 scope text (v1.2.x→v1.5.0); update §3.1 refs (SWE1 1.9→2.1, SWE3 1.10→1.12, SWE5 1.5→1.9); correct §6 total 52→50 modules; update test_null_statement_comment count 10→11 and total 1182→1183 — closes #305 #306 #309 #312 |
 | 1.13 | 2026-06-26 | Claude | Add NR-004 tests (12 tests, test_misra_rules.py 52→64), typedef-alias tests (6 tests, test_defines.py 16→22), test_print_summary.py (7 tests, new); update §5 and §6 totals 1157→1182 — issues #279 #278 #272 #244 |
@@ -50,8 +51,8 @@ Unit verification covers both dynamic testing (pytest test suite) and static ver
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.1 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.12 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.14 |
 | CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.9 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
 

--- a/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
+++ b/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE5-001 | **Version** | 1.9 |
+| **Document ID** | CSC-SWE5-001 | **Version** | 1.10 |
 | **Project** | CStyleCheck | **Date** | 2026-06-26 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.10 | 2026-06-27 | Fix §3.1 cross-refs: SWE4 1.14→1.16, SWE6 1.10→1.12 | Dermot Murphy |
 | 1.9 | 2026-06-26 | Claude | ASPICE audit — update §3.1 refs (SWE2 1.8→1.9, SWE4 1.12→1.14, SWE6 1.7→1.10, SYS4 1.5→1.7); update §3.2 CM baseline to v1.5.0 tag; update §6 overall result 1182→1183 — closes #306 #309 |
 | 1.8 | 2026-06-26 | Claude | v1.5.0 release — update product version reference in §3 scope |
 | 1.7 | 2026-06-26 | Claude | Add SIT-020 for non_ascii_source (Rule 4.1), per-file summary breakdown, and typedef-alias constant.case exemption — issues #279 #278 #272 #244 |
@@ -46,8 +47,8 @@ The primary integration test suite is `tests/test_cli.py`, which invokes `cstyle
 | Document ID | Title | Version |
 |---|---|---|
 | CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.9 |
-| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.14 |
-| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.10 |
+| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.16 |
+| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.12 |
 | CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.7 |
 
 ### 3.2 Test Environment

--- a/docs/aspice/CStyleCheck_SWE6_Qualification_Test.md
+++ b/docs/aspice/CStyleCheck_SWE6_Qualification_Test.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE6-001 | **Version** | 1.11 |
+| **Document ID** | CSC-SWE6-001 | **Version** | 1.12 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.12 | 2026-06-27 | Fix §3.1 cross-ref: SWE1 2.1→2.3 | Dermot Murphy |
 | 1.11 | 2026-06-27 | Claude | ASPICE audit — populate SWQ-010 execution evidence; fill §7 coverage values; fix §8 issue #54 status; fix §9 branch coverage; fix §10 v1.0.0→v1.5.0; update Review & Approval dates — closes #318 #323 |
 | 1.10 | 2026-06-26 | Claude | ASPICE audit corrections: update §3.2 config under test to v1.5.0; fix §3.1/§3.3/§9/Appendix A stale references; populate execution results for SWQ-001/002/004/005/006/007 — closes #310 |
 | 1.9 | 2026-06-26 | Claude | Correct rule count 74→72 throughout (§3 SWQ-003, §7 RTM): 72 is the confirmed count from source-code analysis; macro.trailing_semicolon/multistatement_wrapper were already in the 71 base |
@@ -47,7 +48,7 @@ Qualification tests (SWE.6) differ from integration tests (SWE.5) in that they v
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.1 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
 | CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.9 |
 | CSC-SYS5-001 | CStyleCheck System Verification Report | 1.6 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |

--- a/docs/aspice/CStyleCheck_SYS4_Integration_Test_Spec.md
+++ b/docs/aspice/CStyleCheck_SYS4_Integration_Test_Spec.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS4-001 | **Version** | 1.8 |
+| **Document ID** | CSC-SYS4-001 | **Version** | 1.9 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-27 | Fix §3.3 cross-ref: SYS2 1.9→2.0 | Dermot Murphy |
 | 1.8 | 2026-06-27 | Claude | ASPICE audit — replace §6 SWE5 traceability placeholders with actual SIT-001–SIT-014 test case IDs; update Review & Approval dates — closes #320 #323 |
 | 1.7 | 2026-06-26 | Claude | ASPICE audit — update §3.3 SYS2 ref (1.8→1.9); update §5 overall result test count (965→1183) — closes #306 #311 |
 | 1.6 | 2026-06-26 | Claude | v1.5.0 release — update product version reference in §3.1 scope |
@@ -54,7 +55,7 @@ SWE.4/SWE.5 unit and component-level tests are documented in the software test s
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 1.9 |
+| CSC-SYS2-001 | CStyleCheck System Requirements Specification | 2.0 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
 | CSC-SYS5-001 | CStyleCheck System Verification Report | 1.7 |
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |


### PR DESCRIPTION
## Summary

Sync develop → main after PR #326 merge.

Brings all ASPICE cross-reference cascade fixes to main — resolves all findings from the second internal CL2 audit:

- SWE1 v2.3: §3.2 SYS2 ref corrected 1.9→2.0 (FAIL-001)
- SWE2 v1.10: §3.1 SWE1 2.1→2.3, SWE3 1.12→1.14
- SWE3 v1.14: §3.1 SWE1 2.1→2.3, SWE4 1.14→1.16
- SWE4 v1.16: §3.1 SWE1 2.1→2.3, SWE3 1.12→1.14
- SWE5 v1.10: §3.1 SWE4 1.14→1.16, SWE6 1.10→1.12
- SWE6 v1.12: §3.1 SWE1 2.1→2.3
- SYS4 v1.9: §3.3 SYS2 1.9→2.0
- SVD v1.18: all cross-doc refs cascaded; §9.3 "71 rule IDs" phrasing clarified
- README: stale "Rule IDs (64 total)" heading → "Rule IDs (72 total)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_