### PR TITLE
fix: remove non-ASCII chars from output; version/date header in summary

### DIFF
--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -209,7 +209,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  misc.eof_comment       Last non-blank line must be '/* EOF: filename */'\n"
             "                         followed by exactly one blank line.\n\n"
             "Exit codes:\n"
-            "  0  Clean — no violations (or --version/--help)\n"
+            "  0  Clean - no violations (or --version/--help)\n"
             "  1  One or more errors found\n"
             "  2  Configuration or invocation error"
         ),
@@ -443,7 +443,7 @@ def main() -> int:
         # than silently discarding the file (issue #90).
         print(
             f"WARNING: --spell-words '{args.spell_words}' supplied but "
-            "spell_check.enabled is false in config — words file ignored.",
+            "spell_check.enabled is false in config; words file ignored.",
             file=sys.stderr,
         )
 
@@ -762,7 +762,7 @@ def main() -> int:
             tee.print(html_text)
 
         if args.summary and output_format == "text":
-            print_summary(all_violations, len(files), tee)
+            print_summary(all_violations, len(files), tee, _VERSION_STRING)
 
         if args.exit_zero:
             return 0

--- a/src/cstylecheck/output.py
+++ b/src/cstylecheck/output.py
@@ -7,6 +7,7 @@ Imports from: models.
 """
 from __future__ import annotations
 
+import datetime
 from collections import Counter
 
 
@@ -259,20 +260,25 @@ def _violations_to_html(violations: list, files_checked: int,
 # Summary
 # ---------------------------------------------------------------------------
 
-def print_summary(all_violations: list, files_checked: int, tee: Tee) -> None:
+def print_summary(all_violations: list, files_checked: int, tee: Tee,
+                  version_string: str = "") -> None:
     errors   = sum(1 for v in all_violations if v.severity == "error")
     warnings = sum(1 for v in all_violations if v.severity == "warning")
     infos    = sum(1 for v in all_violations if v.severity == "info")
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     tee.print("\n" + "=" * 60)
+    if version_string:
+        tee.print(f"  {version_string} | {now}")
+        tee.print("=" * 60)
     tee.print("  Errors & Warnings:")
-    tee.print(f"  Errors        : {errors}")
-    tee.print(f"  Warnings      : {warnings}")
-    tee.print(f"  Info          : {infos}")
-    tee.print(f"  {chr(8211) * 36}")
-    tee.print(f"  Total         : {errors + warnings + infos}")
-    tee.print("=" * 60)
+    tee.print(f"    Errors        : {errors}")
+    tee.print(f"    Warnings      : {warnings}")
+    tee.print(f"    Info          : {infos}")
+    tee.print(f"    {'-' * 36}")
+    tee.print(f"    Total         : {errors + warnings + infos}")
     rule_counts: Counter = Counter(v.rule for v in all_violations)
     if rule_counts:
+        tee.print("=" * 60)
         tee.print("  Top violated rules:")
         for rule, count in rule_counts.most_common(10):
             tee.print(f"    {rule:<45} {count}")

--- a/src/cstylecheck/wizard.py
+++ b/src/cstylecheck/wizard.py
@@ -168,10 +168,10 @@ def run_wizard(
             prompt_fn=prompt_fn,
         )
         if not answer:
-            print_fn("Aborted — existing config preserved.")
+            print_fn("Aborted - existing config preserved.")
             return 1
 
-    print_fn("\nCStyleCheck config wizard — press Enter to accept defaults.\n")
+    print_fn("\nCStyleCheck config wizard - press Enter to accept defaults.\n")
 
     # ---- Naming convention ----
     var_case = _ask_choice(


### PR DESCRIPTION
Closes #363

## Summary

- **Root cause of mojibake fixed**: `chr(8211)` (en dash U+2013) was used as a separator in `print_summary()` — this is a non-ASCII byte sequence that renders as `ÔÇö` on Windows CP1252 terminals. Replaced with plain ASCII `-`.
- **Em dashes removed** from all user-visible terminal strings in `wizard.py` (`"Aborted — ..."`, `"CStyleCheck config wizard — ..."`) and `cli.py` (spell-check warning, `--help` exit-code description). All replaced with `-`.
- **Version + date header**: `print_summary()` now accepts a `version_string` parameter; when supplied (as `_VERSION_STRING` from `cli.py`), the first summary block line shows e.g. `CStyleCheck 1.2.3 | 2026-07-06 10:05:00`.
- **Consistent indentation**: Errors / Warnings / Info / Total lines now use 4-space indent, matching the Files section.
- **No double `===` lines**: the separator before "Top violated rules" is only emitted when there are rules to show, so clean runs no longer produce two consecutive `===` lines.

## New summary format

```
============================================================
  CStyleCheck 1.2.3 | 2026-07-06 10:05:00
============================================================
  Errors & Warnings:
    Errors        : 2
    Warnings      : 1
    Info          : 0
    ------------------------------------
    Total         : 3
============================================================
  Top violated rules:
    function.prefix                               2
    variables.case                                1
============================================================
  Files:
    Files checked       : 10
    Files with errors   : 2
    Files with warnings : 0
    Files with info     : 0
    Files clean         : 8
============================================================
```

## Test plan

- [ ] `python -m pytest tests/ -q` → 1279 passed
- [ ] Run `cstylecheck --summary` on Windows in a CP1252 terminal; confirm no mojibake in output
- [ ] Run `--init` wizard; confirm no mojibake
- [ ] Run `--summary` with violations; confirm version/date on first line, 4-space indent, single `===` between sections
- [ ] Run `--summary` with no violations; confirm no double `===` lines

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_