### PR TITLE
docs: move README contributions line outside list; fix SWE2/SWE3 header dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ The purpose of this project is three-fold:
 - As an experiment to prompt Claude to generate all content - eg documents, webpages, issues, code, workflow - no manual correction of files
 - For a human to review all the work - either manually or with the help of an AI
 
-Contributions are very welcome.
-
 ![Logo](logo/cstylecheck.jpg)
 
 Embedded C Style Compliance Checker for GitHub Actions / pre-commit hooks.
@@ -15,6 +13,8 @@ Implements **Barr-C:2018** and MISRA-C complementary rules across **73 rule IDs*
 [![Tests](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/cstylecheck_tests.yml/badge.svg)](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/cstylecheck_tests.yml)
 [![Naming Convention](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dermot-murphy/CStyleCheck/gh-pages/cstylecheck/badge.json)](https://dermot-murphy.github.io/CStyleCheck/cstylecheck/)
 [![Docker](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/docker_publish.yml/badge.svg)](https://github.com/dermot-murphy/CStyleCheck/actions/workflows/docker_publish.yml)
+
+Contributions are very welcome.
 
 📖 **[Rules and Configuration Reference](Rules-and-Configuration.md)** — full
 documentation for all 73 rules with YAML configuration and annotated C examples.

--- a/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
+++ b/docs/aspice/CStyleCheck_SWE2_SW_Architecture.md
@@ -9,7 +9,7 @@
 | Field | Value | Field | Value |
 |---|---|---|---|
 | **Document ID** | CSC-SWE2-001 | **Version** | 1.12 |
-| **Project** | CStyleCheck | **Date** | 2026-06-27 |
+| **Project** | CStyleCheck | **Date** | 2026-07-06 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.2 |

--- a/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
+++ b/docs/aspice/CStyleCheck_SWE3_Detailed_Design.md
@@ -9,7 +9,7 @@
 | Field | Value | Field | Value |
 |---|---|---|---|
 | **Document ID** | CSC-SWE3-001 | **Version** | 1.16 |
-| **Project** | CStyleCheck | **Date** | 2026-06-27 |
+| **Project** | CStyleCheck | **Date** | 2026-07-06 |
 | **Status** | Released | **Classification** | Internal |
 | **Author** | Claude | **Reviewer** | Dermot Murphy |
 | **Approver** | Dermot Murphy | **Related Process** | SWE.3 |


### PR DESCRIPTION
## Summary

- **README**: moved "Contributions are very welcome." from between the three-fold purpose list and the logo to after the badge row, where it renders clearly outside the list context on the GitHub home page (closes visual rendering issue where it appeared as part of list item 3)
- **SWE2 v1.12**: corrected header `Date` field from `2026-06-27` to `2026-07-06` to match revision history
- **SWE3 v1.16**: corrected header `Date` field from `2026-06-27` to `2026-07-06` to match revision history

## Closed issues

Closes #372, #373, #374, #375, #376 — all SWE2–SWE6 ASPICE audit findings were already resolved in the v1.6.0 release (PR #380); the only remaining gaps were the two stale header dates fixed here. Issues #377, #378, #379 closed separately as completed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGhNhEytbn5R9JarnrJzE)_