### PR TITLE
fix(wiki): read version dynamically from pyproject.toml in ASPICE index

### DIFF
--- a/.github/workflows/wiki_publish.yml
+++ b/.github/workflows/wiki_publish.yml
@@ -318,6 +318,14 @@ jobs:
           # ASPICE-Index.md
           now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
+          # Read version from pyproject.toml so the index stays current
+          _ver_match = re.search(
+              r'^version\s*=\s*"([^"]+)"',
+              Path("pyproject.toml").read_text(encoding="utf-8"),
+              re.MULTILINE,
+          )
+          project_version = _ver_match.group(1) if _ver_match else "unknown"
+
           def classify(fn):
               # Match "_<CODE><digit>" rather than a bare substring - otherwise
               # e.g. "_ACQ4_Supplier_..." misclassifies as Support (_SUP is a
@@ -353,7 +361,7 @@ jobs:
           idx_lines = [
               "# ASPICE CL2 Documentation",
               "",
-              "**CStyleCheck v1.2.0** | Automotive SPICE PAM v4.0 | Capability Level 2",
+              f"**CStyleCheck v{project_version}** | Automotive SPICE PAM v4.0 | Capability Level 2",
               "",
               f"*Auto-generated from docs/aspice/ on {now}.*",
               "",


### PR DESCRIPTION
## Summary

The ASPICE wiki index page (`ASPICE-Index.md`) had the version hardcoded as `CStyleCheck v1.2.0` — this has been stale since v1.3.0.

## Change

In `wiki_publish.yml`, extract the version from `pyproject.toml` at publish time using a regex on `version = "x.y.z"`, then interpolate it into the ASPICE index header. From now on the index will always show the correct release version automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_