### PR TITLE
Sync develop → main: ASPICE atomic cross-ref fix (SVD v1.19)

### DIFF
--- a/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
@@ -9,7 +9,7 @@
 | Field | Value | Field | Value |
 |---|---|---|---|
 | **Document ID** | CSC-SUP1-001 | **Version** | 1.7 |
-| **Project** | CStyleCheck | **Date** | 2026-06-26 |
+| **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SUP.1 |

--- a/docs/aspice/CStyleCheck_SUP8_CM_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP8_CM_Plan.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP8-001 | **Version** | 1.8 |
+| **Document ID** | CSC-SUP8-001 | **Version** | 1.9 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.9 | 2026-06-27 | Fix §3.3 cross-ref: SWE1 2.2→2.4 (+ any other stale refs fixed) | Dermot Murphy |
 | 1.8 | 2026-06-27 | Claude | ASPICE audit — §3.1 scope v1.2.0→v1.5.0; §3.3 SWE1 ref 1.9→2.2; update Review & Approval dates — closes #321 #323 |
 | 1.7 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
 | 1.6 | 2026-06-04 | Claude | Deep accuracy audit: fix CI-024 workflow filename (rules.yml→cstylecheck_rules.yml), fix §7.5 reference, update SWE1-001 version in §3.3 — resolves issue #163 |
@@ -58,7 +59,7 @@ This plan applies to all configuration items produced by the CStyleCheck project
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
 | CSC-SUP9-001 | CStyleCheck Problem Resolution Management Plan | 1.2 |
 | CSC-SUP10-001 | CStyleCheck Change Request Management Plan | 1.2 |
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.2 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.4 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.18 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.19 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.19 | 2026-06-27 | Cascade cross-ref update: SWE1→2.4, SWE2→1.11, SWE3→1.15, SWE4→1.17, SWE5→1.11, SWE6→1.13, SUP8→1.9 | Dermot Murphy |
 | 1.18 | 2026-06-27 | Cascade cross-ref update: SWE1→2.3, SWE2→1.10, SWE3→1.14, SWE4→1.16, SWE5→1.10, SWE6→1.12, SYS4→1.9 | Dermot Murphy |
 | 1.17 | 2026-06-27 | Claude | ASPICE audit — update §3.1/§5.5/§10 doc version refs (SWE1 2.1→2.2, SWE3 1.12→1.13, SWE4 1.14→1.15, SWE6 1.10→1.11, SYS2 1.9→2.0, SYS4 1.7→1.8, SUP8 1.7→1.8); update approval dates — closes #315 #316 #317 #318 #319 #320 #321 #322 #323 |
 | 1.16 | 2026-06-26 | Claude | ASPICE audit corrections — update §3.1/§5.5/§10 doc version refs (SWE1 2.0→2.1, SWE2 1.8→1.9, SWE3 1.11→1.12, SWE4 1.13→1.14, SWE5 1.8→1.9, SWE6 1.9→1.10, SUP1 1.6→1.7, SYS2 1.6→1.9, SYS4 1.6→1.7); update test count 1182→1183 throughout — closes #302 #303 #304 #305 #306 #307 #308 #309 #310 #311 #312 |
@@ -51,13 +52,13 @@ This document satisfies the release-identification and configuration-status-acco
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.10 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.14 |
-| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.16 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.10 |
-| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.12 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.8 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.4 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Design | 1.11 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.15 |
+| CSC-SWE4-001 | CStyleCheck Software Unit Verification Specification | 1.17 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.11 |
+| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.13 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
 | CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.7 |
 | CSC-MAN3-001 | CStyleCheck Project Management Plan | 1.6 |
 
@@ -201,13 +202,13 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SVD-001 | Software Version Description (this document) | 1.18 |
-| CSC-SWE1-001 | Software Requirements Specification | 2.3 |
-| CSC-SWE2-001 | Software Architecture Design | 1.10 |
-| CSC-SWE3-001 | Software Detailed Design | 1.14 |
-| CSC-SWE4-001 | Software Unit Verification Specification | 1.16 |
-| CSC-SWE5-001 | Software Integration Test Specification | 1.10 |
-| CSC-SWE6-001 | Software Qualification Test Specification | 1.12 |
+| CSC-SVD-001 | Software Version Description (this document) | 1.19 |
+| CSC-SWE1-001 | Software Requirements Specification | 2.4 |
+| CSC-SWE2-001 | Software Architecture Design | 1.11 |
+| CSC-SWE3-001 | Software Detailed Design | 1.15 |
+| CSC-SWE4-001 | Software Unit Verification Specification | 1.17 |
+| CSC-SWE5-001 | Software Integration Test Specification | 1.11 |
+| CSC-SWE6-001 | Software Qualification Test Specification | 1.13 |
 | CSC-SYS2-001 | System Requirements Specification | 2.0 |
 | CSC-SYS3-001 | System Architecture Design | 1.5 |
 | CSC-SYS4-001 | System Integration Test Specification | 1.9 |
@@ -215,7 +216,7 @@ Platforms: `linux/amd64`, `linux/arm64`.
 | CSC-MAN3-001 | Project Management Plan | 1.6 |
 | CSC-MAN5-001 | Risk Management Plan | 1.3 |
 | CSC-SUP1-001 | Quality Assurance Plan | 1.7 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.8 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.9 |
 | CSC-SUP9-001 | Problem Resolution Plan | 1.2 |
 | CSC-SUP10-001 | Change Request Plan | 1.2 |
 | CSC-ACQ4-001 | Supplier Monitoring Plan | 1.2 |
@@ -364,12 +365,12 @@ to work without modification.
 | System Architecture | CSC-SYS3-001 | 1.5 | Released |
 | System Integration Tests | CSC-SYS4-001 | 1.9 | Released |
 | System Verification | CSC-SYS5-001 | 1.7 | Released |
-| Software Requirements | CSC-SWE1-001 | 2.3 | Released |
-| Software Architecture | CSC-SWE2-001 | 1.10 | Released |
-| Detailed Design | CSC-SWE3-001 | 1.14 | Released |
-| Unit Verification | CSC-SWE4-001 | 1.16 | Released |
-| Integration Tests | CSC-SWE5-001 | 1.10 | Released |
-| Qualification Tests | CSC-SWE6-001 | 1.12 | Released |
+| Software Requirements | CSC-SWE1-001 | 2.4 | Released |
+| Software Architecture | CSC-SWE2-001 | 1.11 | Released |
+| Detailed Design | CSC-SWE3-001 | 1.15 | Released |
+| Unit Verification | CSC-SWE4-001 | 1.17 | Released |
+| Integration Tests | CSC-SWE5-001 | 1.11 | Released |
+| Qualification Tests | CSC-SWE6-001 | 1.13 | Released |
 | Source Code | `src/cstylecheck/` (package) | 1.5.0 | Released |
 | Test Suite | `tests/` (1183 tests) | 1.5.0 | Released |
 | CI Automation | `.github/workflows/` + `scripts/ci/` | 1.5.0 | Released |

--- a/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
+++ b/docs/aspice/CStyleCheck_SWE1_SW_Requirements.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE1-001 | **Version** | 2.3 |
+| **Document ID** | CSC-SWE1-001 | **Version** | 2.4 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 2.4 | 2026-06-27 | Fix §3.2 cross-refs: cascade update (SWE2 1.9→1.11 + any other stale refs fixed) | Dermot Murphy |
 | 2.3 | 2026-06-27 | Fix §3.2 cross-ref: SYS2 1.9→2.0 | Dermot Murphy |
 | 2.2 | 2026-06-27 | Claude | ASPICE audit — fix §3.2 SWE2 ref 1.8→1.9 and SYS2 ref 1.6→1.9; update Review & Approval dates — closes #315 #323 |
 | 2.1 | 2026-06-26 | Claude | ASPICE audit — fix §3.1 scope text (v1.2.x → v1.5.0) — closes #305 |
@@ -53,8 +54,8 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.1 — Software Requir
 |---|---|---|
 | CSC-SYS2-001 | CStyleCheck System Requirements Specification | 2.0 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.9 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.11 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
 | Barr-C:2018 | Barr Group Embedded C Coding Standard | 2018 |
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
 

--- a/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
+++ b/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE2-001 | **Version** | 1.10 |
-| **Project** | CStyleCheck | **Date** | 2026-06-26 |
+| **Document ID** | CSC-SWE2-001 | **Version** | 1.11 |
+| **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.2 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.11 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.3→2.4, SWE3 1.14→1.15; fix header date | Dermot Murphy |
 | 1.10 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.1→2.3, SWE3 1.12→1.14 | Dermot Murphy |
 | 1.9 | 2026-06-26 | Claude | v1.9 — ASPICE audit corrections: fix §3 scope text (v1.2.x→v1.5.0); update §3.1 SWE1/SWE3 version refs; add v1.4.0/v1.5.0 methods to §8.1 run_all() sequence; add SWE1-MISRA-004/SWE1-089/SWE1-090 to §10 RTM — closes #307 |
 | 1.8 | 2026-06-18 | Claude | ASPICE audit #254 — sync referenced-document version citations to current versions |
@@ -44,10 +45,10 @@ This document satisfies **Automotive SPICE® PAM v4.0, SWE.2 — Software Archit
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.4 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.14 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.15 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE3-001 | **Version** | 1.14 |
+| **Document ID** | CSC-SWE3-001 | **Version** | 1.15 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.15 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.3→2.4, SWE2 1.9→1.11, SWE4 1.16→1.17 | Dermot Murphy |
 | 1.14 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.1→2.3, SWE4 1.14→1.16 | Dermot Murphy |
 | 1.13 | 2026-06-27 | Claude | ASPICE audit — approve §9 Review & Approval (3 roles were Pending) — closes #316 #323 |
 | 1.12 | 2026-06-26 | Claude | ASPICE audit corrections: fix §3 scope text (v1.2.x→v1.5.0); update §3.1 SWE1/SWE4 version refs; correct UNIT-102–113 Component from COMP-01 to COMP-05f/COMP-05h; add _check_non_ascii_source to UNIT-22 run_all() order — closes #308 |
@@ -45,9 +46,9 @@ This document defines the detailed design of each software unit in **CStyleCheck
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.9 |
-| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.16 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.4 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.11 |
+| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.17 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
+++ b/docs/aspice/CStyleCheck_SWE4_Unit_Verification.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE4-001 | **Version** | 1.16 |
+| **Document ID** | CSC-SWE4-001 | **Version** | 1.17 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.17 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.3→2.4, SWE3 1.14→1.15, SWE5 1.9→1.11 | Dermot Murphy |
 | 1.16 | 2026-06-27 | Fix §3.1 cross-refs: SWE1 2.1→2.3, SWE3 1.12→1.14 | Dermot Murphy |
 | 1.15 | 2026-06-27 | Claude | ASPICE audit — fix §4.2 test count 1041→1183; fix §6 COMP-01→COMP-05f/h for 11 modules; update coverage ref to v1.5.0; update Review & Approval dates — closes #317 #323 |
 | 1.14 | 2026-06-26 | Claude | ASPICE audit — fix §3 scope text (v1.2.x→v1.5.0); update §3.1 refs (SWE1 1.9→2.1, SWE3 1.10→1.12, SWE5 1.5→1.9); correct §6 total 52→50 modules; update test_null_statement_comment count 10→11 and total 1182→1183 — closes #305 #306 #309 #312 |
@@ -51,10 +52,10 @@ Unit verification covers both dynamic testing (pytest test suite) and static ver
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
-| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.14 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.9 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.4 |
+| CSC-SWE3-001 | CStyleCheck Software Detailed Design | 1.15 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.11 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
+++ b/docs/aspice/CStyleCheck_SWE5_Integration_Test.md
@@ -8,8 +8,8 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE5-001 | **Version** | 1.10 |
-| **Project** | CStyleCheck | **Date** | 2026-06-26 |
+| **Document ID** | CSC-SWE5-001 | **Version** | 1.11 |
+| **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.5 |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.11 | 2026-06-27 | Fix §3.1 cross-refs: SWE4 1.16→1.17, SWE6 1.12→1.13, SYS4 1.7→1.9; fix header date | Dermot Murphy |
 | 1.10 | 2026-06-27 | Fix §3.1 cross-refs: SWE4 1.14→1.16, SWE6 1.10→1.12 | Dermot Murphy |
 | 1.9 | 2026-06-26 | Claude | ASPICE audit — update §3.1 refs (SWE2 1.8→1.9, SWE4 1.12→1.14, SWE6 1.7→1.10, SYS4 1.5→1.7); update §3.2 CM baseline to v1.5.0 tag; update §6 overall result 1182→1183 — closes #306 #309 |
 | 1.8 | 2026-06-26 | Claude | v1.5.0 release — update product version reference in §3 scope |
@@ -46,10 +47,10 @@ The primary integration test suite is `tests/test_cli.py`, which invokes `cstyle
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.9 |
-| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.16 |
-| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.12 |
-| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.7 |
+| CSC-SWE2-001 | CStyleCheck Software Architecture Description | 1.11 |
+| CSC-SWE4-001 | CStyleCheck Unit Verification Specification | 1.17 |
+| CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.13 |
+| CSC-SYS4-001 | CStyleCheck System Integration Test Specification | 1.9 |
 
 ### 3.2 Test Environment
 

--- a/docs/aspice/CStyleCheck_SWE6_Qualification_Test.md
+++ b/docs/aspice/CStyleCheck_SWE6_Qualification_Test.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SWE6-001 | **Version** | 1.12 |
+| **Document ID** | CSC-SWE6-001 | **Version** | 1.13 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -22,6 +22,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.13 | 2026-06-27 | Fix §3.1 cross-ref: SWE1 2.3→2.4 | Dermot Murphy |
 | 1.12 | 2026-06-27 | Fix §3.1 cross-ref: SWE1 2.1→2.3 | Dermot Murphy |
 | 1.11 | 2026-06-27 | Claude | ASPICE audit — populate SWQ-010 execution evidence; fill §7 coverage values; fix §8 issue #54 status; fix §9 branch coverage; fix §10 v1.0.0→v1.5.0; update Review & Approval dates — closes #318 #323 |
 | 1.10 | 2026-06-26 | Claude | ASPICE audit corrections: update §3.2 config under test to v1.5.0; fix §3.1/§3.3/§9/Appendix A stale references; populate execution results for SWQ-001/002/004/005/006/007 — closes #310 |
@@ -48,10 +49,10 @@ Qualification tests (SWE.6) differ from integration tests (SWE.5) in that they v
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.3 |
-| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.9 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Specification | 2.4 |
+| CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.11 |
 | CSC-SYS5-001 | CStyleCheck System Verification Report | 1.6 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
 
 ### 3.2 Software Configuration Under Test
 


### PR DESCRIPTION
## Summary

Sync develop → main after PR #332 merge.

Full atomic cross-reference fix — resolves all 28 stale citations found across 9 ASPICE documents (closes #328–#331):

- SWE1 v2.4: §3.2 SWE2 1.9→1.11, SUP8 1.7→1.9
- SWE2 v1.11: §3.1 SWE1 2.3→2.4, SWE3 1.14→1.15, SUP8 1.7→1.9; header date fixed
- SWE3 v1.15: §3.1 SWE1 2.3→2.4, SWE2 1.9→1.11, SWE4 1.16→1.17
- SWE4 v1.17: §3.1 SWE1 2.3→2.4, SWE3 1.14→1.15, SWE5 1.9→1.11, SUP8 1.7→1.9
- SWE5 v1.11: §3.1 SWE2 1.9→1.11, SWE4 1.16→1.17, SWE6 1.12→1.13, SYS4 1.7→1.9; header date fixed
- SWE6 v1.13: §3.1 SWE1 2.3→2.4, SWE5 1.9→1.11, SUP8 1.7→1.9
- SUP8 v1.9: §3.3 SWE1 2.2→2.4
- SUP1: header date 2026-06-26→2026-06-27
- SVD v1.19: all cross-doc refs cascaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_