### PR TITLE
fix(cli): prevent verbose progress messages corrupting output lines (closes #357)

### DIFF
--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -502,6 +502,8 @@ def main() -> int:
             _n = len(files)
             _msg = f"Found {_n} file(s) - starting analysis..."
             print(f"{_msg:<79}", file=sys.stderr, flush=True)
+            if sys.stderr.isatty():
+                print(file=sys.stderr, flush=True)  # blank line — \r progress lands below "Found…"
 
         output_format  = getattr(args, "output_format", "text")
         all_violations: list = []
@@ -568,8 +570,7 @@ def main() -> int:
                         tee.print(v)
 
         if getattr(args, "verbose", False) and sys.stderr.isatty():
-            print(" " * 80, end="\r",
-                  file=sys.stderr)  # erase last progress line
+            print("\r" + " " * 79, file=sys.stderr)  # erase progress line, advance cursor
         # Cross-file sign-compatibility check (needs all files ingested first).
         # Uses the source cache so no file is read from disk a second time.
         sign_cfg = cfg.get("sign_compatibility", {})


### PR DESCRIPTION
## Summary

Fixes the `--verbose` output corruption where scanning progress messages bleed onto the `Found N file(s) - starting analysis...` line and leave the cursor on a blank row before the first violation is printed.

### Before

```
Found 240 file(s) - starting analysis...                                       tils\sprintf.h\S2LP_CORE_SPI.hhn.hrs.hg.hhg.h.hh.h
```

### After

```
Found 240 file(s) - starting analysis...
Scanning: path/to/last/file.h

path/to/file.c:42: ERROR [rule.id] ...
```

## Root cause

Two related problems in `cli.py`:

1. The `\r` scanning messages could land on the `Found N file(s)...` line because some Windows terminal configurations do not guarantee the cursor has advanced to the next line before the first `\r` write.
2. The post-scan erase used `end="\r"`, leaving the cursor at column 0 of the now-blank scanning line, so the first violation appeared on that visual row.

## Fix

- **`cli.py` line ~504**: Print a blank line after `Found N file(s)...` (tty-only) to guarantee the `\r` progress messages land on a dedicated line below it.
- **`cli.py` line ~571**: Changed `print(" " * 80, end="\r")` to `print("\r" + " " * 79)` — default `end="\n"` advances the cursor past the erased line before violations print.

## Test plan

- [x] Full suite: 1266 tests passed, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_