### PR TITLE
chore: add prerelease_check.sh and check_my_project.bat helper scripts

### DIFF
--- a/scripts/check_my_project.bat
+++ b/scripts/check_my_project.bat
@@ -1,0 +1,43 @@
+@echo off
+REM check_my_project.bat — run CStyleCheck against your own C codebase.
+REM Edit the paths in the CONFIG section below before running.
+REM Usage:  scripts\check_my_project.bat
+
+REM =============================================================================
+REM CONFIG — edit these paths
+REM =============================================================================
+
+REM Path to cstylecheck (use "cstylecheck" if installed via pip/pipx)
+SET CHECKER=cstylecheck
+
+REM Root of the C source tree to check (supports glob include below)
+SET SRC_ROOT=C:\path\to\your\project\src
+
+REM Your project rules.yml (copy src\rules.yml and customise)
+SET CONFIG=C:\path\to\your\project\cstylecheck\rules.yml
+
+REM Additional flags (remove or add as needed)
+SET FLAGS=--summary --warnings-as-errors
+
+REM =============================================================================
+REM END CONFIG
+REM =============================================================================
+
+echo === CStyleCheck — %SRC_ROOT% ===
+echo Config : %CONFIG%
+echo.
+
+%CHECKER% --config "%CONFIG%" --include "%SRC_ROOT%\**\*.c" --include "%SRC_ROOT%\**\*.h" %FLAGS%
+
+IF %ERRORLEVEL% EQU 0 (
+    echo.
+    echo [PASS] No violations found.
+) ELSE IF %ERRORLEVEL% EQU 1 (
+    echo.
+    echo [WARN] Violations reported — see output above.
+) ELSE (
+    echo.
+    echo [ERROR] CStyleCheck exited with error code %ERRORLEVEL% (config problem^?^)
+)
+
+exit /b %ERRORLEVEL%

--- a/scripts/prerelease_check.sh
+++ b/scripts/prerelease_check.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# prerelease_check.sh — mirrors the full CI gate locally before a release.
+# Run from the repository root: bash scripts/prerelease_check.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+ok()   { echo "[PASS] $*"; PASS=$((PASS+1)); }
+fail() { echo "[FAIL] $*"; FAIL=$((FAIL+1)); }
+skip() { echo "[SKIP] $*"; SKIP=$((SKIP+1)); }
+
+has_module() { python -c "import $1" 2>/dev/null; }
+
+echo "=== CStyleCheck pre-release gate ==="
+echo
+
+# 1. YAML sync check (src/rules.yml must match tests/rules.yml except known test fixtures)
+echo "--- 1. YAML sync check ---"
+DIFF=$(diff src/rules.yml tests/rules.yml \
+       | grep '^[<>]' \
+       | grep -v 'style: tabs\|style: spaces\|allow_loop_vars_short\|TEST FIXTURE\|intentionally' \
+       || true)
+if [ -n "$DIFF" ]; then
+    fail "tests/rules.yml differs from src/rules.yml"
+    echo "$DIFF"
+else
+    ok "rules.yml in sync"
+fi
+echo
+
+# 2. Full test suite (with coverage if pytest-cov is available)
+echo "--- 2. pytest ---"
+if has_module pytest; then
+    COV_FLAGS=""
+    if has_module pytest_cov; then
+        COV_FLAGS="--cov=src --cov-branch --cov-fail-under=85"
+    fi
+    if python -m pytest tests/ -q --tb=short $COV_FLAGS 2>&1; then
+        ok "pytest passed"
+    else
+        fail "pytest failed"
+    fi
+else
+    skip "pytest not installed (pip install pytest)"
+fi
+echo
+
+# 3. ruff lint
+echo "--- 3. ruff lint ---"
+if has_module ruff; then
+    if python -m ruff check src/ tests/ 2>&1; then
+        ok "ruff clean"
+    else
+        fail "ruff reported violations"
+    fi
+else
+    skip "ruff not installed (pip install ruff)"
+fi
+echo
+
+# 4. mypy type check
+echo "--- 4. mypy ---"
+if has_module mypy; then
+    if python -m mypy src/cstylecheck/ --ignore-missing-imports --no-error-summary 2>&1; then
+        ok "mypy clean"
+    else
+        fail "mypy reported errors"
+    fi
+else
+    skip "mypy not installed (pip install mypy)"
+fi
+echo
+
+# 5. Self-check: tool checks its own source with zero error-level violations
+echo "--- 5. CStyleCheck self-check ---"
+ERROR_COUNT=$(python src/cstylecheck.py --config src/rules.yml src/cstylecheck/ \
+              | grep -c ': ERROR ' || true)
+if [ "$ERROR_COUNT" -eq 0 ]; then
+    ok "self-check: 0 error-level violations"
+else
+    fail "self-check: $ERROR_COUNT error-level violations"
+    python src/cstylecheck.py --config src/rules.yml src/cstylecheck/ | grep ': ERROR '
+fi
+echo
+
+# Summary
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- `scripts/prerelease_check.sh` — mirrors the full CI gate so you can verify locally before pushing a release
- `scripts/check_my_project.bat` — Windows batch file to run cstylecheck against your own C codebase (placeholder paths to edit)

## prerelease_check.sh — what it checks

1. **YAML sync** — `src/rules.yml` vs `tests/rules.yml` (catches the issue from PR #342)
2. **pytest** — full 1223-test suite; adds `--cov` flags if `pytest-cov` is installed, skips gracefully otherwise
3. **ruff lint** — skips if not installed
4. **mypy** — skips if not installed
5. **Self-check** — runs cstylecheck on its own source; fails if any `ERROR`-level violations found

Usage:
```bash
bash scripts/prerelease_check.sh
```

## check_my_project.bat — what to edit

Three `SET` lines at the top:
- `CHECKER` — path to `cstylecheck` (or just `cstylecheck` if on PATH)
- `SRC_ROOT` — root of your C source tree
- `CONFIG` — path to your `rules.yml`

## Test plan
- [x] `prerelease_check.sh` runs to completion locally: 3 passed, 0 failed, 2 skipped (ruff/mypy not in sandbox)
- [x] All 1223 tests pass within the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_