### PR TITLE
fix(types): X | None for optional parameters (fixes mypy errors in prerelease check)

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -174,15 +174,15 @@ class Checker:
         source: str,
         cfg: dict,
         spell_words=None,
-        alias_prefixes: list = None,
-        disabled_rules: frozenset = None,
-        ident_disabled_rules: dict = None,
-        inline_suppressions: dict = None,
-        defines: list = None,
-        extra_banned: frozenset = None,
+        alias_prefixes: list | None = None,
+        disabled_rules: frozenset | None = None,
+        ident_disabled_rules: dict | None = None,
+        inline_suppressions: dict | None = None,
+        defines: list | None = None,
+        extra_banned: frozenset | None = None,
         copyright_header=None,
-        c_keywords: frozenset = None,
-        c_stdlib_names: frozenset = None,
+        c_keywords: frozenset | None = None,
+        c_stdlib_names: frozenset | None = None,
     ):
         self.filepath      = filepath
         # Normalise line endings once at construction time so all check

--- a/src/cstylecheck/sign_checker.py
+++ b/src/cstylecheck/sign_checker.py
@@ -68,8 +68,8 @@ _RE_SINT_CAST  = re.compile(r"^\s*\(\s*(?:signed|int\w+|sint\w+)\s*\)")
 
 
 def _classify_tokens(tokens: list,
-                     signed_types: set = None,
-                     unsigned_types: set = None) -> str:
+                     signed_types: set | None = None,
+                     unsigned_types: set | None = None) -> str:
     """Return sign classification from a list of type/qualifier tokens.
 
     *signed_types* and *unsigned_types* default to the module-level sets when
@@ -93,8 +93,8 @@ def _classify_tokens(tokens: list,
 
 
 def _signedness_of_type(type_str: str, tmap: dict,
-                        signed_types: set = None,
-                        unsigned_types: set = None) -> str:
+                        signed_types: set | None = None,
+                        unsigned_types: set | None = None) -> str:
     """Resolve a full type string (e.g. 'int8_t' or 'unsigned short') to a sign."""
     tokens = type_str.split()
     result = _classify_tokens(tokens, signed_types, unsigned_types)
@@ -379,7 +379,7 @@ class DeclaredNotDefinedChecker:
         re.MULTILINE,
     )
 
-    def __init__(self, cfg: dict, defines: list = None):
+    def __init__(self, cfg: dict, defines: list | None = None):
         self._cfg:         dict = cfg
         self._defines:     list = defines or []
         self._decls:       list = []   # (filepath, line, col, name, kind)


### PR DESCRIPTION
## Summary

Fixes mypy errors surfaced by `scripts/prerelease_check.sh`:

```
error: Incompatible default for parameter "alias_prefixes"
       (default has type "None", parameter has type "list[Any]")
```

## Root cause

Parameters were annotated with a concrete type (`list`, `dict`, `frozenset`, `set`) but defaulted to `None`. mypy requires the annotation to declare `None` as a valid type via a union.

## Changes

- `src/cstylecheck/checker.py` — 8 `__init__` parameters: `alias_prefixes`, `disabled_rules`, `ident_disabled_rules`, `inline_suppressions`, `defines`, `extra_banned`, `c_keywords`, `c_stdlib_names`
- `src/cstylecheck/sign_checker.py` — 5 parameters: `signed_types`/`unsigned_types` in `_classify_tokens` and `_signedness_of_type`, `defines` in `SignChecker.__init__`

Uses `X | None` union syntax (valid from Python 3.10, the project minimum). No behavioural change — all call sites and `or []`/`or frozenset()` guards in the bodies are unchanged.

## Test plan
- [x] 1223 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_