### PR TITLE
fix: function violations reported on wrong line; inline suppression misses them

### DIFF
--- a/src/cstylecheck/checker.py
+++ b/src/cstylecheck/checker.py
@@ -994,6 +994,14 @@ class Checker:
             if is_exempt(name, _fp_cfg.get("exempt_patterns", [])):
                 continue
 
+            # RE_FUNCTION_DEF starts with (?:^|\n), so m.start() may point to
+            # the '\n' ending the previous line. Advance past it so violations
+            # are reported on the function's own line (important for inline
+            # suppression matching).
+            fn_start = (m.start() + 1
+                        if m.start() < len(self.clean) and self.clean[m.start()] == '\n'
+                        else m.start())
+
             # Detect whether this is a static function definition by inspecting
             # the text immediately before the match (up to 120 chars back).
             window_start = max(0, m.start())
@@ -1009,21 +1017,21 @@ class Checker:
                 sp_pfx = sp_cfg.get("prefix", "prv_")
                 sp_sev = sp_cfg.get("severity", "warning")
                 if not name.startswith(sp_pfx):
-                    self._v(m.start(), sp_sev, "function.static_prefix",
+                    self._v(fn_start, sp_sev, "function.static_prefix",
                             f"Static function '{name}' must start with "
                             f"'{sp_pfx}' (static function prefix)")
 
-            self._require_module_prefix(name, m.start(), "function.prefix")
+            self._require_module_prefix(name, fn_start, "function.prefix")
 
             fn_max = fn_cfg.get("max_length")
             if fn_max and len(name) > fn_max:
-                self._v(m.start(), sev, "function.max_length",
+                self._v(fn_start, sev, "function.max_length",
                         f"Function '{name}' length {len(name)} exceeds "
                         f"maximum {fn_max} characters")
 
             fn_min = fn_cfg.get("min_length")
             if fn_min and len(name) < fn_min:
-                self._v(m.start(), sev, "function.min_length",
+                self._v(fn_start, sev, "function.min_length",
                         f"Function '{name}' length {len(name)} is below "
                         f"minimum {fn_min} characters")
 
@@ -1034,13 +1042,13 @@ class Checker:
 
             if style in ("object_verb", "verb_object"):
                 if not self._body_is_object_verb(body, object_exclusions, abbrevs):
-                    self._v(m.start(), sev, "function.style",
+                    self._v(fn_start, sev, "function.style",
                             f"Function '{name}' body '{body}' should be "
                             f"ObjectVerb segments separated by '_' "
                             f"(e.g. {pfx}BufferRead or {pfx}LiveData_Read)")
             elif style == "lower_snake":
                 if not matches_case(body, "lower_snake"):
-                    self._v(m.start(), sev, "function.style",
+                    self._v(fn_start, sev, "function.style",
                             f"Function '{name}' body '{body}' should be "
                             f"lower_snake")
 

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -12,6 +12,7 @@ import argparse
 import fnmatch
 import glob as glob_mod
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Generator
@@ -481,6 +482,24 @@ def main() -> int:
     try:
         # Discover files lazily — emit progress immediately rather than
         # blocking until the entire glob tree is walked.
+        # Terminal width used for all verbose progress lines.  Capped at one
+        # less than the physical width so a full-width message never wraps —
+        # a wrapped line places the cursor on the next row, which breaks \r
+        # positioning for every subsequent progress write.
+        _verbose_tty = getattr(args, "verbose", False) and sys.stderr.isatty()
+        _tty_cols = (shutil.get_terminal_size((80, 24)).columns - 1
+                     if _verbose_tty else 79)
+
+        def _progress(msg: str) -> None:
+            """Write a \r-terminated progress line capped to the terminal width."""
+            if len(msg) > _tty_cols:
+                msg = msg[:_tty_cols - 3] + "..."
+            print(f"{msg:<{_tty_cols}}", end="\r", file=sys.stderr, flush=True)
+
+        def _clear_progress() -> None:
+            """Erase the current progress line and advance the cursor."""
+            print("\r" + " " * _tty_cols, file=sys.stderr)
+
         files: list = []
         for _fp in discover_files(
             args.files,
@@ -489,10 +508,8 @@ def main() -> int:
             cfg.get("ignore", {}),
         ):
             files.append(_fp)
-            if getattr(args, "verbose", False) and sys.stderr.isatty():
-                _msg = f"Discovering: {_fp}"
-                print(f"{_msg:<79}", end="\r",
-                      file=sys.stderr, flush=True)
+            if _verbose_tty:
+                _progress(f"Discovering: {_fp}")
 
         if not files:
             print("No C files to check.", file=sys.stderr)
@@ -501,10 +518,10 @@ def main() -> int:
         if getattr(args, "verbose", False):
             _n = len(files)
             _msg = f"Found {_n} file(s) - starting analysis..."
-            if sys.stderr.isatty():
-                # Clear any leftover chars beyond col 79 from long discovery paths
-                print("\r" + " " * 120, end="\r", file=sys.stderr, flush=True)
-            print(f"{_msg:<79}", file=sys.stderr, flush=True)
+            if _verbose_tty:
+                # Erase any leftover from long discovery messages before printing
+                _clear_progress()
+            print(f"{_msg:<{_tty_cols}}", file=sys.stderr, flush=True)
 
         output_format  = getattr(args, "output_format", "text")
         all_violations: list = []
@@ -516,11 +533,10 @@ def main() -> int:
 
         for filepath in files:
             if getattr(args, "verbose", False):
-                _msg = f"Scanning: {filepath}"
-                if sys.stderr.isatty():
-                    print(f"{_msg:<79}", end="\r", file=sys.stderr, flush=True)
+                if _verbose_tty:
+                    _progress(f"Scanning: {filepath}")
                 else:
-                    print(_msg, file=sys.stderr, flush=True)
+                    print(f"Scanning: {filepath}", file=sys.stderr, flush=True)
             try:
                 source = Path(filepath).read_text(encoding="utf-8", errors="replace")
                 source_cache[filepath] = source
@@ -567,7 +583,6 @@ def main() -> int:
             # of the progress line (left there by \r), so printing to stdout here
             # would corrupt it.  Violations are flushed after the progress line
             # is cleared below.
-            _verbose_tty = getattr(args, "verbose", False) and sys.stderr.isatty()
             if output_format == "text" and not _verbose_tty:
                 for v in sorted(result.violations, key=lambda x: (x.line, x.col)):
                     if args.github_actions:
@@ -575,12 +590,12 @@ def main() -> int:
                     else:
                         tee.print(v)
 
-        if getattr(args, "verbose", False) and sys.stderr.isatty():
-            print("\r" + " " * 120, file=sys.stderr)  # erase progress line (wide), advance cursor
+        if _verbose_tty:
+            _clear_progress()  # erase scanning progress line, advance cursor
 
         # Flush deferred violations (verbose+TTY mode) now that the progress line
         # has been cleared and the cursor is on a clean line.
-        if output_format == "text" and getattr(args, "verbose", False) and sys.stderr.isatty():
+        if output_format == "text" and _verbose_tty:
             for v in sorted(all_violations,
                             key=lambda x: (x.filepath, x.line, x.col)):
                 if args.github_actions:

--- a/tests/test_inline_suppression.py
+++ b/tests/test_inline_suppression.py
@@ -229,5 +229,80 @@ class TestBlockCommentSuppression(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+_FP_CFG = cfg_only(
+    file_prefix={"enabled": True, "severity": "error"},
+    functions={"enabled": True, "severity": "error"},
+)
+
+
+class TestFunctionPrefixBlockCommentSuppression(unittest.TestCase):
+    """Inline suppression of function.prefix via /* */ block-comment syntax.
+
+    RE_FUNCTION_DEF starts with (?:^|\\n) so m.start() used to point to the
+    '\\n' ending the *previous* line, placing the violation one line before the
+    function itself and outside the suppression block.  The fn_start correction
+    in _check_functions() must ensure the violation lands on the function's own
+    line so the suppression map can match it.
+    """
+
+    def _run(self, src: str) -> set:
+        c = Checker("hal_ble.c", src, _FP_CFG)
+        return {(v.line, v.rule) for v in c.run_all().violations}
+
+    def test_function_prefix_fires_without_suppression(self):
+        src = textwrap.dedent("""\
+            void assert_nrf_callback(uint16_t line_num, const uint8_t* file_name)
+            {
+                (void)line_num; (void)file_name;
+            }
+        """)
+        viols = self._run(src)
+        self.assertTrue(any(r == "function.prefix" for _, r in viols))
+
+    def test_function_prefix_suppressed_by_block_comment_disable(self):
+        src = textwrap.dedent("""\
+            /* cstylecheck: disable=function.prefix */
+            void assert_nrf_callback(uint16_t line_num, const uint8_t* file_name)
+            {
+                (void)line_num; (void)file_name;
+            }
+            /* cstylecheck: enable=function.prefix */
+        """)
+        viols = self._run(src)
+        self.assertFalse(any(r == "function.prefix" for _, r in viols),
+                         f"Expected no function.prefix violation; got {viols}")
+
+    def test_function_prefix_suppressed_by_slashslash_disable(self):
+        src = textwrap.dedent("""\
+            // cstylecheck: disable=function.prefix
+            void assert_nrf_callback(uint16_t line_num, const uint8_t* file_name)
+            {
+                (void)line_num; (void)file_name;
+            }
+            // cstylecheck: enable=function.prefix
+        """)
+        viols = self._run(src)
+        self.assertFalse(any(r == "function.prefix" for _, r in viols),
+                         f"Expected no function.prefix violation; got {viols}")
+
+    def test_function_after_enable_is_still_checked(self):
+        src = textwrap.dedent("""\
+            /* cstylecheck: disable=function.prefix */
+            void assert_nrf_callback(uint16_t line_num, const uint8_t* file_name)
+            {
+                (void)line_num; (void)file_name;
+            }
+            /* cstylecheck: enable=function.prefix */
+            void another_bad_name(void)
+            {
+            }
+        """)
+        viols = self._run(src)
+        prefix_lines = {ln for ln, r in viols if r == "function.prefix"}
+        self.assertNotIn(2, prefix_lines)
+        self.assertIn(7, prefix_lines)
+
+
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `RE_FUNCTION_DEF` / `RE_FUNCTION_DECL` both start with `(?:^|\n)`, so `m.start()` points to the `\n` at the end of the **preceding** line. All function-rule violations (`function.prefix`, `function.static_prefix`, `function.max_length`, `function.min_length`, `function.style`) were therefore reported one line too early.
- This caused inline suppression blocks such as `/* cstylecheck: disable=function.prefix */` to silently miss the violation: the suppression map covers the function's own line, but the violation was anchored to the line above it.
- Also includes the previously pushed terminal-width verbose fix (commit `cc475a7`, closes #357): progress messages are now capped to `shutil.get_terminal_size().columns - 1` characters so they never wrap on narrow terminals.

## Changes

**`src/cstylecheck/checker.py`**
- Compute `fn_start` at the top of the `_check_functions()` loop: if `self.clean[m.start()] == '\n'` advance by 1, otherwise keep `m.start()`. All five function-rule `_v()` calls and the `_require_module_prefix()` call now use `fn_start`.

**`tests/test_inline_suppression.py`**
- Add `TestFunctionPrefixBlockCommentSuppression` (4 tests) covering:
  - violation fires without suppression
  - `/* cstylecheck: disable=function.prefix */` block suppresses it
  - `// cstylecheck: disable=function.prefix` block suppresses it
  - function after `enable` is still checked

**`src/cstylecheck/cli.py`** (commit `cc475a7`)
- Added `_progress()` / `_clear_progress()` helpers using `shutil.get_terminal_size()` to prevent verbose progress lines from wrapping and corrupting subsequent output.

## Test plan

- [ ] `python -m pytest tests/ -q` → 1279 passed, 2 subtests passed
- [ ] Run `cstylecheck` in verbose mode on a multi-file project in an 80-column terminal; confirm no output corruption
- [ ] Verify `/* cstylecheck: disable=function.prefix */` block suppresses `function.prefix` violations for functions inside the block

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_