### PR TITLE
fix(checker): skip constant.case for function/type alias #defines (closes #355)

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -412,7 +412,23 @@ class Checker:
                 and name.lower().endswith(td_suffix.lower())
             )
 
-            if not is_typedef_alias and not matches_case(name, expected_case):
+            # Skip constant.case when the RHS is a single bare identifier that
+            # is NOT itself an ALL_CAPS constant or boolean/null keyword: the
+            # define is a function/type/symbol alias, not a constant value.
+            # e.g. #define MW_KX134_HAL_PowerOnInit  HAL_Acc_PowerOnInit
+            #      #define module_my_type_t          uint8_t
+            # ALL_CAPS RHS (e.g. SOME_OTHER_CONST) is still a constant alias
+            # so the LHS case check still applies.  issue #355
+            _BOOL_NULL = {"true", "false", "TRUE", "FALSE", "NULL", "nullptr"}
+            is_fn_alias = (
+                not is_fn
+                and bool(re.fullmatch(r'[a-zA-Z_][a-zA-Z0-9_]*', rest))
+                and not re.fullmatch(r'[A-Z][A-Z0-9_]*', rest)
+                and rest not in _BOOL_NULL
+            )
+
+            if not is_typedef_alias and not is_fn_alias \
+                    and not matches_case(name, expected_case):
                 self._v(m.start(), sev, f"{rule_pfx}.case",
                         f"{label} '{name}' must be {expected_case}")
 

--- a/tests/test_defines.py
+++ b/tests/test_defines.py
@@ -174,9 +174,11 @@ class TestTypedefSuffixExemption(unittest.TestCase):
             filepath="module.c",
         ))
 
-    def test_typedef_suffix_disabled_alias_flagged(self):
-        """When suffix check is disabled, _t-suffixed name IS flagged as constant.case."""
-        self.assertTrue(has(
+    def test_typedef_suffix_disabled_alias_not_flagged(self):
+        """Even with suffix check disabled, a single-identifier RHS (uint8_t) is
+        detected as a type/symbol alias by the fn-alias heuristic (issue #355)
+        and constant.case is not raised."""
+        self.assertFalse(has(
             "#define module_my_type_t uint8_t\n",
             TYPEDEF_CONST_CFG_DISABLED_SUFFIX,
             "constant.case",
@@ -200,6 +202,72 @@ class TestTypedefSuffixExemption(unittest.TestCase):
             "constant.case",
             filepath="module.c",
         ))
+
+
+class TestFunctionAliasExemption(unittest.TestCase):
+    """Issue #355: object-like #defines whose RHS is a single bare identifier
+    (function/symbol alias) must not trigger constant.case."""
+
+    def test_hal_function_alias_not_flagged(self):
+        """#define MW_KX134_HAL_PowerOnInit HAL_Acc_PowerOnInit — mixed-case alias."""
+        self.assertFalse(has(
+            "#define MW_KX134_HAL_PowerOnInit\tHAL_Acc_PowerOnInit\n",
+            CONST_CFG, "constant.case", filepath="module.c",
+        ))
+
+    def test_multiple_hal_aliases_not_flagged(self):
+        src = (
+            "#define MW_KX134_HAL_PowerOnInit   HAL_Acc_PowerOnInit\n"
+            "#define MW_KX134_HAL_Read          HAL_Acc_SPI_Read\n"
+            "#define MW_KX134_HAL_Write         HAL_Acc_SPI_Write\n"
+        )
+        self.assertEqual(count(src, CONST_CFG, "constant.case", filepath="module.c"), 0)
+
+    def test_lower_snake_alias_not_flagged(self):
+        """#define my_module_init  other_module_init — lower_snake alias."""
+        self.assertFalse(has(
+            "#define my_module_init  other_module_init\n",
+            CONST_CFG, "constant.case", filepath="module.c",
+        ))
+
+    def test_numeric_rhs_still_flagged(self):
+        """#define mixedName 100 — RHS is a numeric literal, must still flag."""
+        self.assertTrue(has(
+            "#define mixedName 100\n",
+            CONST_CFG, "constant.case", filepath="module.c",
+        ))
+
+    def test_expression_rhs_still_flagged(self):
+        """#define myFlag (1U << 3) — RHS is an expression, must still flag."""
+        self.assertTrue(has(
+            "#define myFlag (1U << 3)\n",
+            CONST_CFG, "constant.case", filepath="module.c",
+        ))
+
+    def test_all_caps_alias_not_flagged(self):
+        """#define MY_MODULE_FUNC SOME_OTHER_FUNC — both ALL_CAPS, passes anyway
+        (LHS is valid upper_snake; ALL_CAPS RHS is a constant alias so fn-alias
+        heuristic does NOT apply, but the name itself passes the case check)."""
+        self.assertFalse(has(
+            "#define MY_MODULE_FUNC SOME_OTHER_FUNC\n",
+            CONST_CFG, "constant.case", filepath="module.c",
+        ))
+
+    def test_mixed_case_lhs_all_caps_rhs_still_flagged(self):
+        """#define mixedName SOME_CONSTANT — ALL_CAPS RHS is a constant alias,
+        fn-alias heuristic does not apply, so LHS case is still checked."""
+        self.assertTrue(has(
+            "#define mixedName SOME_CONSTANT\n",
+            CONST_CFG, "constant.case", filepath="module.c",
+        ))
+
+    def test_alias_still_checks_prefix(self):
+        """Function alias must still pass the module-prefix check."""
+        viols = [v for v in run(
+            "#define NoPrefixAlias HAL_Acc_PowerOnInit\n",
+            CONST_CFG, filepath="module.c",
+        ) if v.rule == "constant.prefix"]
+        self.assertTrue(viols, "Expected constant.prefix violation for missing module prefix")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes a false positive where `constant.case` incorrectly fires for `#define` macros that are function or type aliases rather than constant definitions.

### Problem

```c
// Hardware abstraction layer alias — function naming convention is intentional
#define MW_KX134_HAL_PowerOnInit    HAL_Acc_PowerOnInit

// ERROR [constant.case] Constant 'MW_KX134_HAL_PowerOnInit' must be upper_snake
```

### Fix

In `_check_defines()`, before applying `constant.case` to an object-like `#define`, the replacement text is inspected. If it is a **single bare identifier whose name is not ALL_CAPS** (i.e. not itself a constant), the define is classified as a function/type/symbol alias and `constant.case` is skipped.

| RHS pattern | Classification | `constant.case` applied? |
|---|---|---|
| `HAL_Acc_PowerOnInit` | function alias (mixed-case identifier) | No |
| `uint8_t` | type alias (lowercase identifier) | No |
| `SOME_CONSTANT` | constant alias (ALL_CAPS identifier) | Yes |
| `100` / `(1U << 3)` | literal / expression | Yes |
| `NULL` / `true` / `false` | boolean/null keyword | Yes |

All other checks (`constant.prefix`, `constant.max_length`, `constant.min_length`) still apply to aliases so module-prefix enforcement is preserved.

### Side effect

The fn-alias heuristic also catches type aliases (`uint8_t`, `uint16_t`) independently of the typedef-suffix feature, making `constant.case` exempt for those even when the typedef suffix check is disabled. One existing test updated to reflect this more correct behaviour.

## Test plan
- [x] 8 new tests in `TestFunctionAliasExemption` covering HAL aliases, type aliases, multi-alias files, expression/literal RHS still flagged, ALL_CAPS alias still flagged, prefix still checked.
- [x] 1 existing test updated (`test_typedef_suffix_disabled_alias_flagged` → `_not_flagged`).
- [x] Full suite: 1266 tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_