### PR TITLE
fix: normalise file path separators to OS native

### DIFF
--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -148,7 +148,7 @@ def discover_files(
         abs_p = os.path.abspath(p)
         if abs_p not in seen and not is_ignored(p):
             seen.add(abs_p)
-            yield p
+            yield os.path.normpath(p)
 
     for f in explicit:
         yield from emit(f)


### PR DESCRIPTION
## Summary

On Windows, `glob()` returns paths with forward slashes while `os.walk` + `os.path.join` uses backslashes, producing mixed-separator paths like `U:\path/to/file.c` in scanning progress messages and violation output.

**Fix**: apply `os.path.normpath(p)` in `emit()` inside `discover_files()` so every yielded path uses `os.sep` consistently before it is stored in the file list, displayed in progress messages, or reported in violations.

## Test plan

- [ ] `python -m pytest tests/ -q` → 1279 passed
- [ ] On Windows, run `cstylecheck --include "U:\path\**\*.c" --verbose`; confirm all displayed paths use `\` exclusively

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_