### PR TITLE
ASPICE fix: SYS2 §3.3 and SUP1 §3.1 stale cross-refs (SVD v1.20)

### DIFF
--- a/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
+++ b/docs/aspice/CStyleCheck_SUP1_Quality_Assurance_Plan.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SUP1-001 | **Version** | 1.7 |
+| **Document ID** | CSC-SUP1-001 | **Version** | 1.8 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.8 | 2026-06-27 | Fix §3.1 cross-refs: SUP8 1.7→1.9, SWE4 1.14→1.17 | Dermot Murphy |
 | 1.7 | 2026-06-26 | Claude | ASPICE audit — update §3.1 SWE4 ref (1.12→1.14) — closes #306 #329 |
 | 1.6 | 2026-06-26 | Claude | Update §3 scope to v1.5.0 (minor release: F-017 misc.non_ascii_source, F-018 per-file summary, F-019 constant.case typedef exemption, B-004 RE_FUNCTION_DECL fix) |
 | 1.5 | 2026-06-26 | Claude | §5.4: add per-release peer-review record production as a release gate checklist item; update §3 scope to v1.4.1 — closes issue #268 |
@@ -42,10 +43,10 @@ QA activities for CStyleCheck verify that project processes are followed as plan
 | Document ID | Title | Version |
 |---|---|---|
 | CSC-MAN3-001 | Project Management Plan | 1.6 |
-| CSC-SUP8-001 | Configuration Management Plan | 1.7 |
+| CSC-SUP8-001 | Configuration Management Plan | 1.9 |
 | CSC-SUP9-001 | Problem Resolution Management Plan | 1.2 |
 | CSC-SUP10-001 | Change Request Management Plan | 1.2 |
-| CSC-SWE4-001 | Unit Verification Specification | 1.14 |
+| CSC-SWE4-001 | Unit Verification Specification | 1.17 |
 
 ---
 

--- a/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
+++ b/docs/aspice/CStyleCheck_SVD_Software_Version_Description.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SVD-001 | **Version** | 1.19 |
+| **Document ID** | CSC-SVD-001 | **Version** | 1.20 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 1.20 | 2026-06-27 | Cascade: SYS2→2.1, SUP1→1.8 | Dermot Murphy |
 | 1.19 | 2026-06-27 | Cascade cross-ref update: SWE1→2.4, SWE2→1.11, SWE3→1.15, SWE4→1.17, SWE5→1.11, SWE6→1.13, SUP8→1.9 | Dermot Murphy |
 | 1.18 | 2026-06-27 | Cascade cross-ref update: SWE1→2.3, SWE2→1.10, SWE3→1.14, SWE4→1.16, SWE5→1.10, SWE6→1.12, SYS4→1.9 | Dermot Murphy |
 | 1.17 | 2026-06-27 | Claude | ASPICE audit — update §3.1/§5.5/§10 doc version refs (SWE1 2.1→2.2, SWE3 1.12→1.13, SWE4 1.14→1.15, SWE6 1.10→1.11, SYS2 1.9→2.0, SYS4 1.7→1.8, SUP8 1.7→1.8); update approval dates — closes #315 #316 #317 #318 #319 #320 #321 #322 #323 |
@@ -59,7 +60,7 @@ This document satisfies the release-identification and configuration-status-acco
 | CSC-SWE5-001 | CStyleCheck Software Integration Test Specification | 1.11 |
 | CSC-SWE6-001 | CStyleCheck Software Qualification Test Specification | 1.13 |
 | CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
-| CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.7 |
+| CSC-SUP1-001 | CStyleCheck Quality Assurance Plan | 1.8 |
 | CSC-MAN3-001 | CStyleCheck Project Management Plan | 1.6 |
 
 ---
@@ -202,20 +203,20 @@ Platforms: `linux/amd64`, `linux/arm64`.
 
 | Document ID | Title | Version |
 |---|---|---|
-| CSC-SVD-001 | Software Version Description (this document) | 1.19 |
+| CSC-SVD-001 | Software Version Description (this document) | 1.20 |
 | CSC-SWE1-001 | Software Requirements Specification | 2.4 |
 | CSC-SWE2-001 | Software Architecture Design | 1.11 |
 | CSC-SWE3-001 | Software Detailed Design | 1.15 |
 | CSC-SWE4-001 | Software Unit Verification Specification | 1.17 |
 | CSC-SWE5-001 | Software Integration Test Specification | 1.11 |
 | CSC-SWE6-001 | Software Qualification Test Specification | 1.13 |
-| CSC-SYS2-001 | System Requirements Specification | 2.0 |
+| CSC-SYS2-001 | System Requirements Specification | 2.1 |
 | CSC-SYS3-001 | System Architecture Design | 1.5 |
 | CSC-SYS4-001 | System Integration Test Specification | 1.9 |
 | CSC-SYS5-001 | System Verification Specification | 1.7 |
 | CSC-MAN3-001 | Project Management Plan | 1.6 |
 | CSC-MAN5-001 | Risk Management Plan | 1.3 |
-| CSC-SUP1-001 | Quality Assurance Plan | 1.7 |
+| CSC-SUP1-001 | Quality Assurance Plan | 1.8 |
 | CSC-SUP8-001 | Configuration Management Plan | 1.9 |
 | CSC-SUP9-001 | Problem Resolution Plan | 1.2 |
 | CSC-SUP10-001 | Change Request Plan | 1.2 |
@@ -361,7 +362,7 @@ to work without modification.
 
 | Work Product | Document | Version | Status |
 |---|---|---|---|
-| System Requirements | CSC-SYS2-001 | 2.0 | Released |
+| System Requirements | CSC-SYS2-001 | 2.1 | Released |
 | System Architecture | CSC-SYS3-001 | 1.5 | Released |
 | System Integration Tests | CSC-SYS4-001 | 1.9 | Released |
 | System Verification | CSC-SYS5-001 | 1.7 | Released |

--- a/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
+++ b/docs/aspice/CStyleCheck_SYS2_System_Requirements.md
@@ -8,7 +8,7 @@
 
 | Field | Value | Field | Value |
 |---|---|---|---|
-| **Document ID** | CSC-SYS2-001 | **Version** | 2.0 |
+| **Document ID** | CSC-SYS2-001 | **Version** | 2.1 |
 | **Project** | CStyleCheck | **Date** | 2026-06-27 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
@@ -20,6 +20,7 @@
 
 | Version | Date | Author | Description of Change |
 |---|---|---|---|
+| 2.1 | 2026-06-27 | Fix §3.3 cross-refs: SUP8 1.7→1.9, SWE1 2.2→2.4 | Dermot Murphy |
 | 2.0 | 2026-06-27 | Claude | ASPICE audit — §3.1 scope v1.4.1→v1.5.0 and 71→72 rule IDs; §3.3 SWE1 ref 1.9→2.2; SYS-F-011 71→72; §6 RTM add SWE1-MISRA-004/SWE1-089/SWE1-090 traceability; update Review & Approval dates — closes #319 #323 |
 | 1.9 | 2026-06-26 | Claude | §6 RTM: replace all `\<SWE.1-REQ-xxx\>` placeholders with actual SWE1-xxx IDs; add CSC-SWE1-001 to §3.3; update §3.1 scope to v1.4.1 — closes issue #292 |
 | 1.8 | 2026-06-26 | Claude | Update SYS-F-020 to include v1.4.0 misc and macro-safety rules — closes issue #261 |
@@ -59,9 +60,9 @@ The system is deployed in four integration modes:
 |---|---|---|
 | ASPICE PAM v4.0 | Automotive SPICE Process Assessment Model | 4.0 |
 | Barr-C:2018 | Barr Group Embedded C Coding Standard | 2018 |
-| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.7 |
+| CSC-SUP8-001 | CStyleCheck Configuration Management Plan | 1.9 |
 | CSC-SYS3-001 | CStyleCheck System Architecture Description | 1.5 |
-| CSC-SWE1-001 | CStyleCheck Software Requirements Analysis | 2.2 |
+| CSC-SWE1-001 | CStyleCheck Software Requirements Analysis | 2.4 |
 
 ### 3.4 Glossary
 


### PR DESCRIPTION
## Summary

Targeted fix for the 4 cross-reference failures found in the final internal ASPICE CL2 audit.

| Document | Was | Now | Fix |
|---|---|---|---|
| SYS2 | v2.0 | **v2.1** | §3.3: CSC-SUP8-001 1.7→1.9, CSC-SWE1-001 2.2→2.4 |
| SUP1 | v1.7 | **v1.8** | §3.1: CSC-SUP8-001 1.7→1.9, CSC-SWE4-001 1.14→1.17 |
| SVD | v1.19 | **v1.20** | §3.1/§5.5/§10: SYS2→2.1, SUP1→1.8 |

**Cascade boundary note:** SYS2 v2.0→v2.1 is a §3.3 administrative correction only (no requirements content modified). Documents referencing SYS2 v2.0 (SWE1 §3.2, SYS4 §3.3) are still tracing to the same requirements set — cascade is intentionally stopped here to prevent infinite regress.

No source code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_