### PR TITLE
fix: verbose output interleaving, fn-ptr typedef false positive, block-comment suppression

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -77,9 +77,11 @@ _STANDARD_C_HEADERS: frozenset = frozenset({
 
 
 # Control-flow keywords that must never be mistaken for a return type.
+# typedef is included so that function-pointer typedefs are not parsed as
+# function declarations/definitions (issue #359).
 _CFKW = (
     r"if|else|while|for|do|switch|case|return|goto|break|continue"
-    r"|sizeof|typeof|__typeof__|__attribute__|defined|assert"
+    r"|sizeof|typeof|__typeof__|__attribute__|defined|assert|typedef"
 )
 
 RE_FUNCTION_DEF = re.compile(

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -501,9 +501,10 @@ def main() -> int:
         if getattr(args, "verbose", False):
             _n = len(files)
             _msg = f"Found {_n} file(s) - starting analysis..."
-            print(f"{_msg:<79}", file=sys.stderr, flush=True)
             if sys.stderr.isatty():
-                print(file=sys.stderr, flush=True)  # blank line — \r progress lands below "Found…"
+                # Clear any leftover chars beyond col 79 from long discovery paths
+                print("\r" + " " * 120, end="\r", file=sys.stderr, flush=True)
+            print(f"{_msg:<79}", file=sys.stderr, flush=True)
 
         output_format  = getattr(args, "output_format", "text")
         all_violations: list = []
@@ -562,7 +563,12 @@ def main() -> int:
             result  = checker.run_all()
             all_violations.extend(result.violations)
 
-            if output_format == "text":
+            # In verbose+TTY mode defer violation printing: the cursor is at col 0
+            # of the progress line (left there by \r), so printing to stdout here
+            # would corrupt it.  Violations are flushed after the progress line
+            # is cleared below.
+            _verbose_tty = getattr(args, "verbose", False) and sys.stderr.isatty()
+            if output_format == "text" and not _verbose_tty:
                 for v in sorted(result.violations, key=lambda x: (x.line, x.col)):
                     if args.github_actions:
                         tee.print(v.github_annotation())
@@ -570,7 +576,17 @@ def main() -> int:
                         tee.print(v)
 
         if getattr(args, "verbose", False) and sys.stderr.isatty():
-            print("\r" + " " * 79, file=sys.stderr)  # erase progress line, advance cursor
+            print("\r" + " " * 120, file=sys.stderr)  # erase progress line (wide), advance cursor
+
+        # Flush deferred violations (verbose+TTY mode) now that the progress line
+        # has been cleared and the cursor is on a clean line.
+        if output_format == "text" and getattr(args, "verbose", False) and sys.stderr.isatty():
+            for v in sorted(all_violations,
+                            key=lambda x: (x.filepath, x.line, x.col)):
+                if args.github_actions:
+                    tee.print(v.github_annotation())
+                else:
+                    tee.print(v)
         # Cross-file sign-compatibility check (needs all files ingested first).
         # Uses the source cache so no file is read from disk a second time.
         sign_cfg = cfg.get("sign_compatibility", {})

--- a/src/cstylecheck/preprocessor.py
+++ b/src/cstylecheck/preprocessor.py
@@ -67,7 +67,7 @@ def _comment_only_lines(source: str) -> set:
 
 
 _RE_SUPPRESS = re.compile(
-    r"//\s*cstylecheck\s*:\s*"
+    r"(?://|/\*)\s*cstylecheck\s*:\s*"
     r"(disable-next-line|disable|enable)"
     r"(?:=([^\n*/]+))?",
     re.IGNORECASE,

--- a/tests/test_inline_suppression.py
+++ b/tests/test_inline_suppression.py
@@ -162,5 +162,72 @@ class TestCheckerInlineSuppression(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+class TestBlockCommentSuppression(unittest.TestCase):
+    """Issue #360: /* cstylecheck: disable=... */ block-comment syntax must
+    be recognised in addition to // comments."""
+
+    def test_block_comment_same_line_single_rule(self):
+        src = 'int x = 1234;  /* cstylecheck: disable=misc.magic_number */\n'
+        s = parse_inline_suppressions(src)
+        self.assertIn("misc.magic_number", s.get(1, frozenset()))
+
+    def test_block_comment_block_disable_enable(self):
+        src = textwrap.dedent("""\
+            /* cstylecheck: disable=misc.magic_number */
+            int uart_a = 42;
+            int uart_b = 99;
+            /* cstylecheck: enable=misc.magic_number */
+            int uart_c = 77;
+        """)
+        s = parse_inline_suppressions(src)
+        self.assertIn("misc.magic_number", s.get(2, frozenset()))
+        self.assertIn("misc.magic_number", s.get(3, frozenset()))
+        self.assertNotIn(5, s)
+
+    def test_block_comment_disable_multiple_rules(self):
+        src = textwrap.dedent("""\
+            /* cstylecheck: disable=misc.magic_number, variables.case */
+            int BadName = 42;
+            /* cstylecheck: enable=misc.magic_number, variables.case */
+        """)
+        s = parse_inline_suppressions(src)
+        self.assertIn("misc.magic_number", s.get(2, frozenset()))
+        self.assertIn("variables.case", s.get(2, frozenset()))
+
+    def test_block_comment_suppress_end_to_end(self):
+        src = textwrap.dedent("""\
+            uint8_t uart_Init(void) {
+                /* cstylecheck: disable=misc.magic_number */
+                int uart_a = 42;
+                int uart_b = 99;
+                /* cstylecheck: enable=misc.magic_number */
+                int uart_c = 77;
+                return uart_a;
+            }
+        """)
+        violations = _violations(src)
+        magic_by_line = {ln for ln, r in violations if r == "misc.magic_number"}
+        self.assertNotIn(3, magic_by_line)
+        self.assertNotIn(4, magic_by_line)
+        self.assertIn(6, magic_by_line)
+
+    def test_slashslash_comment_still_works(self):
+        """Existing // syntax must continue to work after adding /* support."""
+        src = textwrap.dedent("""\
+            uint8_t uart_Init(void) {
+                // cstylecheck: disable=misc.magic_number
+                int uart_a = 42;
+                // cstylecheck: enable=misc.magic_number
+                int uart_b = 77;
+                return uart_a;
+            }
+        """)
+        violations = _violations(src)
+        magic_by_line = {ln for ln, r in violations if r == "misc.magic_number"}
+        self.assertNotIn(3, magic_by_line)
+        self.assertIn(5, magic_by_line)
+
+
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_prefix.py
+++ b/tests/test_parameter_prefix.py
@@ -580,5 +580,44 @@ class TestCallStatementNotMisparsedAsDeclaration(unittest.TestCase):
         self.assertFalse(has(src, ON, RULE))
 
 
+# ===========================================================================
+# Regression: function-pointer typedef names must not be mistaken for
+# parameter names (issue #359).
+# ===========================================================================
+
+class TestFunctionPointerTypedefNotFlagged(unittest.TestCase):
+    """Issue #359: typedef void (*fn_t)(void* arg) must not raise p_prefix on
+    the function-pointer name or on substrings of it."""
+
+    def test_fn_ptr_typedef_no_p_prefix_violation(self):
+        """The function-pointer name hal_rtos_thread_entry_t must not be
+        parsed as a parameter."""
+        src = "typedef void (*hal_rtos_thread_entry_t) (void* arg1, void* arg2, void* arg3);\n"
+        self.assertFalse(has(src, ON, RULE),
+            "typedef function-pointer name must not trigger variable.parameter.p_prefix")
+
+    def test_fn_ptr_typedef_no_hread_entry_t_substring(self):
+        """Specifically: 'hread_entry_t' (a substring produced by the old
+        regex backtracking) must not be reported."""
+        src = "typedef void (*hal_rtos_thread_entry_t) (void* arg1);\n"
+        viols = [v for v in run(src, ON) if v.rule == RULE]
+        names = {v.message.split("'")[1] for v in viols}
+        self.assertNotIn("hread_entry_t", names)
+
+    def test_multiple_fn_ptr_typedefs_no_violations(self):
+        """Multiple function-pointer typedefs in one translation unit."""
+        src = (
+            "typedef void (*hal_rtos_thread_entry_t) (void* p_arg1, void* p_arg2);\n"
+            "typedef int  (*hal_callback_t) (uint8_t p_event, uint32_t p_data);\n"
+        )
+        self.assertFalse(has(src, ON, RULE))
+
+    def test_regular_function_declaration_still_checked(self):
+        """A regular function declaration (not typedef) must still be checked."""
+        src = "void hal_init(uint8_t arg1, uint32_t arg2);\n"
+        self.assertTrue(has(src, ON, RULE),
+            "Regular function prototype parameters must still be checked")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Three fixes on this branch:

### 1. `--verbose` progress/violation output interleaving (closes #357)

Two root causes of corrupted verbose output on Windows TTY:

- **Discovery path overflow**: paths longer than 79 chars wrote chars beyond col 79 that `Found N file(s)...` couldn't clear. Fix: write a 120-space clear before printing `Found N file(s)...`.
- **Stdout/stderr cursor sharing**: violations were printed to stdout inside the scanning loop while the progress cursor was at col 0 of the progress line (left there by `\r`). On Windows, stdout and stderr share the same console cursor. Fix: in verbose+TTY mode, skip inline violation printing; flush all violations after the progress line is cleared.

### 2. `variable.parameter.p_prefix` false positive on function-pointer typedef (closes #359)

`RE_FUNCTION_DEF` and `RE_FUNCTION_DECL` share the `_CFKW` negative lookahead that prevents C flow keywords from being mistaken for a return type. Adding `typedef` to `_CFKW` stops both regexes from matching `typedef void (*fn_t)(...);` as a function declaration, eliminating the false positive where a substring of the function-pointer name (e.g. `hread_entry_t` from `hal_rtos_thread_entry_t`) was extracted as a parameter.

### 3. `/* cstylecheck: disable=... */` block comments not recognised (closes #360)

`_RE_SUPPRESS` only matched `//` single-line comments. Changed the comment-opener pattern to `(?://|/\*)` so that `/* cstylecheck: disable=rule */` syntax is accepted. The rule-list terminator `[^\n*/]` already excluded `*` and `/`, so block comments parse correctly without further changes.

## Test plan

- [x] 4 new tests in `TestFunctionPointerTypedefNotFlagged` (test_parameter_prefix.py)
- [x] 5 new tests in `TestBlockCommentSuppression` (test_inline_suppression.py)
- [x] Full suite: 1275 tests passed, 0 failures.
