### PR TITLE
fix: summary version/date/layout refinements

### DIFF
--- a/src/cstylecheck/__init__.py
+++ b/src/cstylecheck/__init__.py
@@ -19,10 +19,23 @@ try:
     from _version import __version__ as _VERSION
 except ImportError:
     try:
-        from importlib.metadata import version as _pkg_version
-        _VERSION = _pkg_version("cstylecheck")
+        # Read directly from pyproject.toml when running from source so that
+        # stale .egg-info directories don't report an outdated version.
+        import re as _re
+        from pathlib import Path as _Path
+        _pyproj = _Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+        _m = _re.search(r'^version\s*=\s*"([^"]+)"', _pyproj.read_text(), _re.MULTILINE)
+        if _m:
+            _VERSION = _m.group(1)
+        else:
+            raise ValueError("version not found")
+        del _re, _Path, _pyproj, _m
     except Exception:
-        _VERSION = "0.0.0.dev"
+        try:
+            from importlib.metadata import version as _pkg_version
+            _VERSION = _pkg_version("cstylecheck")
+        except Exception:
+            _VERSION = "0.0.0.dev"
 
 _VERSION_STRING = f"{_TOOL_NAME} {_VERSION}"
 

--- a/src/cstylecheck/output.py
+++ b/src/cstylecheck/output.py
@@ -266,7 +266,7 @@ def print_summary(all_violations: list, files_checked: int, tee: Tee,
     warnings = sum(1 for v in all_violations if v.severity == "warning")
     infos    = sum(1 for v in all_violations if v.severity == "info")
     now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    tee.print("\n" + "=" * 60)
+    tee.print("=" * 60)
     if version_string:
         tee.print(f"  {version_string}")
         tee.print(f"  Run at: {now}")

--- a/src/cstylecheck/output.py
+++ b/src/cstylecheck/output.py
@@ -268,22 +268,9 @@ def print_summary(all_violations: list, files_checked: int, tee: Tee,
     now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     tee.print("\n" + "=" * 60)
     if version_string:
-        tee.print(f"  {version_string} | {now}")
+        tee.print(f"  {version_string}")
+        tee.print(f"  Run at: {now}")
         tee.print("=" * 60)
-    tee.print("  Errors & Warnings:")
-    tee.print(f"    Errors        : {errors}")
-    tee.print(f"    Warnings      : {warnings}")
-    tee.print(f"    Info          : {infos}")
-    tee.print(f"    {'-' * 36}")
-    tee.print(f"    Total         : {errors + warnings + infos}")
-    rule_counts: Counter = Counter(v.rule for v in all_violations)
-    if rule_counts:
-        tee.print("=" * 60)
-        tee.print("  Top violated rules:")
-        for rule, count in rule_counts.most_common(10):
-            tee.print(f"    {rule:<45} {count}")
-    tee.print("=" * 60)
-
     # Per-file breakdown: bucket each file into errors / warnings / info / ok
     files_with_errors:   set = set()
     files_with_warnings: set = set()
@@ -311,3 +298,17 @@ def print_summary(all_violations: list, files_checked: int, tee: Tee,
         tee.print(f"    Files with info     : {files_info_only}")
         tee.print(f"    Files clean         : {files_clean}")
         tee.print("=" * 60)
+
+    tee.print("  Results:")
+    tee.print(f"    {'Errors':<20}: {errors}")
+    tee.print(f"    {'Warnings':<20}: {warnings}")
+    tee.print(f"    {'Info':<20}: {infos}")
+    tee.print(f"    {'-' * 22}")
+    tee.print(f"    {'Total':<20}: {errors + warnings + infos}")
+    rule_counts: Counter = Counter(v.rule for v in all_violations)
+    if rule_counts:
+        tee.print("=" * 60)
+        tee.print("  Top violated rules:")
+        for rule, count in rule_counts.most_common(10):
+            tee.print(f"    {rule:<45} {count}")
+    tee.print("=" * 60)

--- a/tests/test_print_summary.py
+++ b/tests/test_print_summary.py
@@ -90,10 +90,10 @@ class TestPrintSummaryPerFileBreakdown(unittest.TestCase):
 class TestPrintSummaryLabels(unittest.TestCase):
     """Issue #352: section labels and Files checked placement."""
 
-    def test_errors_and_warnings_label_present(self):
-        """Top section must be labelled 'Errors & Warnings:'."""
+    def test_results_label_present(self):
+        """Results section must be labelled 'Results:'."""
         out = _capture([_v("a.c", "error")], 1)
-        self.assertIn("Errors & Warnings:", out)
+        self.assertIn("Results:", out)
 
     def test_files_checked_in_files_section(self):
         """'Files checked' must appear in the Files: section, not above it."""
@@ -103,13 +103,13 @@ class TestPrintSummaryLabels(unittest.TestCase):
         files_checked_idx = next(i for i, l in enumerate(lines) if "Files checked" in l)
         self.assertGreater(files_checked_idx, files_label_idx)
 
-    def test_files_checked_not_in_errors_section(self):
-        """'Files checked' must NOT appear before the Errors & Warnings label."""
+    def test_files_checked_before_results_section(self):
+        """'Files checked' must appear in the Files: section, before the Results: label."""
         out = _capture([_v("a.c", "warning")], 2)
         lines = out.splitlines()
-        ew_idx = next(i for i, l in enumerate(lines) if "Errors & Warnings:" in l)
+        results_idx = next(i for i, l in enumerate(lines) if "Results:" in l)
         fc_idx = next(i for i, l in enumerate(lines) if "Files checked" in l)
-        self.assertGreater(fc_idx, ew_idx)
+        self.assertLess(fc_idx, results_idx)
 
     def test_files_checked_count_correct(self):
         """Files checked count in the Files: section matches argument."""


### PR DESCRIPTION
## Summary

Follow-up refinements to `print_summary()` after PR #364.

- **Version now reads correctly from source**: `__init__.py` version resolution now tries `pyproject.toml` directly before `importlib.metadata`, so a stale `.egg-info` in `src/` no longer causes `0.0.0.dev` or an older version to be reported.
- **Header split over two lines**:
  ```
  CStyleCheck 1.6.0
  Run at: 2026-07-06 10:05:00
  ```
- **Section order swapped**: `Files:` now appears before `Results:` (renamed from `Errors & Warnings:`), so file counts are visible first.
- **Aligned `:`**: `Results:` labels use 20-char width, matching the `Files:` section so both columns of `:` are vertically aligned.
- Updated `test_print_summary.py` to match renamed label and new section order.

## New format

```
============================================================
  CStyleCheck 1.6.0
  Run at: 2026-07-06 10:05:00
============================================================
  Files:
    Files checked       : 238
    Files with errors   : 5
    Files with warnings : 3
    Files with info     : 0
    Files clean         : 230
============================================================
  Results:
    Errors              : 7
    Warnings            : 4
    Info                : 0
    ----------------------
    Total               : 11
============================================================
  Top violated rules:
    function.prefix                               5
    variables.case                                4
    misc.magic_number                             3
============================================================
```

## Test plan

- [ ] `python -m pytest tests/ -q` → 1279 passed
- [ ] Run `--summary` from source; confirm version shows `1.6.0` not `0.0.0.dev`
- [ ] Confirm `Files:` section precedes `Results:` section
- [ ] Confirm `:` columns are vertically aligned across both sections

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_