### PR TITLE
feat: add copyright notice to --version and summary output

### DIFF
--- a/src/cstylecheck/__init__.py
+++ b/src/cstylecheck/__init__.py
@@ -38,6 +38,7 @@ except ImportError:
             _VERSION = "0.0.0.dev"
 
 _VERSION_STRING = f"{_TOOL_NAME} {_VERSION}"
+_COPYRIGHT = "(C) 2026 Dermot Murphy"
 
 # ---------------------------------------------------------------------------
 # Re-export everything from sub-modules (public API)

--- a/src/cstylecheck/cli.py
+++ b/src/cstylecheck/cli.py
@@ -34,7 +34,7 @@ from .sign_checker import SignChecker, DeclaredNotDefinedChecker
 from .baseline import load_baseline, write_baseline, _baseline_key
 from .output import Tee, _violations_to_json, _violations_to_sarif, _violations_to_html, print_summary
 from .wizard import run_wizard, run_preset, PRESETS
-from . import _TOOL_NAME, _VERSION, _VERSION_STRING
+from . import _TOOL_NAME, _VERSION, _VERSION_STRING, _COPYRIGHT
 
 
 # ---------------------------------------------------------------------------
@@ -370,6 +370,7 @@ def main() -> int:
     raw_argv = sys.argv[1:]
     if "--version" in raw_argv:
         print(_VERSION_STRING)
+        print(_COPYRIGHT)
         return 0
     if "-h" in raw_argv or "--help" in raw_argv:
         # Re-parse with a temporary parser just to print help, then exit 0
@@ -395,6 +396,7 @@ def main() -> int:
         return 0
     if getattr(args, "version", False):
         print(_VERSION_STRING)
+        print(_COPYRIGHT)
         return 0
 
     # --update-config: merge new defaults into the config file and exit.
@@ -762,7 +764,7 @@ def main() -> int:
             tee.print(html_text)
 
         if args.summary and output_format == "text":
-            print_summary(all_violations, len(files), tee, _VERSION_STRING)
+            print_summary(all_violations, len(files), tee, _VERSION_STRING, _COPYRIGHT)
 
         if args.exit_zero:
             return 0

--- a/src/cstylecheck/output.py
+++ b/src/cstylecheck/output.py
@@ -261,7 +261,7 @@ def _violations_to_html(violations: list, files_checked: int,
 # ---------------------------------------------------------------------------
 
 def print_summary(all_violations: list, files_checked: int, tee: Tee,
-                  version_string: str = "") -> None:
+                  version_string: str = "", copyright_string: str = "") -> None:
     errors   = sum(1 for v in all_violations if v.severity == "error")
     warnings = sum(1 for v in all_violations if v.severity == "warning")
     infos    = sum(1 for v in all_violations if v.severity == "info")
@@ -269,6 +269,8 @@ def print_summary(all_violations: list, files_checked: int, tee: Tee,
     tee.print("=" * 60)
     if version_string:
         tee.print(f"  {version_string}")
+        if copyright_string:
+            tee.print(f"  {copyright_string}")
         tee.print(f"  Run at: {now}")
         tee.print("=" * 60)
     # Per-file breakdown: bucket each file into errors / warnings / info / ok


### PR DESCRIPTION
## Summary

Adds `_COPYRIGHT = "(C) 2026 Dermot Murphy"` to `__init__.py` and displays it in two places:

**`--version` output:**
```
CStyleCheck 1.6.0
(C) 2026 Dermot Murphy
```

**`--summary` header:**
```
============================================================
  CStyleCheck 1.6.0
  (C) 2026 Dermot Murphy
  Run at: 2026-07-06 10:05:00
============================================================
```

## Test plan

- [ ] `python -m pytest tests/ -q` → 1279 passed
- [ ] `cstylecheck --version` prints version then copyright on next line
- [ ] `cstylecheck --summary` shows copyright in the header block

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_